### PR TITLE
docs: rename full name to "Open AI for Scientist" + add hero tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 <div align="center">
 
-<img src="readme-gifs-hd/openai4s_penta.gif" alt="OpenAI4S · Open AI for Science" width="480"/>
+<img src="readme-gifs-hd/openai4s_penta.gif" alt="OpenAI4S · Open AI for Scientist" width="480"/>
 
-### Open AI for Science
+### Open AI for Scientist
+
+## 💸 Replicating Claude Science in two cuts or less
 
 **An open-source, _Code-as-Action_ scientific research agent.**<br/>
 <sub>The model's action space is a Turing-complete kernel — **not** a fixed tool schema.</sub>
@@ -180,7 +182,7 @@ Released under the **MIT License** — see [`LICENSE`](LICENSE).
   author = {OpenAI4S contributors},
   year   = {2026},
   url    = {https://github.com/PKU-YuanGroup/OpenAI4S},
-  note   = {Open AI for Science — a pure-stdlib reproduction of the Code-as-Action paradigm}
+  note   = {Open AI for Scientist — a pure-stdlib reproduction of the Code-as-Action paradigm}
 }
 ```
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,8 +1,10 @@
 <div align="center">
 
-<img src="readme-gifs-hd/openai4s_penta.gif" alt="OpenAI4S · 面向科研的开源 AI" width="480"/>
+<img src="readme-gifs-hd/openai4s_penta.gif" alt="OpenAI4S · 面向科学家的开源 AI" width="480"/>
 
-### 面向科研的开源 AI
+### 面向科学家的开源 AI
+
+## 💸 9.9 元豆包 API 复刻 Claude Science
 
 **一个开源的「代码即行动」(Code-as-Action) 科研智能体。**<br/>
 <sub>模型的动作空间是一个图灵完备的持久内核 —— **而不是**一份固定的工具清单。</sub>
@@ -180,7 +182,7 @@ uv run pre-commit run --all-files   # 全量格式化 + lint
   author = {OpenAI4S contributors},
   year   = {2026},
   url    = {https://github.com/PKU-YuanGroup/OpenAI4S},
-  note   = {Open AI for Science —— 对 Code-as-Action 范式的纯标准库开源复现}
+  note   = {Open AI for Scientist —— 对 Code-as-Action 范式的纯标准库开源复现}
 }
 ```
 


### PR DESCRIPTION
## What

Rebrands the project's **full name** and adds a prominent hero tagline to both READMEs.

### Full name
`Open AI for Science` → **`Open AI for Scientist`** — hero title, GIF alt text, and citation `note` (zh: `面向科研的开源 AI` → `面向科学家的开源 AI`). The short name **OpenAI4S** is unchanged; it now expands to *Open AI **4** **S**cientist*.

### Hero tagline (most prominent element, `##`-sized, right under the name)
- **EN** — 💸 Replicating Claude Science in two cuts or less
- **ZH** — 💸 9.9 元豆包 API 复刻 Claude Science

Scope: `README.md` + `README_zh.md` only (2 files, +10 / −6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)