### PR TITLE
docs: rebuild demo grid (6 capability-titled GIFs) + ¥9.9 Doubao/Ark note

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@
 
 ---
 
+> [!TIP]
+> **Why "two cuts"?** OpenAI4S needs no pricey frontier-model key — it runs on **Doubao (豆包)** models from the cheapest tier of **Volcengine Ark (火山方舟)**'s Agent Plan: the **"Small" plan at ¥9.9 / month (≈ US$1.4)** — 20,000 Agent-fuel credits per month, multimodal (language · vision · embeddings) models, and built-in web search. Pick the `ark` provider in the UI, point OpenAI4S at that endpoint, and you get a Claude-Science-class Code-as-Action agent for less than a cup of coffee. *That's* the two cuts.
+
+---
+
 ## 🧬 Code-as-Action, not ReAct
 
 Most "AI agents" are **ReAct + `tool_use`**: each step the model emits one `tool_use` JSON, the host runs that single tool, and the loop repeats — the action space is a fixed menu. **OpenAI4S** instead emits **a cell of real Python/R code** that runs in a **persistent kernel**; every "tool" is a plain function on an in-kernel `host` object. The action space is a **Turing-complete language** — one turn can loop, branch, and call libraries while big objects stay resident in kernel memory.
@@ -78,12 +83,16 @@ host.save_artifact(plot(frames))             # ...only "<DataFrame 100000×20>" 
 
 <table>
 <tr>
-  <td width="50%"><b>Scientific API / MCP workflow</b><br/><img src="readme-gifs-hd/demo-01-hd.gif" alt="Scientific API / MCP workflow"></td>
-  <td width="50%"><b>Visual artifact editing</b><br/><img src="readme-gifs-hd/demo-02-hd.gif" alt="Visual artifact editing"></td>
+  <td width="50%"><b>Live API workflow</b> — from UniProt / RCSB to a 3D structure &amp; report<br/><img src="readme-gifs-hd/demo-01-hd.gif" alt="Live API workflow: from UniProt / RCSB to a 3D structure and report"></td>
+  <td width="50%"><b>Real-data analysis</b> — human insulin INS (P01308): from UniProt / RCSB to a reproducible report<br/><img src="readme-gifs-hd/demo-05-hd.gif" alt="Real-data analysis: human insulin INS / UniProt P01308 from UniProt / RCSB to a reproducible report"></td>
 </tr>
 <tr>
-  <td width="50%"><b>Plan-mode scientific analysis</b><br/><img src="readme-gifs-hd/demo-03-hd.gif" alt="Plan mode scientific analysis"></td>
-  <td width="50%"><b>Protein engineering</b><br/><img src="readme-gifs-hd/demo-04-hd.gif" alt="Protein engineering"></td>
+  <td width="50%"><b>Visual artifact editing</b> — “raise the confidence cutoff to 75” in one line<br/><img src="readme-gifs-hd/demo-02-hd.gif" alt="Visual artifact editing: raise the confidence cutoff to 75 in one line"></td>
+  <td width="50%"><b>Annotation-driven chart editing</b> — lasso a region &amp; recolor the legend<br/><img src="readme-gifs-hd/demo-06-hd.gif" alt="Annotation-driven chart editing: lasso a region and recolor the legend"></td>
+</tr>
+<tr>
+  <td width="50%"><b>Plan-mode research</b> — artemisinin &amp; paclitaxel solubility prediction<br/><img src="readme-gifs-hd/demo-03-hd.gif" alt="Plan-mode research: artemisinin and paclitaxel solubility prediction"></td>
+  <td width="50%"><b>Protein engineering</b> — from sequence to ranked mutants &amp; structural rationale<br/><img src="readme-gifs-hd/demo-04-hd.gif" alt="Protein engineering: from sequence to ranked mutants and structural rationale"></td>
 </tr>
 </table>
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -29,6 +29,11 @@
 
 ---
 
+> [!TIP]
+> **为什么是 9.9 元?** OpenAI4S 不需要昂贵的前沿模型 Key —— 它跑在**豆包**模型上,用的是 **火山方舟** Agent Plan 里最便宜的一档:**「体验版 Small」套餐,¥9.9 / 月** —— 每月 20,000 Agent 燃料值、语言 / 图像 / 向量化等多模态模型、开箱即用的联网搜索。在 UI 里把供应商选成 `ark`、指向这个接口,你就用不到一杯咖啡的钱得到了一个 Claude Science 级的 Code-as-Action 智能体。这,就是那「9.9 元」。
+
+---
+
 ## 🧬 代码即 Agent,而非 ReAct
 
 如今绝大多数「AI Agent」是 **ReAct + `tool_use`**:每一步,模型返回一个 `tool_use` JSON,宿主执行**单个**工具,再循环，也就是动作空间是一份固定菜单。**OpenAI4S** 则产出**一段真正的 Python/R 代码 cell**,在**持久内核**里执行;所有「工具」都是内核内 `host` 对象上的普通函数。它的动作空间是**一门图灵完备语言** —— 一个 turn 内即可循环、分支、调用库,而大对象常驻在内核内存里。
@@ -78,12 +83,16 @@ host.save_artifact(plot(frames))             # ……上下文里只留 "<DataFr
 
 <table>
 <tr>
-  <td width="50%"><b>科学 API / MCP 工作流</b><br/><img src="readme-gifs-hd/demo-01-hd.gif" alt="科学 API / MCP 工作流"></td>
-  <td width="50%"><b>可视化产物编辑</b><br/><img src="readme-gifs-hd/demo-02-hd.gif" alt="可视化产物编辑"></td>
+  <td width="50%"><b>Live API 工作流</b>:从 UniProt / RCSB 到 3D 结构和报告<br/><img src="readme-gifs-hd/demo-01-hd.gif" alt="Live API 工作流:从 UniProt / RCSB 到 3D 结构和报告"></td>
+  <td width="50%"><b>真实数据分析</b>:人胰岛素 INS 从 UniProt / RCSB 到可复现报告<br/><img src="readme-gifs-hd/demo-05-hd.gif" alt="真实数据分析:人胰岛素 INS 从 UniProt / RCSB 到可复现报告"></td>
 </tr>
 <tr>
-  <td width="50%"><b>计划模式科研分析</b><br/><img src="readme-gifs-hd/demo-03-hd.gif" alt="计划模式科研分析"></td>
-  <td width="50%"><b>蛋白质工程</b><br/><img src="readme-gifs-hd/demo-04-hd.gif" alt="蛋白质工程"></td>
+  <td width="50%"><b>可视化产物编辑</b>:一句话把 confidence 阈值线抬到 75<br/><img src="readme-gifs-hd/demo-02-hd.gif" alt="可视化产物编辑:一句话把 confidence 阈值线抬到 75"></td>
+  <td width="50%"><b>注释驱动图表编辑</b>:圈选区域并重绘图例配色<br/><img src="readme-gifs-hd/demo-06-hd.gif" alt="注释驱动图表编辑:圈选区域并重绘图例配色"></td>
+</tr>
+<tr>
+  <td width="50%"><b>计划模式科研分析</b>:青蒿素与紫杉醇溶解度预测<br/><img src="readme-gifs-hd/demo-03-hd.gif" alt="计划模式科研分析:青蒿素与紫杉醇溶解度预测"></td>
+  <td width="50%"><b>蛋白质工程</b>:从序列到突变候选与结构解释<br/><img src="readme-gifs-hd/demo-04-hd.gif" alt="蛋白质工程:从序列到突变候选与结构解释"></td>
 </tr>
 </table>
 


### PR DESCRIPTION
## What

Two README-only presentation changes (English + 简体中文), no code.

### 1 · Demo grid rebuilt
The `🎬 Demo` table goes from 4 GIFs to a **6-GIF 3×2 grid**, and each title now states the **capability demonstrated** instead of a bare category. Order `[01, 05, 02, 06, 03, 04]`:

| | col 1 | col 2 |
|---|---|---|
| **row 1** — live real-data pipelines | Live API workflow (UniProt/RCSB → 3D structure + report) | **Real-data analysis — human insulin INS / UniProt P01308 → reproducible report** |
| **row 2** — artifact / chart editing | Visual artifact editing (confidence → 75) | Annotation-driven chart editing (lasso + recolor) |
| **row 3** — analysis + engineering | Plan-mode research (artemisinin/paclitaxel solubility) | Protein engineering (sequence → mutants) |

`demo-05` is the newly uploaded human-insulin real-data demo (replaces the earlier duplicate of the solubility task).

### 2 · ¥9.9 explainer callout
A `> [!TIP]` note before the Code-as-Action section explains the tagline: the demos run on **Doubao (豆包)** models via **Volcengine Ark (火山方舟) Agent Plan · "Small"** tier — **¥9.9/mo** (20,000 Agent-fuel credits, multimodal models, web search), set through the `ark` provider.

Scope: `README.md` + `README_zh.md` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)