### PR TITLE
[codex] Fix annotation comment cancellation

### DIFF
--- a/openai4s/server/webui/app.js
+++ b/openai4s/server/webui/app.js
@@ -2462,8 +2462,11 @@ async function send(text, opts) {
   }
   catch (e) {
     if (annIds.length) {
-      try { await loadAnnotations(S.currentId); }
-      catch { setLocalAnnotationStatus(annIds, "open"); }
+      // POST failed → annotations were never consumed server-side. Reconcile with the server
+      // if reachable; if that reload also fails, revert the optimistic "sent" flip locally so
+      // the pending comments stay visible for a retry instead of vanishing from the composer.
+      const reloaded = await loadAnnotations(S.currentId);
+      if (!reloaded) setLocalAnnotationStatus(annIds, "open");
       refreshAllStages(); updateAnnotBadge();
     }
     hint(t("toast.sendFailed", e.message), true);
@@ -2728,10 +2731,11 @@ async function deleteAnnotations(ids) {
   if (failed) throw failed.reason || new Error("delete failed");
 }
 async function loadAnnotations(fid) {
-  let res = {}; try { res = await api(`/frames/${fid}/annotations`); } catch { res = {}; }
-  if (fid !== S.currentId) return;
+  let res; try { res = await api(`/frames/${fid}/annotations`); } catch { return false; }
+  if (fid !== S.currentId) return true;
   S.annotations = (res && res.annotations) || [];
   updateAnnotBadge();
+  return true;
 }
 /* Render an image the user can pin comments onto, with zoom + pan. Used by the
    dock viewer AND the fullscreen modal. Zoom is WIDTH-BASED (the image element
@@ -2963,10 +2967,10 @@ function toggleAnnotList(anchor) {
   pop.appendChild(el("div", "annot-list-head", t("annot.list.head", open.length)));
   open.forEach(an => {
     const row = el("div", "annot-list-row");
-    const t = el("div", "annot-list-t");
-    t.appendChild(el("span", "annot-list-pin", String(an.number)));
-    t.appendChild(el("span", "annot-list-file", an.artifact_name || "artifact"));
-    row.appendChild(t);
+    const trow = el("div", "annot-list-t");   // do NOT shadow the global i18n t() used below
+    trow.appendChild(el("span", "annot-list-pin", String(an.number)));
+    trow.appendChild(el("span", "annot-list-file", an.artifact_name || "artifact"));
+    row.appendChild(trow);
     row.appendChild(el("div", "annot-list-body", an.body || ""));
     const acts = el("div", "annot-list-acts");
     const openBtn = el("button", "annot-mini", t("common.view")); openBtn.onclick = () => { pop.remove(); const art = (S.artifacts || []).find(x => x.id === an.artifact_id); if (art) openViewer(art); };

--- a/openai4s/server/webui/app.js
+++ b/openai4s/server/webui/app.js
@@ -127,6 +127,8 @@ Object.assign(I18N.zh, {
   "annot.comment.plural": " 条评论",
   "annot.comment.singular": " 条评论",
   "annot.deleted": "已删除标注",
+  "annot.discard.title": "取消待发送评论",
+  "annot.discarded": "已取消待发送评论",
   "annot.draft.placeholder": "添加标注…",
   "annot.list.head": "待发送标注 · {0}",
   "annot.noSession": "请先打开一个会话",
@@ -697,6 +699,8 @@ Object.assign(I18N.en, {
   "annot.comment.plural": " comments",
   "annot.comment.singular": " comment",
   "annot.deleted": "Annotation deleted",
+  "annot.discard.title": "Cancel pending comments",
+  "annot.discarded": "Pending comments cancelled",
   "annot.draft.placeholder": "Add annotation…",
   "annot.list.head": "Pending annotations · {0}",
   "annot.noSession": "Please open a session first",
@@ -2443,6 +2447,7 @@ async function send(text, opts) {
   S.running = true; enableComposer(false); $("#cancel-btn").classList.remove("hidden"); hint(t("toast.running"), false, true);
   $("#composer").value = ""; grow();
   const annIds = anns.map(x => x.id);
+  if (annIds.length) { setLocalAnnotationStatus(annIds, "sent"); refreshAllStages(); updateAnnotBadge(); }
   sub(S.currentId);  // guarantee this client is subscribed BEFORE the POST spawns the
                      // turn thread. On the FIRST turn opened via newSession(), S.currentId
                      // is already set so the block above is skipped and openConversation's
@@ -2452,10 +2457,17 @@ async function send(text, opts) {
                      // false once the blocking POST returns). Idempotent set add.
   try {
     await api(`/frames/${S.currentId}/message`, { method: "POST", body: JSON.stringify({ input_data: { request: payload }, model: S.defaultModel, plan: planNow, explore: exploreNow, annotation_ids: annIds }) });
-    // annotations are now folded into the turn server-side → flip them to "sent"
+    // The optimistic status above clears the badge immediately; reload once the turn POST finishes to reconcile with the server.
     if (annIds.length) { try { await loadAnnotations(S.currentId); } catch {} refreshAllStages(); updateAnnotBadge(); }
   }
-  catch (e) { hint(t("toast.sendFailed", e.message), true); }
+  catch (e) {
+    if (annIds.length) {
+      try { await loadAnnotations(S.currentId); }
+      catch { setLocalAnnotationStatus(annIds, "open"); }
+      refreshAllStages(); updateAnnotBadge();
+    }
+    hint(t("toast.sendFailed", e.message), true);
+  }
   if (S.running) turnDone("completed");
   loadSessions();
 }
@@ -2695,6 +2707,26 @@ function renderArtifactBody(body, a) {
 /* ---------- image annotations (figure review → message → remote edit) ---------- */
 function annotationsFor(artifactId) { return (S.annotations || []).filter(x => x.artifact_id === artifactId); }
 function openAnnotations() { return (S.annotations || []).filter(x => x.status === "open"); }
+function annotationId(an) { return an && (an.id || an.annotation_id); }
+function setLocalAnnotationStatus(ids, status) {
+  const wanted = new Set((ids || []).filter(Boolean));
+  if (!wanted.size) return;
+  S.annotations = (S.annotations || []).map(an => wanted.has(annotationId(an)) ? { ...an, status } : an);
+}
+async function deleteAnnotations(ids) {
+  const wanted = [...new Set((ids || []).filter(Boolean))];
+  if (!wanted.length) return;
+  const results = await Promise.allSettled(wanted.map(id => api(`/annotations/${id}`, { method: "DELETE" }).then(() => id)));
+  const deleted = results.filter(r => r.status === "fulfilled").map(r => r.value);
+  if (deleted.length) {
+    const gone = new Set(deleted);
+    S.annotations = (S.annotations || []).filter(an => !gone.has(annotationId(an)));
+    refreshAllStages();
+    updateAnnotBadge();
+  }
+  const failed = results.find(r => r.status === "rejected");
+  if (failed) throw failed.reason || new Error("delete failed");
+}
 async function loadAnnotations(fid) {
   let res = {}; try { res = await api(`/frames/${fid}/annotations`); } catch { res = {}; }
   if (fid !== S.currentId) return;
@@ -2888,7 +2920,7 @@ function openPinPop(stage, a, an) {
   foot.appendChild(el("div", "annot-foot-l"));
   const del = el("button", "annot-btn ghost danger", t("common.delete")); del.onclick = async () => {
     del.disabled = true;
-    try { await api(`/annotations/${an.id}`, { method: "DELETE" }); S.annotations = (S.annotations || []).filter(x => x.id !== an.id); closeAnnotPop(); refreshAllStages(); updateAnnotBadge(); hint(t("annot.deleted")); }
+    try { await deleteAnnotations([annotationId(an)]); closeAnnotPop(); hint(t("annot.deleted")); }
     catch (e) { del.disabled = false; hint(t("toast.deleteFailed", e.message), true); }
   };
   const close = el("button", "annot-btn solid", t("common.close")); close.onclick = () => closeAnnotPop();
@@ -2902,10 +2934,26 @@ function updateAnnotBadge() {
   const open = openAnnotations();
   if (!open.length) { bar.classList.add("hidden"); bar.innerHTML = ""; return; }
   bar.classList.remove("hidden"); bar.innerHTML = "";
-  const chip = el("button", "annot-chip"); chip.appendChild(iconEl("message-square", 14));
-  chip.appendChild(el("span", null, " " + open.length + (open.length === 1 ? " comment" : " comments")));
-  chip.title = t("annot.chip.title");
-  chip.onclick = (e) => { e.stopPropagation(); toggleAnnotList(chip); };
+  const chip = el("span", "annot-chip");
+  const main = el("button", "annot-chip-main"); main.appendChild(iconEl("message-square", 14));
+  main.appendChild(el("span", null, " " + open.length + (open.length === 1 ? " comment" : " comments")));
+  main.title = t("annot.chip.title");
+  main.onclick = (e) => { e.stopPropagation(); toggleAnnotList(chip); };
+  const cancel = el("button", "annot-chip-x"); cancel.innerHTML = icon("x", 13); cancel.title = t("annot.discard.title");
+  cancel.onclick = async (e) => {
+    e.preventDefault(); e.stopPropagation();
+    cancel.disabled = true;
+    try {
+      await deleteAnnotations(openAnnotations().map(annotationId));
+      closeAnnotPop();
+      const p = $("#annot-list-pop"); if (p) p.remove();
+      hint(t("annot.discarded"));
+    } catch (err) {
+      cancel.disabled = false;
+      hint(t("annot.remove.err", err.message), true);
+    }
+  };
+  chip.appendChild(main); chip.appendChild(cancel);
   bar.appendChild(chip);
 }
 function toggleAnnotList(anchor) {
@@ -2922,12 +2970,12 @@ function toggleAnnotList(anchor) {
     row.appendChild(el("div", "annot-list-body", an.body || ""));
     const acts = el("div", "annot-list-acts");
     const openBtn = el("button", "annot-mini", t("common.view")); openBtn.onclick = () => { pop.remove(); const art = (S.artifacts || []).find(x => x.id === an.artifact_id); if (art) openViewer(art); };
-    const rm = el("button", "annot-mini danger", t("btn.remove")); rm.onclick = async () => { try { await api(`/annotations/${an.id}`, { method: "DELETE" }); S.annotations = (S.annotations || []).filter(x => x.id !== an.id); refreshAllStages(); updateAnnotBadge(); pop.remove(); toggleAnnotList(anchor); } catch (e) { hint(t("annot.remove.err", e.message), true); } };
+    const rm = el("button", "annot-mini danger", t("btn.remove")); rm.onclick = async () => { try { await deleteAnnotations([annotationId(an)]); pop.remove(); if (openAnnotations().length && anchor.parentElement) toggleAnnotList(anchor); } catch (e) { hint(t("annot.remove.err", e.message), true); } };
     acts.appendChild(openBtn); acts.appendChild(rm); row.appendChild(acts);
     pop.appendChild(row);
   });
   anchor.parentElement.appendChild(pop);
-  setTimeout(() => document.addEventListener("mousedown", function h(ev) { if (!pop.contains(ev.target) && ev.target !== anchor) { pop.remove(); document.removeEventListener("mousedown", h); } }), 0);
+  setTimeout(() => document.addEventListener("mousedown", function h(ev) { if (!pop.contains(ev.target) && !anchor.contains(ev.target)) { pop.remove(); document.removeEventListener("mousedown", h); } }), 0);
 }
 
 /* Fullscreen: center modal. */

--- a/openai4s/server/webui/style.css
+++ b/openai4s/server/webui/style.css
@@ -687,9 +687,14 @@ body.has-key-banner #sidebar,body.has-key-banner #main,body.has-key-banner #righ
 /* composer chip */
 .annot-bar{position:relative;padding:2px 2px 8px}
 .annot-bar.hidden{display:none}
-.annot-chip{display:inline-flex;align-items:center;gap:4px;background:var(--bg-200);border:1px solid var(--border);color:var(--text-200);border-radius:20px;padding:4px 12px 4px 10px;font-size:12.5px;cursor:pointer}
+.annot-chip{display:inline-flex;align-items:center;gap:0;background:var(--bg-200);border:1px solid var(--border);color:var(--text-200);border-radius:20px;padding:0;font-size:12.5px;overflow:hidden}
 .annot-chip:hover{background:var(--hover)}
 .annot-chip .ic-svg{color:var(--clay-em)}
+.annot-chip-main{display:inline-flex;align-items:center;gap:4px;border:0;background:transparent;color:inherit;font:inherit;padding:4px 7px 4px 10px;cursor:pointer}
+.annot-chip-x{display:inline-flex;align-items:center;justify-content:center;width:22px;height:22px;margin-right:3px;border:0;border-radius:50%;background:transparent;color:var(--text-400);cursor:pointer}
+.annot-chip-x .ic-svg{color:currentColor}
+.annot-chip-x:hover{background:var(--bg-300);color:var(--danger)}
+.annot-chip-x:disabled{opacity:.45;cursor:default}
 .annot-list-pop{position:absolute;bottom:calc(100% + 6px);left:0;z-index:60;width:340px;max-width:88vw;background:var(--bg-000);border:1px solid var(--border-card);border-radius:12px;box-shadow:var(--shadow-pop);padding:10px;max-height:320px;overflow:auto}
 .annot-list-head{font-size:12px;color:var(--text-400);margin:2px 4px 8px}
 .annot-list-row{padding:8px;border-radius:9px}


### PR DESCRIPTION
## Summary

- Clear pending annotation comments from the composer immediately after they are submitted with a message.
- Add an inline cancel button to the pending comment chip so users can discard comments before submitting.
- Reuse one annotation deletion helper for pin popovers, pending-list removal, and the new cancel action.

## Why

Pending image comments could stay visible after submission while the message request was still running, and there was no direct cancel affordance on the composer chip if the user decided not to submit the comment.

## Validation

- `node --check openai4s/server/webui/app.js`
- `git diff --check`
- Direct annotation store/gateway assertion script