### PR TITLE
fix(config): placeholder API key from .env.example falsely reported a…

### DIFF
--- a/openai4s/config.py
+++ b/openai4s/config.py
@@ -47,6 +47,23 @@ def _load_dotenv() -> None:
 _load_dotenv()
 
 
+# Obvious template stubs copied verbatim from .env.example — never a real key.
+# Filtering these means cfg.llm.api_key (and everything derived from it:
+# effective_api_key, profile seeding, has_api_key) can never mistake a template
+# stub for a configured secret. NOTE: deliberately excludes test values like
+# "test-key" — those are used by the offline test suite (tests/conftest.py).
+_PLACEHOLDER_API_KEYS = {
+    "your-api-key-here", "your_api_key_here", "your-api-key", "your_api_key",
+    "your-key-here", "your_key_here", "placeholder", "changeme", "replace-me",
+}
+
+
+def is_placeholder_api_key(k: str | None) -> bool:
+    """True if `k` is empty or an obvious template placeholder, not a real key."""
+    k = (k or "").strip().lower()
+    return (not k) or k in _PLACEHOLDER_API_KEYS
+
+
 def _default_data_dir() -> Path:
     env = os.environ.get("OPENAI4S_DATA_DIR")
     if env:
@@ -122,6 +139,12 @@ class LLMConfig:
                 if os.environ.get(native):
                     self.api_key = os.environ[native]
                     break
+
+        # Drop obvious placeholder stubs (e.g. a .env copied verbatim from
+        # .env.example) so they aren't mistaken for a real key downstream
+        # (has_api_key, profile seeding, effective_api_key, ...).
+        if self.api_key and is_placeholder_api_key(self.api_key):
+            self.api_key = ""
 
         # Fill provider built-in defaults so base_url/model are always concrete
         # (status pages, turn logs, etc. read cfg.llm.model directly). Lazy

--- a/openai4s/server/gateway.py
+++ b/openai4s/server/gateway.py
@@ -39,7 +39,7 @@ from urllib.parse import parse_qs, unquote, urlparse
 
 from openai4s.agent.compaction import compact, should_compact
 from openai4s.agent.loop import SYSTEM_PROMPT, _extract_code, _format_observation
-from openai4s.config import Config, get_config
+from openai4s.config import Config, get_config, is_placeholder_api_key
 from openai4s.host_dispatch import build_dispatcher
 from openai4s.kernel import Kernel
 from openai4s.llm import ARK_PLAN_MODELS, PROVIDERS, chat
@@ -5078,7 +5078,8 @@ def make_handler(cfg: Config, hub: WSHub, runner: SessionRunner):
                 "provider": p.get("provider") or "",
                 "base_url": p.get("base_url") or "",
                 "model": p.get("model") or "",
-                "has_api_key": bool((p.get("api_key") or "").strip()),
+                "has_api_key": bool((p.get("api_key") or "").strip())
+                and not is_placeholder_api_key(p.get("api_key")),
             }
 
         def _model_profiles_payload(self) -> dict:


### PR DESCRIPTION
…s configured

setup.sh copies .env.example to .env, leaving OPENAI4S_LLM_API_KEY=your-api-key-here. On first launch that stub is seeded into every built-in Ark model profile and persisted to SQLite, so Customize>Models shows a configured key for all of them but requests 401. The stub was never recognized anywhere in the chain.

- config.py: add is_placeholder_api_key() + a placeholder set; LLMConfig.__post_init__ drops them so cfg.llm.api_key never carries a stub into has_api_key, profile seeding, or effective_api_key. test-key (offline suite) is deliberately preserved.
- gateway.py: _mask_profile rejects placeholders too, so the UI never reports "configured" for a stub regardless of where the value came from.