### PR TITLE
test(contract): kernel wire protocol, WebSocket framing, bytes routes, store row shapes

### DIFF
--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -1,5 +1,8 @@
 import base64
+import io
+import json
 import re
+import struct
 import threading
 import time
 from pathlib import Path
@@ -1022,3 +1025,185 @@ def test_upload_base64_decode_and_raw_fallback(tmp_path):
         {"filename": "c.bin", "content_base64": "%%% not base64 %%%", "frame_id": fid}
     )
     assert _bytes(res) == "%%% not base64 %%%".encode("utf-8")
+
+
+# --- hand-rolled WebSocket wire format (risk register: payload drift) -------
+def test_ws_encode_frame_length_ladder():
+    """RFC 6455 server frames: FIN|opcode first byte, then the 7-bit /
+    16-bit / 64-bit length ladder switching at exactly 126 and 65536 —
+    and server frames are NEVER masked (no 0x80 bit on byte 1)."""
+    small = gateway_mod._ws_encode(b"hello")
+    assert small[0] == 0x81  # FIN + text opcode
+    assert small[1] == 5  # 7-bit length, mask bit clear
+    assert small[2:] == b"hello"
+
+    edge = gateway_mod._ws_encode(b"x" * 126)
+    assert edge[1] == 126
+    assert edge[2:4] == struct.pack(">H", 126)
+    assert edge[4:] == b"x" * 126
+
+    big = gateway_mod._ws_encode(b"y" * 65536, opcode=0x2)
+    assert big[0] == 0x82  # FIN + binary opcode
+    assert big[1] == 127
+    assert big[2:10] == struct.pack(">Q", 65536)
+    assert len(big) == 10 + 65536
+
+
+def test_ws_read_frame_unmasks_and_roundtrips():
+    """_ws_read_frame unmasks client frames, passes opcodes through, returns
+    None on a truncated header, and round-trips every _ws_encode length
+    class — the encode/decode pair cannot drift apart silently."""
+    payload = b'{"type":"ping"}'
+    mask = bytes([0x12, 0x34, 0x56, 0x78])
+    masked = bytes(b ^ mask[i % 4] for i, b in enumerate(payload))
+    frame = bytes([0x81, 0x80 | len(payload)]) + mask + masked
+    assert gateway_mod._ws_read_frame(io.BytesIO(frame)) == (0x1, payload)
+
+    # masked frame in the 16-bit length class
+    payload2 = b"z" * 300
+    masked2 = bytes(b ^ mask[i % 4] for i, b in enumerate(payload2))
+    frame2 = bytes([0x82, 0x80 | 126]) + struct.pack(">H", 300) + mask + masked2
+    assert gateway_mod._ws_read_frame(io.BytesIO(frame2)) == (0x2, payload2)
+
+    # unmasked server frames round-trip across all three length classes
+    for n in (0, 1, 125, 126, 65535, 65536):
+        enc = gateway_mod._ws_encode(b"a" * n)
+        assert gateway_mod._ws_read_frame(io.BytesIO(enc)) == (0x1, b"a" * n)
+
+    # control frame opcode passes through untouched
+    close = gateway_mod._ws_encode(b"", opcode=0x8)
+    assert gateway_mod._ws_read_frame(io.BytesIO(close)) == (0x8, b"")
+
+    # truncated header → None (connection treated as closed)
+    assert gateway_mod._ws_read_frame(io.BytesIO(b"")) is None
+    assert gateway_mod._ws_read_frame(io.BytesIO(b"\x81")) is None
+
+
+# --- raw-bytes artifact routes ----------------------------------------------
+def _bytes_handler(cfg, runner, hub=None):
+    """Handler with _send captured — bytes routes bypass _json entirely."""
+    handler_cls = gateway_mod.make_handler(cfg, hub or _Hub(), runner)
+    handler = object.__new__(handler_cls)
+    sends = []
+    handler._send = lambda code, body, ctype, extra=None: sends.append(
+        (code, body, ctype)
+    )
+    handler._query = lambda: {}
+    handler._body = lambda: {}
+    return handler, sends
+
+
+def test_serve_artifact_three_way_resolution_and_bytes_contract(tmp_path):
+    """GET /api/artifacts/{ident} resolution order: version_id →
+    artifact_id → filename. A version id serves ITS OWN historical bytes
+    (even when a file named like that id also exists), an artifact id serves
+    the latest bytes, Content-Type comes from the stored row, and an unknown
+    ident gets a JSON {"error": ...} 404 on this otherwise-bytes route."""
+    cfg, runner, store, fid, st = _runner_frame(tmp_path)
+    handler, sends = _bytes_handler(cfg, runner)
+
+    f = st.workspace / "table.csv"
+    f.write_text("v1")
+    rec1 = runner._register_file(st, f, "c1", lambda e: None)
+    f.write_text("v2-longer")
+    runner._register_file(st, f, "c2", lambda e: None)
+
+    # version_id → that version's own snapshot bytes + its stored content_type
+    handler._api("GET", f"/artifacts/{rec1['version_id']}")
+    code, body, ctype = sends[-1]
+    assert (code, body) == (200, b"v1")
+    assert ctype == store.version_meta(rec1["version_id"])["content_type"]
+
+    # artifact_id → the LATEST version's bytes (GET on a bare id is bytes,
+    # not JSON — only DELETE matches the JSON route above it)
+    handler._api("GET", f"/artifacts/{rec1['artifact_id']}")
+    assert sends[-1][:2] == (200, b"v2-longer")
+
+    # filename → artifact_by_filename fallback, serving the live path
+    handler._api("GET", "/artifacts/table.csv")
+    assert sends[-1][:2] == (200, b"v2-longer")
+
+    # ORDER: a registered artifact literally NAMED like rec1's version id
+    # must not shadow it — version_id resolution wins over filename
+    trap = st.workspace / rec1["version_id"]
+    trap.write_text("filename-shadow")
+    runner._register_file(st, trap, "c3", lambda e: None)
+    handler._api("GET", f"/artifacts/{rec1['version_id']}")
+    assert sends[-1][:2] == (200, b"v1")
+
+    # the wart: unknown ident answers this bytes route with a JSON envelope
+    handler._api("GET", "/artifacts/no-such-ident")
+    code, body, ctype = sends[-1]
+    assert code == 404
+    assert json.loads(body) == {"error": "artifact not found"}
+    assert ctype.startswith("application/json")
+
+
+def test_preview_route_forces_html_content_type(tmp_path):
+    """GET /preview/{ident} serves the same resolved bytes but ALWAYS stamps
+    text/html, whatever the stored content_type says."""
+    cfg, runner, store, fid, st = _runner_frame(tmp_path)
+    handler, sends = _bytes_handler(cfg, runner)
+    handler.headers = {}  # _route consults Origin/Cookie headers
+
+    f = st.workspace / "report.md"
+    f.write_text("# hi")
+    rec = runner._register_file(st, f, "c1", lambda e: None)
+
+    handler.path = f"/preview/{rec['artifact_id']}"
+    handler._route("GET")
+    code, body, ctype = sends[-1]
+    assert (code, body) == (200, b"# hi")
+    assert ctype == "text/html; charset=utf-8"
+
+
+def test_upload_without_frame_id_stores_file_but_never_broadcasts(tmp_path):
+    """POST /api/uploads with NO frame_id: the file lands under
+    data_dir/uploads, the artifact row has no root_frame_id, and no
+    artifact_created event is broadcast — only frame-scoped uploads notify."""
+    cfg, runner, store, fid, st = _runner_frame(tmp_path)
+    hub = _Hub()
+    handler_cls = gateway_mod.make_handler(cfg, hub, runner)
+    handler = object.__new__(handler_cls)
+
+    res = handler._upload(
+        {
+            "filename": "loose.bin",
+            "content_base64": base64.b64encode(b"data!").decode(),
+        }
+    )
+    assert res["id"] == res["artifact_id"] and res["filename"] == "loose.bin"
+    assert (cfg.data_dir / "uploads" / "loose.bin").read_bytes() == b"data!"
+
+    a = store.get_artifact(res["artifact_id"])
+    assert a["root_frame_id"] is None
+    assert a["is_user_upload"] == 1
+    assert [e for e in hub.events if e.get("type") == "artifact_created"] == []
+    # the sessionless artifact still resolves and serves by id
+    assert Path(store.resolve_artifact_path(res["artifact_id"])).read_bytes() == (
+        b"data!"
+    )
+
+
+def test_body_malformed_json_treated_as_empty_dict(tmp_path):
+    """_body() contract: an unparseable JSON body, an empty body, and a
+    missing Content-Length all collapse to {} — route handlers never see a
+    parse error and treat the request as field-less."""
+    cfg = _cfg(tmp_path)
+    runner = gateway_mod.SessionRunner(cfg, _Hub())
+    handler_cls = gateway_mod.make_handler(cfg, _Hub(), runner)
+    handler = object.__new__(handler_cls)
+
+    def _with(raw: bytes):
+        handler.headers = {"Content-Length": str(len(raw))}
+        handler.rfile = io.BytesIO(raw)
+        return handler._body()
+
+    assert _with(b'{"a": 1}') == {"a": 1}  # valid JSON parses
+    assert _with(b"this is not json") == {}  # malformed → {}
+    assert _with(b"{truncated") == {}
+    assert _with(b"") == {}  # Content-Length: 0 → {} without reading
+
+    handler.headers = {}  # no Content-Length header at all
+    handler.rfile = io.BytesIO(b'{"ignored": true}')
+    assert handler._body() == {}

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -1,5 +1,7 @@
 """Kernel tests: persistent namespace, print capture, error attribution,
 usage accounting, and host_call RPC round-trip (dispatcher stubbed)."""
+import threading
+
 import pytest
 
 from openai4s.kernel import Kernel
@@ -194,6 +196,128 @@ def test_restart_bumps_generation_and_resets_namespace():
         assert k.is_alive()
         r = k.execute("print('x' in globals())")
         assert r["stdout"].strip() == "False"
+
+
+# --- inner-RPC wire contracts (PR 06/PR 10 reviewers) -----------------------
+# 15MB wire cap, host_ack pre-response frames, bounded-discard desync
+# recovery, and the SIGINT interrupt contract. Extra pre-response frames are
+# injected through the manager's OWN _send/_service_host_call machinery —
+# the single-frame-reader loop and the host-call transaction stay intact.
+
+
+def test_host_call_wire_cap_rejects_oversized_payload():
+    """A host_call whose JSON frame exceeds the 15MB wire cap raises
+    ValueError IN the kernel before anything is written — the dispatcher never
+    sees the call and the channel stays usable for the next RPC."""
+    with Kernel(dispatcher=_echo_dispatcher) as k:
+        r = k.execute(
+            "big = 'x' * 15_000_001\n"
+            "try:\n"
+            "    host._call('ping', [big])\n"
+            "except ValueError as e:\n"
+            "    print('capped:', '15MB wire cap' in str(e))\n"
+            "print(host._call('ping', []))"
+        )
+        assert r["error"] is None
+        # if the frame had reached the wire, 'ping' would have succeeded and
+        # the 'capped:' line would be missing entirely
+        assert r["stdout"].splitlines() == ["capped: True", "pong"]
+
+
+def test_host_ack_and_bounded_discard_recovery():
+    """Pre-response frames the worker must survive: a correct-id host_ack is
+    skipped WITHOUT counting against the discard budget, and up to exactly
+    _DISCARD_BUDGET (8) out-of-order/garbage frames are discarded before the
+    id-matched response — the RPC still returns its data."""
+    with Kernel(dispatcher=_echo_dispatcher) as k:
+        orig = k._service_host_call
+
+        def noisy(frame):
+            # correct-id ack: the "keep waiting" signal, never a discard
+            k._send({"type": "host_ack", "id": frame["id"]})
+            # exactly 8 discardable frames = the full budget:
+            # 6 stale responses (id mismatch) + 1 non-JSON line + 1 non-dict
+            for i in range(6):
+                k._send({"type": "host_response", "id": f"stale-{i}", "data": "old"})
+            k._proc.stdin.write("this line is not json\n")
+            k._proc.stdin.flush()
+            k._send([1, 2, 3])
+            orig(frame)
+
+        k._service_host_call = noisy
+        r = k.execute("print(host._call('ping', []))")
+        assert r["error"] is None
+        assert r["stdout"].strip() == "pong"
+
+
+def test_host_call_desync_over_budget_raises_and_kernel_survives():
+    """One frame past the discard budget (9 mismatched frames, no real
+    response) makes host_call give up with a 'protocol desync' RuntimeError
+    instead of spinning forever — and the worker keeps serving afterwards."""
+    with Kernel(dispatcher=_echo_dispatcher) as k:
+        orig = k._service_host_call
+
+        def flood(frame):
+            for i in range(9):
+                k._send({"type": "host_response", "id": f"stale-{i}", "data": None})
+            # never send the real response — the worker must bail on its own
+
+        k._service_host_call = flood
+        r = k.execute(
+            "try:\n"
+            "    host._call('ping', [])\n"
+            "except RuntimeError as e:\n"
+            "    print('caught:', e)"
+        )
+        assert r["error"] is None
+        assert "host.ping: protocol desync" in r["stdout"]
+        # with a sane host again, the same worker answers the next RPC
+        k._service_host_call = orig
+        r2 = k.execute("print(host._call('ping', []))")
+        assert r2["stdout"].strip() == "pong"
+
+
+def test_sigint_interrupt_reports_interrupted_true_lineno_none():
+    """The host.exec_interrupt contract: a DELIVERED SIGINT ends the cell with
+    interrupted=True, error='Interrupted' and NO error_lineno — and the kernel
+    (with its namespace) survives the interrupt."""
+    with Kernel(dispatcher=_echo_dispatcher) as k:
+        k.execute("marker = 'still-here'")
+        started = threading.Event()
+        result = {}
+
+        def run():
+            result["r"] = k.execute(
+                "print('cell-started')\nimport time\ntime.sleep(30)",
+                on_chunk=lambda _text: started.set(),
+            )
+
+        t = threading.Thread(target=run, daemon=True)
+        t.start()
+        # the first stdout chunk proves user code is executing (handler armed)
+        assert started.wait(15), "cell never produced its first stdout chunk"
+        k.interrupt()
+        t.join(timeout=15)
+        assert not t.is_alive(), "interrupt did not stop the cell"
+
+        r = result["r"]
+        assert r["interrupted"] is True
+        assert r["error"] == "Interrupted"
+        assert r["trace"]["error_lineno"] is None
+        assert k.is_alive()
+        assert k.execute("print(marker)")["stdout"].strip() == "still-here"
+
+
+def test_user_raised_keyboardinterrupt_is_normal_error_with_lineno():
+    """The contrast half of the SIGINT contract: user code raising
+    KeyboardInterrupt itself is a NORMAL error (interrupted=False) with a real
+    lineno — only a delivered signal sets interrupted=True."""
+    with Kernel(dispatcher=_echo_dispatcher) as k:
+        r = k.execute("x = 1\nraise KeyboardInterrupt('manual')")
+        assert r["interrupted"] is False
+        assert "KeyboardInterrupt" in r["error"]
+        assert r["trace"]["error_lineno"] == 2
+        assert k.is_alive()
 
 
 if __name__ == "__main__":

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,0 +1,211 @@
+"""Store schema/serializer contracts for artifact_versions and lineage_edges.
+
+store.py is a future extraction target (docs/refactor-plan.md) — these lock
+the row shapes and id conventions callers depend on TODAY, so an extraction
+that drops or renames a column fails here first.
+"""
+from openai4s.config import Config, LLMConfig
+from openai4s.store import get_store
+
+
+def _store(tmp_path):
+    cfg = Config(
+        data_dir=tmp_path,
+        llm=LLMConfig(provider="deepseek", api_key="test-key"),
+    )
+    return get_store(cfg.db_path)
+
+
+# --- artifact_versions -------------------------------------------------------
+def test_save_artifact_return_shape_and_version_row_columns(tmp_path):
+    store = _store(tmp_path)
+    f = tmp_path / "data.csv"
+    f.write_text("a,b\n1,2\n")
+
+    rec = store.save_artifact(
+        path=str(f),
+        filename="data.csv",
+        content_type="text/csv",
+        size_bytes=8,
+        checksum="abc123",
+        producing_cell_id="cell-1",
+        frame_id="f-1",
+        project_id="default",
+    )
+    # the serializer dict handed back to every caller (gateway, dispatcher)
+    assert set(rec) == {
+        "artifact_id",
+        "version_id",
+        "filename",
+        "path",
+        "content_type",
+        "size_bytes",
+        "checksum",
+        "created_at",
+    }
+    assert rec["artifact_id"].startswith("a-")
+    assert rec["version_id"].startswith("v-")
+    assert isinstance(rec["created_at"], int)
+
+    # the raw artifact_versions row: base schema + migration columns
+    row = store.version_meta(rec["version_id"])
+    assert set(row) == {
+        "version_id",
+        "artifact_id",
+        "filename",
+        "content_type",
+        "size_bytes",
+        "checksum",
+        "path",
+        "snapshot_path",
+        "producing_cell_id",
+        "frame_id",
+        "created_at",
+        "env_snapshot_id",
+    }
+    assert row["path"] == str(f)
+    assert row["snapshot_path"] is None  # bound later by the gateway snapshotter
+    assert row["env_snapshot_id"] is None
+    assert row["producing_cell_id"] == "cell-1"
+    assert row["frame_id"] == "f-1"
+    assert store.version_meta("v-does-not-exist") is None
+
+
+def test_list_versions_row_shape_ordering_and_latest_pointer(tmp_path):
+    store = _store(tmp_path)
+    rec1 = store.save_artifact(
+        path="/w/x.txt",
+        filename="x.txt",
+        content_type=None,
+        size_bytes=1,
+        checksum=None,
+    )
+    rec2 = store.save_artifact(
+        path="/w/x.txt",
+        filename="x.txt",
+        content_type=None,
+        size_bytes=2,
+        checksum=None,
+        artifact_id=rec1["artifact_id"],
+    )
+    # latest_version_id never dangles: it points at the newest version row
+    assert store.get_artifact(rec1["artifact_id"])["latest_version_id"] == (
+        rec2["version_id"]
+    )
+
+    vs = store.list_versions(rec1["artifact_id"])
+    assert set(vs[0]) == {
+        "version_id",
+        "filename",
+        "content_type",
+        "size_bytes",
+        "checksum",
+        "producing_cell_id",
+        "frame_id",
+        "created_at",
+        "is_latest",
+        "ordinal",
+    }
+    # newest first (rowid breaks same-millisecond ties), ordinal 1 = oldest
+    assert [v["version_id"] for v in vs] == [rec2["version_id"], rec1["version_id"]]
+    assert [v["ordinal"] for v in vs] == [2, 1]
+    assert vs[0]["is_latest"] is True and vs[1]["is_latest"] is False
+
+
+def test_resolve_artifact_path_prefers_snapshot_keeps_live_path(tmp_path):
+    """resolve_artifact_path serves COALESCE(snapshot_path, path) for both
+    version and artifact idents, while set_version_snapshot leaves ``path``
+    untouched so the version_for_path reverse lookup keeps resolving."""
+    store = _store(tmp_path)
+    rec = store.save_artifact(
+        path="/live/file.txt",
+        filename="file.txt",
+        content_type=None,
+        size_bytes=1,
+        checksum=None,
+    )
+    assert store.resolve_artifact_path(rec["version_id"]) == "/live/file.txt"
+
+    store.set_version_snapshot(rec["version_id"], "/frozen/file.txt")
+    assert store.resolve_artifact_path(rec["version_id"]) == "/frozen/file.txt"
+    assert store.resolve_artifact_path(rec["artifact_id"]) == "/frozen/file.txt"
+    assert store.version_meta(rec["version_id"])["path"] == "/live/file.txt"
+    assert store.version_for_path("/live/file.txt") == rec["version_id"]
+    assert store.resolve_artifact_path("nope") is None
+
+
+# --- lineage_edges -----------------------------------------------------------
+def test_lineage_edge_row_shape_and_directional_queries(tmp_path):
+    store = _store(tmp_path)
+    rec_in = store.save_artifact(
+        path="/w/in.csv",
+        filename="in.csv",
+        content_type="text/csv",
+        size_bytes=1,
+        checksum=None,
+    )
+    rec_out = store.save_artifact(
+        path="/w/out.csv",
+        filename="out.csv",
+        content_type="text/csv",
+        size_bytes=1,
+        checksum=None,
+    )
+    store.add_lineage_edge(
+        input_version_id=rec_in["version_id"],
+        output_version_id=rec_out["version_id"],
+        producing_cell_id="cell-9",
+        frame_id="f-9",
+    )
+
+    # raw row shape (the schema contract an extraction must preserve)
+    row = store._conn.execute("SELECT * FROM lineage_edges").fetchone()
+    assert set(row.keys()) == {
+        "edge_id",
+        "input_version_id",
+        "output_version_id",
+        "producing_cell_id",
+        "frame_id",
+        "created_at",
+    }
+    assert row["edge_id"].startswith("e-")
+    assert row["input_version_id"] == rec_in["version_id"]
+    assert row["output_version_id"] == rec_out["version_id"]
+    assert row["producing_cell_id"] == "cell-9"
+    assert row["frame_id"] == "f-9"
+
+    # serializer: lineage_inputs joins back to the input's file identity
+    assert store.lineage_inputs(rec_out["version_id"]) == [
+        {
+            "version_id": rec_in["version_id"],
+            "filename": "in.csv",
+            "path": "/w/in.csv",
+        }
+    ]
+    # directional traversal returns BARE version ids, both ways
+    assert store.lineage_edges_for(rec_out["version_id"], "up") == [
+        rec_in["version_id"]
+    ]
+    assert store.lineage_edges_for(rec_in["version_id"], "down") == [
+        rec_out["version_id"]
+    ]
+    assert store.lineage_edges_for("v-unknown", "up") == []
+
+
+def test_lineage_input_with_no_version_row_keeps_id_null_identity(tmp_path):
+    """LEFT JOIN contract: an edge whose input version row is missing still
+    reports the id, with filename/path null — never dropped from the list."""
+    store = _store(tmp_path)
+    rec_out = store.save_artifact(
+        path="/w/out.csv",
+        filename="out.csv",
+        content_type=None,
+        size_bytes=1,
+        checksum=None,
+    )
+    store.add_lineage_edge(
+        input_version_id="v-ghost", output_version_id=rec_out["version_id"]
+    )
+    assert store.lineage_inputs(rec_out["version_id"]) == [
+        {"version_id": "v-ghost", "filename": None, "path": None}
+    ]


### PR DESCRIPTION
## Summary

Follow-up to the roadmap's PR 10: adds the 16 contract tests that adversarial reviewers flagged as still-missing protocol edges. Tests only — zero production-code changes, fully offline.

| File | Tests | Contracts locked |
| --- | --- | --- |
| `tests/test_kernel.py` | +5 | 15MB `host_call` wire cap (raises in-kernel, channel survives); `host_ack` pre-response frames; bounded-discard desync recovery (budget edge proven both sides); SIGINT → `interrupted=True, error_lineno=None`; user `KeyboardInterrupt` contrast |
| `tests/test_gateway.py` | +6 | RFC 6455 `_ws_encode`/`_ws_read_frame` length ladder + unmask round-trips (risk register: "WebSocket payload drift"); artifact bytes-route three-way ident resolution proven as an order; JSON-404-on-bytes-route wart pinned; `/preview` forced `text/html`; upload without `frame_id` broadcasts nothing; malformed JSON body → `{}` |
| `tests/test_store.py` | new, +5 | `save_artifact` return shape, `a-`/`v-` id prefixes; exact `artifact_versions` column set incl. migration columns; `list_versions` ordering/`is_latest`; snapshot-over-live resolution; `lineage_edges` raw columns + `lineage_inputs` ghost-input LEFT-JOIN |

## Verification

- `uv run pytest` — **275 passed, 1 skipped, 1 deselected** (fully offline)
- `uv run pre-commit run --all-files` — green
- Reviewed by two adversarial audit agents (both PASS); the SIGINT test was run 4 consecutive times to rule out flakes; full suite run twice to rule out order-dependence.

## Notes for reviewers

- These tests deliberately couple to private internals (`Kernel._send`, `store._conn`, handler stubs) — that is the point of behavior-locking before the planned large-file extraction; extraction PRs should update them deliberately, not delete them.
- Spotted in passing, intentionally NOT fixed here (tests-only PR): `store.py` `lineage_edges_for` is annotated `-> list[dict]` but returns bare version-id strings — worth a one-line follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)