### PR TITLE
fix(security): use os.path.commonpath for path containment (CodeQL follow-up)

### DIFF
--- a/openai4s/jobs.py
+++ b/openai4s/jobs.py
@@ -88,15 +88,15 @@ class JobManager:
             return {"error": "empty command"}
         kind = kind if kind in ("bash", "python") else "bash"
         # Confine the working directory to the jobs root: normalize a caller-supplied
-        # cwd and require the result to stay inside the root, so it cannot escape via
-        # ".." or an absolute path (no path injection).
-        root_dir = os.path.realpath(str(self.root))
+        # cwd and require it to share the root as a common path prefix, so it cannot
+        # escape via ".." traversal or an absolute path (no path injection).
+        base = os.path.realpath(str(self.root))
         if cwd:
-            wd = os.path.normpath(os.path.join(root_dir, cwd))
-            if wd != root_dir and not wd.startswith(root_dir + os.sep):
+            wd = os.path.normpath(os.path.join(base, cwd))
+            if os.path.commonpath((base, wd)) != base:
                 return {"error": "cwd escapes the jobs root"}
         else:
-            wd = root_dir
+            wd = base
         Path(wd).mkdir(parents=True, exist_ok=True)
         job = Job(kind, command, wd)
         with self._lock:

--- a/openai4s/server/gateway.py
+++ b/openai4s/server/gateway.py
@@ -3898,11 +3898,12 @@ def make_handler(cfg: Config, hub: WSHub, runner: SessionRunner):
                 return True
             if path.startswith("/static/"):
                 rel = path[len("/static/") :]
-                # Normalize the requested path and require it to stay inside the
-                # web-UI root, so it cannot escape via ".." or an absolute path.
-                root_dir = os.path.realpath(str(WEBUI_DIR))
-                target_s = os.path.normpath(os.path.join(root_dir, rel))
-                if target_s != root_dir and not target_s.startswith(root_dir + os.sep):
+                # Normalize the requested path and require it to share the web-UI
+                # root as a common path prefix, so it cannot escape via ".." or an
+                # absolute path.
+                base = os.path.realpath(str(WEBUI_DIR))
+                target_s = os.path.normpath(os.path.join(base, rel))
+                if os.path.commonpath((base, target_s)) != base:
                     self._json({"error": "forbidden"}, 403)
                     return True
                 target = Path(target_s)


### PR DESCRIPTION
## Summary

Follow-up to #11. The `normpath` + `startswith` containment checks for `/static/` serving and the jobs `cwd` were **correct but not recognised** by CodeQL's `py/path-injection` sanitizer model, so alerts #14/#16/#17 stayed open on `main` even though the code rejects traversal. Switch both to `os.path.commonpath((base, target)) != base`, the containment idiom CodeQL recognises. Behaviour is unchanged — verified live: legit files serve (200), `../`/absolute escapes are rejected (403 / "cwd escapes the jobs root"), and no directory is created outside the root.

## Change Type
- [x] Bug fix
- [x] Security-related change

## Verification
```text
uv run pytest                       # 299 passed
uv run pre-commit run --all-files   # black · isort · ruff pass
Live: /static/app.js 200 · /static/../../server/gateway.py 403 · /static//etc/hosts 403
      POST /api/compute/jobs {"cwd":"/tmp/x"} -> "cwd escapes the jobs root" (no dir created)
      POST /api/compute/jobs {} -> running
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)