### PR TITLE
Add protein mutation enhancement workflow skill

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -10,14 +10,14 @@ skills/example_stats/
 
 Skills are consumed by **writing code**. The loader surfaces each `SKILL.md` to the model via *progressive disclosure* (only a one-line summary up front; the full doc is fetched on demand with `host.search_skills(query)`), the kernel adds `skills/` to `sys.path`, and the agent runs e.g. `from example_stats.kernel import summary`. A Skill's capability lands as **callable Python inside the kernel** — the same principle as the core paradigm, not another tool schema.
 
-## Bundled Skills (24)
+## Bundled Skills (28)
 
 | category | Skills |
 |---|---|
 | **Structure prediction** (GPU) | `alphafold2` · `openfold3` · `boltz` · `chai1` · `esmfold2` |
 | **Sequence / omics / docking** (GPU) | `fair-esm2` · `evo2` · `borzoi` · `scgpt` · `scvi-tools` · `diffdock` |
 | **Protein design** (GPU) | `proteinmpnn` · `ligandmpnn` · `solublempnn` |
-| **Research workflow** | `literature-review` · `pdf-explore` · `paper-narrative` · `figure-composer` · `figure-style` · `indication-dossier` |
+| **Research workflow** | `literature-review` · `pdf-explore` · `paper-narrative` · `figure-composer` · `figure-style` · `indication-dossier` · `retrosynthesis_planning` · `mineral_spectra_analysis` · `admet_genetic` · `protein-mutation-enhancement` |
 | **Platform** | `remote-compute-nvidia` · `remote-compute-ssh` · `using-model-endpoint` |
 
 `example_stats` is the reference example Skill (pure-stdlib descriptive-statistics helpers).

--- a/skills/protein-mutation-enhancement/SKILL.md
+++ b/skills/protein-mutation-enhancement/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: protein-mutation-enhancement
+description: >
+  Deterministic protein gain-of-function mutation workflow: build single,
+  double, and higher-order mutant libraries; merge ESM sequence-effect scores,
+  structure metrics from ESMFold-class models, property/function scores; rank
+  candidates; and decide whether to stop or start the next design round.
+origin: openai4s
+category: workflow
+requirements: [gpu]
+---
+
+# Protein Mutation Enhancement Workflow
+
+Use this skill when the task is to improve a target protein by iterative
+mutation design. It is an orchestration layer: deterministic library
+construction, score merging, ranking, and loop-control run locally with
+stdlib-only helpers; heavyweight model calls run through existing model skills
+such as `fair-esm2` and `esmfold2`.
+
+## Workflow Contract
+
+1. Validate the wild-type protein sequence and define mutable positions.
+2. Build a deterministic mutant library:
+   - round 1 usually uses single mutants over selected positions;
+   - later rounds expand top candidates to doubles or higher-order combinations;
+   - every variant has a stable ID such as `A12V+G47D`.
+3. Score sequence effect with an ESM masked-LM model:
+   - retrieve `fair-esm2` or `esmfold2` for concrete GPU recipes;
+   - produce a table keyed by `id`, commonly with `esm_delta` where higher is
+     better.
+4. Predict structures for promising mutants:
+   - retrieve `esmfold2` for ESMFold2 / ESMFold2-Fast recipes;
+   - produce structure metrics keyed by `id`, commonly `plddt`, `ptm`, `pae`,
+     `rmsd_to_wt`, or task-specific interface metrics.
+5. Merge sequence, structure, property, and functional assay/proxy metrics.
+6. Rank by weighted normalized score and apply acceptance thresholds.
+7. If any candidate passes thresholds, call `host.submit_output(...)`. If none
+   pass, use the top ranked variants to seed the next loop and expand the
+   library.
+
+## Import
+
+The directory name contains hyphens, so import via `importlib`:
+
+```python
+import importlib
+
+pm = importlib.import_module("protein-mutation-enhancement.kernel")
+```
+
+## Build a Mutation Library
+
+```python
+wt = "MKTAYIAKQRQISFVKSHFSRQ"
+
+library = pm.enumerate_mutants(
+    wt,
+    positions=[3, 5, 8, 12],
+    substitutions={3: ["A", "L", "F"], 5: ["V", "L"], 8: ["R", "K"]},
+    max_order=2,
+    limit=500,
+)
+
+pm.write_fasta(library, "round1_mutants.fasta")
+```
+
+`positions` are 1-indexed. If `substitutions` omits a position, all 20 natural
+amino acids except the wild-type residue are used. Candidate IDs are stable and
+sorted by position, so downstream score tables can safely join on `id`.
+
+## Merge Scores and Rank
+
+After running ESM and structure jobs, load or construct score tables keyed by
+variant ID:
+
+```python
+esm_scores = {
+    "T3L": {"esm_delta": 1.8},
+    "Y5V": {"esm_delta": 0.3},
+    "T3L+Y5V": {"esm_delta": 2.1},
+}
+structure_scores = {
+    "T3L": {"plddt": 86.0, "rmsd_to_wt": 0.8},
+    "Y5V": {"plddt": 71.0, "rmsd_to_wt": 2.4},
+    "T3L+Y5V": {"plddt": 82.0, "rmsd_to_wt": 1.1},
+}
+
+round_result = pm.run_selection_round(
+    library,
+    score_tables=[esm_scores, structure_scores],
+    weights={
+        "esm_delta": 0.45,
+        "plddt": 0.25,
+        "rmsd_to_wt": 0.15,
+        "property_score": 0.15,
+    },
+    directions={"rmsd_to_wt": "low"},
+    acceptance_thresholds={
+        "composite_score": 0.72,
+        "esm_delta": 1.0,
+        "plddt": 75.0,
+    },
+    top_k=20,
+)
+
+best = round_result["ranked"][0]
+print(best["id"], best["composite_score"], round_result["should_continue"])
+```
+
+`property_score` is computed locally from conservative amino-acid-class,
+hydropathy, charge, and size-change heuristics unless an external table
+provides it. External assay or task-proxy metrics can be added as extra columns
+and weights.
+
+## Loop Pattern
+
+```python
+current_library = pm.enumerate_mutants(wt, positions=active_positions, max_order=1)
+
+for round_idx in range(1, 6):
+    # 1. Score `current_library` using fair-esm2 / ESMC.
+    # 2. Fold the promising subset using esmfold2 / ESMFold2-Fast.
+    # 3. Merge the resulting tables.
+    result = pm.run_selection_round(
+        current_library,
+        score_tables=[esm_scores, structure_scores, function_scores],
+        weights=weights,
+        directions=directions,
+        acceptance_thresholds=thresholds,
+        top_k=50,
+    )
+    if not result["should_continue"]:
+        host.submit_output({"accepted": result["accepted"], "round": round_idx})
+        break
+
+    active_positions = pm.suggest_next_positions(result["ranked"], max_positions=10)
+    current_library = pm.enumerate_mutants(
+        wt,
+        positions=active_positions,
+        max_order=min(round_idx + 1, 4),
+        seeds=result["next_round_seeds"],
+        limit=2000,
+    )
+else:
+    host.submit_output({"accepted": [], "ranked": result["ranked"][:20]})
+```
+
+## Practical Defaults
+
+- Start with curated active-site, binding-site, stability, or conservation
+  positions instead of all positions when possible.
+- Use `max_order=1` for the first pass, then expand top single mutants into
+  doubles/combinations with `seeds=...`.
+- Keep the model jobs separate from ranking artifacts:
+  - `mutants.fasta`
+  - `esm_scores.csv`
+  - `structure_scores.csv`
+  - `ranked_candidates.json`
+- Prefer hard acceptance thresholds for safety-critical metrics such as
+  minimum pLDDT or maximum RMSD, and use weighted composite score only after
+  those gates pass.
+
+## Notes
+
+- This skill does not claim a mutation is biologically validated. It ranks
+  candidates for follow-up validation using deterministic, inspectable rules.
+- Core helpers are pure stdlib and safe for the default offline test suite.
+- GPU model installation, weights, and remote execution remain in the model
+  skills (`fair-esm2`, `esmfold2`) and compute skills.

--- a/skills/protein-mutation-enhancement/kernel.py
+++ b/skills/protein-mutation-enhancement/kernel.py
@@ -1,0 +1,587 @@
+"""Deterministic helpers for the protein mutation enhancement workflow.
+
+This sidecar intentionally stays stdlib-only. It builds mutation libraries,
+joins model/assay score tables, computes lightweight property heuristics, ranks
+candidates, and decides whether an iterative design loop should continue.
+Heavy ESM and structure prediction jobs are orchestrated by separate skills.
+"""
+from __future__ import annotations
+
+import csv
+import itertools
+import json
+import math
+import re
+from pathlib import Path
+from typing import Iterable, Mapping, Sequence
+
+AA_ALPHABET = "ACDEFGHIKLMNPQRSTVWY"
+_MUTATION_RE = re.compile(r"^([A-Z])([1-9][0-9]*)([A-Z])$")
+
+_AA_CLASS = {
+    "A": "small",
+    "C": "polar",
+    "D": "negative",
+    "E": "negative",
+    "F": "aromatic",
+    "G": "small",
+    "H": "positive",
+    "I": "hydrophobic",
+    "K": "positive",
+    "L": "hydrophobic",
+    "M": "hydrophobic",
+    "N": "polar",
+    "P": "special",
+    "Q": "polar",
+    "R": "positive",
+    "S": "polar",
+    "T": "polar",
+    "V": "hydrophobic",
+    "W": "aromatic",
+    "Y": "aromatic",
+}
+
+_HYDROPATHY = {
+    "A": 1.8,
+    "C": 2.5,
+    "D": -3.5,
+    "E": -3.5,
+    "F": 2.8,
+    "G": -0.4,
+    "H": -3.2,
+    "I": 4.5,
+    "K": -3.9,
+    "L": 3.8,
+    "M": 1.9,
+    "N": -3.5,
+    "P": -1.6,
+    "Q": -3.5,
+    "R": -4.5,
+    "S": -0.8,
+    "T": -0.7,
+    "V": 4.2,
+    "W": -0.9,
+    "Y": -1.3,
+}
+
+_CHARGE = {
+    "D": -1,
+    "E": -1,
+    "H": 0.5,
+    "K": 1,
+    "R": 1,
+}
+
+_VOLUME = {
+    "A": 88.6,
+    "C": 108.5,
+    "D": 111.1,
+    "E": 138.4,
+    "F": 189.9,
+    "G": 60.1,
+    "H": 153.2,
+    "I": 166.7,
+    "K": 168.6,
+    "L": 166.7,
+    "M": 162.9,
+    "N": 114.1,
+    "P": 112.7,
+    "Q": 143.8,
+    "R": 173.4,
+    "S": 89.0,
+    "T": 116.1,
+    "V": 140.0,
+    "W": 227.8,
+    "Y": 193.6,
+}
+
+
+def validate_sequence(sequence: str, alphabet: str = AA_ALPHABET) -> str:
+    """Return an uppercase sequence, raising ValueError on invalid residues."""
+    seq = "".join(str(sequence).split()).upper()
+    if not seq:
+        raise ValueError("sequence is empty")
+    allowed = set(alphabet)
+    bad = sorted(set(seq) - allowed)
+    if bad:
+        raise ValueError(f"sequence contains unsupported residue(s): {''.join(bad)}")
+    return seq
+
+
+def parse_mutation(mutation: str, sequence: str | None = None) -> dict:
+    """Parse `A12V` into a JSON-friendly dict with 1-indexed position."""
+    match = _MUTATION_RE.match(str(mutation).strip().upper())
+    if not match:
+        raise ValueError(f"invalid mutation: {mutation!r}")
+    wt, pos_s, mutant = match.groups()
+    pos = int(pos_s)
+    bad = sorted({wt, mutant} - set(AA_ALPHABET))
+    if bad:
+        raise ValueError(f"mutation contains unsupported residue(s): {''.join(bad)}")
+    if wt == mutant:
+        raise ValueError(f"mutation does not change residue: {mutation!r}")
+    if sequence is not None:
+        seq = validate_sequence(sequence)
+        if pos > len(seq):
+            raise ValueError(f"mutation position {pos} exceeds sequence length")
+        observed = seq[pos - 1]
+        if observed != wt:
+            raise ValueError(
+                f"wild-type mismatch at {pos}: mutation says {wt}, "
+                f"sequence has {observed}"
+            )
+    return {"from": wt, "position": pos, "to": mutant}
+
+
+def normalize_mutations(
+    mutations: str | Mapping | Sequence,
+    sequence: str | None = None,
+) -> list[dict]:
+    """Normalize mutation strings, dicts, or tuples into sorted mutation dicts.
+
+    Accepted forms include `"A12V+G47D"`, `{"from":"A","position":12,"to":"V"}`,
+    `(12, "V")` when `sequence` is available, and `("A", 12, "V")`.
+    """
+    if mutations is None:
+        return []
+    if isinstance(mutations, str):
+        parts = [p for p in re.split(r"[+,;\s]+", mutations.strip()) if p]
+        parsed = [parse_mutation(part, sequence) for part in parts]
+        return _validate_mutation_set(parsed)
+    if isinstance(mutations, Mapping):
+        parsed = [_coerce_mutation(mutations, sequence)]
+        return _validate_mutation_set(parsed)
+
+    parsed = []
+    for item in mutations:
+        parsed.append(_coerce_mutation(item, sequence))
+    return _validate_mutation_set(parsed)
+
+
+def mutation_id(
+    mutations: str | Mapping | Sequence, sequence: str | None = None
+) -> str:
+    """Return a stable variant ID such as `A12V+G47D` or `WT`."""
+    muts = normalize_mutations(mutations, sequence)
+    if not muts:
+        return "WT"
+    return "+".join(
+        f"{m['from']}{m['position']}{m['to']}"
+        for m in sorted(muts, key=lambda x: x["position"])
+    )
+
+
+def apply_mutations(sequence: str, mutations: str | Mapping | Sequence) -> str:
+    """Apply validated mutations to a wild-type sequence."""
+    seq = validate_sequence(sequence)
+    chars = list(seq)
+    for mut in normalize_mutations(mutations, seq):
+        chars[mut["position"] - 1] = mut["to"]
+    return "".join(chars)
+
+
+def enumerate_mutants(
+    sequence: str,
+    positions: Sequence[int] | None = None,
+    substitutions: Mapping[int | str, Iterable[str] | str] | None = None,
+    max_order: int = 1,
+    seeds: Sequence[str | Mapping | Sequence] | None = None,
+    limit: int | None = None,
+    include_wild_type: bool = False,
+    alphabet: str = AA_ALPHABET,
+) -> list[dict]:
+    """Build a deterministic single/double/combination mutant library.
+
+    `positions` are 1-indexed. If `seeds` are supplied, each seed is kept and
+    expanded with additional mutations up to `max_order`.
+    """
+    seq = validate_sequence(sequence, alphabet)
+    if max_order < 1:
+        raise ValueError("max_order must be >= 1")
+    if limit is not None and limit < 1:
+        raise ValueError("limit must be >= 1 when provided")
+
+    pos_list = _normalize_positions(positions, len(seq))
+    sub_map = _normalize_substitutions(seq, pos_list, substitutions, alphabet)
+    options = [
+        {"from": seq[pos - 1], "position": pos, "to": aa}
+        for pos in pos_list
+        for aa in sub_map[pos]
+    ]
+
+    out: list[dict] = []
+    seen: set[str] = set()
+
+    def add_variant(muts: Sequence[Mapping]) -> bool:
+        mid = mutation_id(muts)
+        if mid in seen:
+            return False
+        mutant_seq = apply_mutations(seq, muts) if muts else seq
+        seen.add(mid)
+        out.append(
+            {
+                "id": mid,
+                "sequence": mutant_seq,
+                "mutations": [dict(m) for m in normalize_mutations(muts, seq)],
+                "order": len(muts),
+            }
+        )
+        return limit is not None and len(out) >= limit
+
+    if include_wild_type and add_variant([]):
+        return out
+
+    seed_sets = [normalize_mutations(seed, seq) for seed in seeds or []]
+    if not seed_sets:
+        for order in range(1, max_order + 1):
+            for combo in itertools.combinations(options, order):
+                if len({m["position"] for m in combo}) != order:
+                    continue
+                if add_variant(combo):
+                    return out
+        return out
+
+    for seed in seed_sets:
+        if len(seed) > max_order:
+            raise ValueError(f"seed {mutation_id(seed)} exceeds max_order")
+        if add_variant(seed):
+            return out
+        occupied = {m["position"] for m in seed}
+        remaining = [m for m in options if m["position"] not in occupied]
+        max_extra = max_order - len(seed)
+        for extra_order in range(1, max_extra + 1):
+            for extra in itertools.combinations(remaining, extra_order):
+                if len({m["position"] for m in extra}) != extra_order:
+                    continue
+                if add_variant([*seed, *extra]):
+                    return out
+    return out
+
+
+def property_score(mutations: str | Mapping | Sequence) -> float:
+    """Score conservative physicochemical change on a 0..1 scale."""
+    muts = normalize_mutations(mutations)
+    if not muts:
+        return 1.0
+    scores = []
+    for mut in muts:
+        wt = mut["from"]
+        aa = mut["to"]
+        class_bonus = 0.15 if _AA_CLASS.get(wt) == _AA_CLASS.get(aa) else 0.0
+        hydropathy_delta = abs(_HYDROPATHY[aa] - _HYDROPATHY[wt]) / 9.0
+        charge_delta = abs(_CHARGE.get(aa, 0.0) - _CHARGE.get(wt, 0.0)) / 2.0
+        volume_delta = abs(_VOLUME[aa] - _VOLUME[wt]) / 170.0
+        penalty = 0.45 * hydropathy_delta + 0.25 * charge_delta
+        penalty += 0.15 * volume_delta
+        scores.append(_clamp(0.85 + class_bonus - penalty))
+    return sum(scores) / len(scores)
+
+
+def read_score_table(path: str | Path, id_column: str = "id") -> dict[str, dict]:
+    """Read a CSV or JSON score table keyed by variant ID."""
+    p = Path(path)
+    if p.suffix.lower() == ".json":
+        payload = json.loads(p.read_text("utf-8"))
+        if isinstance(payload, Mapping):
+            return {str(k): _coerce_score_row(v) for k, v in payload.items()}
+        if isinstance(payload, list):
+            return _records_to_table(payload, id_column)
+        raise ValueError("JSON score table must be an object or list of records")
+
+    with p.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        return _records_to_table(list(reader), id_column)
+
+
+def write_fasta(candidates: Sequence[Mapping], path: str | Path) -> None:
+    """Write candidate sequences to FASTA using candidate `id` as header."""
+    with Path(path).open("w", encoding="utf-8") as handle:
+        for cand in candidates:
+            cid = str(cand["id"])
+            seq = validate_sequence(str(cand["sequence"]))
+            handle.write(f">{cid}\n")
+            for i in range(0, len(seq), 80):
+                handle.write(seq[i : i + 80] + "\n")
+
+
+def rank_mutants(
+    candidates: Sequence[Mapping],
+    score_tables: Sequence[Mapping | Sequence[Mapping]] | None = None,
+    weights: Mapping[str, float] | None = None,
+    directions: Mapping[str, str] | None = None,
+    acceptance_thresholds: Mapping[str, float] | None = None,
+) -> list[dict]:
+    """Merge score tables, normalize metrics, and rank candidates."""
+    weights = dict(weights or {"esm_delta": 0.5, "plddt": 0.3, "property_score": 0.2})
+    directions = {k: v.lower() for k, v in (directions or {}).items()}
+    thresholds = dict(acceptance_thresholds or {})
+    if not weights:
+        raise ValueError("weights must not be empty")
+    if any(v < 0 for v in weights.values()):
+        raise ValueError("weights must be non-negative; use directions for low metrics")
+    total_weight = sum(weights.values())
+    if total_weight <= 0:
+        raise ValueError("at least one metric weight must be positive")
+
+    rows = _merge_candidates(candidates, score_tables or [])
+    for row in rows:
+        if "property_score" in weights and row.get("property_score") is None:
+            row["property_score"] = property_score(row.get("mutations", []))
+
+    normalized_by_metric = {
+        metric: _normalize_metric(rows, metric, directions.get(metric, "high"))
+        for metric in weights
+    }
+
+    ranked = []
+    for row in rows:
+        norm = {
+            metric: normalized_by_metric[metric].get(row["id"], 0.0)
+            for metric in weights
+        }
+        missing = [
+            metric
+            for metric in weights
+            if row.get(metric) is None or not _is_number(row.get(metric))
+        ]
+        composite = sum(norm[m] * weights[m] for m in weights) / total_weight
+        enriched = dict(row)
+        enriched["normalized_scores"] = norm
+        enriched["missing_metrics"] = missing
+        enriched["composite_score"] = round(composite, 6)
+        enriched["passes_thresholds"] = _passes_thresholds(
+            enriched, thresholds, directions
+        )
+        ranked.append(enriched)
+
+    ranked.sort(key=lambda r: (-r["composite_score"], r["id"]))
+    return ranked
+
+
+def run_selection_round(
+    candidates: Sequence[Mapping],
+    score_tables: Sequence[Mapping | Sequence[Mapping]] | None = None,
+    weights: Mapping[str, float] | None = None,
+    directions: Mapping[str, str] | None = None,
+    acceptance_thresholds: Mapping[str, float] | None = None,
+    top_k: int = 20,
+) -> dict:
+    """Rank one design round and return loop-control fields."""
+    if top_k < 1:
+        raise ValueError("top_k must be >= 1")
+    ranked = rank_mutants(
+        candidates,
+        score_tables=score_tables,
+        weights=weights,
+        directions=directions,
+        acceptance_thresholds=acceptance_thresholds,
+    )
+    accepted = [row for row in ranked if row["passes_thresholds"]]
+    return {
+        "ranked": ranked,
+        "accepted": accepted,
+        "should_continue": not bool(accepted),
+        "next_round_seeds": ranked[:top_k] if not accepted else [],
+    }
+
+
+def suggest_next_positions(
+    ranked_candidates: Sequence[Mapping],
+    max_positions: int = 10,
+) -> list[int]:
+    """Pick positions enriched among top-ranked candidates for the next round."""
+    if max_positions < 1:
+        raise ValueError("max_positions must be >= 1")
+    weights: dict[int, float] = {}
+    for rank, cand in enumerate(ranked_candidates):
+        rank_weight = 1.0 / (rank + 1)
+        for mut in normalize_mutations(cand.get("mutations", [])):
+            pos = int(mut["position"])
+            weights[pos] = weights.get(pos, 0.0) + rank_weight
+    return [
+        pos
+        for pos, _ in sorted(weights.items(), key=lambda item: (-item[1], item[0]))[
+            :max_positions
+        ]
+    ]
+
+
+def write_ranked_json(result: Mapping, path: str | Path) -> None:
+    """Persist a selection-round result for review or downstream loops."""
+    Path(path).write_text(json.dumps(result, indent=2, sort_keys=True), "utf-8")
+
+
+def _coerce_mutation(item, sequence: str | None) -> dict:
+    if isinstance(item, str):
+        return parse_mutation(item, sequence)
+    if isinstance(item, Mapping):
+        pos = int(item.get("position", item.get("pos")))
+        wt = str(item.get("from", item.get("wt", ""))).upper()
+        aa = str(item.get("to", item.get("mutant", item.get("aa", "")))).upper()
+        if not wt and sequence is not None:
+            wt = validate_sequence(sequence)[pos - 1]
+        if not wt or not aa:
+            raise ValueError(f"mutation mapping is missing from/to: {item!r}")
+        return parse_mutation(f"{wt}{pos}{aa}", sequence)
+    if isinstance(item, Sequence):
+        if len(item) == 2:
+            if sequence is None:
+                raise ValueError("(position, to) mutations require sequence")
+            pos = int(item[0])
+            wt = validate_sequence(sequence)[pos - 1]
+            return parse_mutation(f"{wt}{pos}{str(item[1]).upper()}", sequence)
+        if len(item) == 3:
+            wt, pos, aa = item
+            return parse_mutation(
+                f"{str(wt).upper()}{int(pos)}{str(aa).upper()}", sequence
+            )
+    raise ValueError(f"cannot parse mutation item: {item!r}")
+
+
+def _validate_mutation_set(mutations: Sequence[Mapping]) -> list[dict]:
+    seen: set[int] = set()
+    out = []
+    for mut in sorted((dict(m) for m in mutations), key=lambda x: x["position"]):
+        pos = int(mut["position"])
+        if pos in seen:
+            raise ValueError(f"multiple mutations target position {pos}")
+        seen.add(pos)
+        out.append(
+            {
+                "from": str(mut["from"]).upper(),
+                "position": pos,
+                "to": str(mut["to"]).upper(),
+            }
+        )
+    return out
+
+
+def _normalize_positions(positions: Sequence[int] | None, length: int) -> list[int]:
+    raw = range(1, length + 1) if positions is None else positions
+    out = sorted({int(pos) for pos in raw})
+    if not out:
+        raise ValueError("positions must not be empty")
+    bad = [pos for pos in out if pos < 1 or pos > length]
+    if bad:
+        raise ValueError(f"positions out of range: {bad}")
+    return out
+
+
+def _normalize_substitutions(
+    sequence: str,
+    positions: Sequence[int],
+    substitutions: Mapping[int | str, Iterable[str] | str] | None,
+    alphabet: str,
+) -> dict[int, list[str]]:
+    allowed = set(alphabet)
+    order = {aa: i for i, aa in enumerate(alphabet)}
+    sub_map = {}
+    substitutions = substitutions or {}
+    for pos in positions:
+        raw = substitutions.get(pos, substitutions.get(str(pos), alphabet))
+        residues = [aa.upper() for aa in (raw if not isinstance(raw, str) else raw)]
+        bad = sorted(set(residues) - allowed)
+        if bad:
+            raise ValueError(f"invalid substitutions at {pos}: {''.join(bad)}")
+        wt = sequence[pos - 1]
+        uniq = sorted({aa for aa in residues if aa != wt}, key=lambda aa: order[aa])
+        sub_map[pos] = uniq
+    return sub_map
+
+
+def _merge_candidates(
+    candidates: Sequence[Mapping],
+    score_tables: Sequence[Mapping | Sequence[Mapping]],
+) -> list[dict]:
+    tables = [_as_score_table(table) for table in score_tables]
+    rows = []
+    for cand in candidates:
+        row = dict(cand)
+        row["id"] = str(row["id"])
+        for table in tables:
+            if row["id"] in table:
+                row.update(table[row["id"]])
+        rows.append(row)
+    return rows
+
+
+def _as_score_table(table: Mapping | Sequence[Mapping]) -> dict[str, dict]:
+    if isinstance(table, Mapping):
+        return {str(k): _coerce_score_row(v) for k, v in table.items()}
+    return _records_to_table(table)
+
+
+def _records_to_table(
+    records: Sequence[Mapping],
+    id_column: str = "id",
+) -> dict[str, dict]:
+    out = {}
+    for record in records:
+        if id_column not in record:
+            raise ValueError(f"score record missing {id_column!r}: {record!r}")
+        cid = str(record[id_column])
+        row = {str(k): _coerce_number(v) for k, v in dict(record).items()}
+        row.pop(id_column, None)
+        out[cid] = row
+    return out
+
+
+def _coerce_score_row(value) -> dict:
+    if isinstance(value, Mapping):
+        return {str(k): _coerce_number(v) for k, v in value.items()}
+    raise ValueError(f"score table value must be a mapping, got {value!r}")
+
+
+def _coerce_number(value):
+    if value in ("", None):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return value
+
+
+def _normalize_metric(
+    rows: Sequence[Mapping], metric: str, direction: str
+) -> dict[str, float]:
+    values = [
+        (row["id"], float(row[metric])) for row in rows if _is_number(row.get(metric))
+    ]
+    if not values:
+        return {}
+    lo = min(v for _, v in values)
+    hi = max(v for _, v in values)
+    if math.isclose(lo, hi):
+        return {cid: 1.0 for cid, _ in values}
+    if direction not in ("high", "low"):
+        raise ValueError(f"direction for {metric!r} must be 'high' or 'low'")
+    if direction == "high":
+        return {cid: (v - lo) / (hi - lo) for cid, v in values}
+    return {cid: (hi - v) / (hi - lo) for cid, v in values}
+
+
+def _passes_thresholds(
+    row: Mapping,
+    thresholds: Mapping[str, float],
+    directions: Mapping[str, str],
+) -> bool:
+    for metric, threshold in thresholds.items():
+        value = row.get(metric)
+        if not _is_number(value):
+            return False
+        if directions.get(metric, "high") == "low":
+            if float(value) > float(threshold):
+                return False
+        elif float(value) < float(threshold):
+            return False
+    return True
+
+
+def _is_number(value) -> bool:
+    return isinstance(value, (int, float)) and math.isfinite(float(value))
+
+
+def _clamp(value: float, lo: float = 0.0, hi: float = 1.0) -> float:
+    return max(lo, min(hi, float(value)))

--- a/tests/test_protein_mutation_enhancement_skill.py
+++ b/tests/test_protein_mutation_enhancement_skill.py
@@ -1,0 +1,121 @@
+"""Offline tests for the protein-mutation-enhancement workflow skill."""
+import importlib
+import sys
+
+import pytest
+
+from openai4s.config import get_config
+
+
+@pytest.fixture(scope="module")
+def pm():
+    sys.path.insert(0, str(get_config().skills_dir))
+    return importlib.import_module("protein-mutation-enhancement.kernel")
+
+
+def test_enumerate_single_and_double_mutants_is_deterministic(pm):
+    library = pm.enumerate_mutants(
+        "ACD",
+        positions=[1, 2],
+        substitutions={1: ["A", "V"], 2: ["C", "D"]},
+        max_order=2,
+    )
+
+    assert [cand["id"] for cand in library] == ["A1V", "C2D", "A1V+C2D"]
+    assert [cand["sequence"] for cand in library] == ["VCD", "ADD", "VDD"]
+    assert library[-1]["order"] == 2
+
+
+def test_seeded_library_expands_without_repeating_positions(pm):
+    library = pm.enumerate_mutants(
+        "ACDE",
+        positions=[1, 2, 3],
+        substitutions={1: "V", 2: "D", 3: "E"},
+        max_order=2,
+        seeds=["A1V"],
+    )
+
+    assert [cand["id"] for cand in library] == ["A1V", "A1V+C2D", "A1V+D3E"]
+
+
+def test_apply_mutations_rejects_wild_type_mismatch(pm):
+    with pytest.raises(ValueError, match="wild-type mismatch"):
+        pm.apply_mutations("ACD", "G1V")
+
+
+def test_rank_mutants_merges_scores_and_applies_thresholds(pm):
+    candidates = pm.enumerate_mutants(
+        "ACD",
+        positions=[1, 2],
+        substitutions={1: "V", 2: "D"},
+        max_order=2,
+    )
+    esm_scores = {
+        "A1V": {"esm_delta": 0.4},
+        "C2D": {"esm_delta": 1.2},
+        "A1V+C2D": {"esm_delta": 1.9},
+    }
+    structure_scores = {
+        "A1V": {"plddt": 88.0, "rmsd_to_wt": 0.7},
+        "C2D": {"plddt": 65.0, "rmsd_to_wt": 1.4},
+        "A1V+C2D": {"plddt": 83.0, "rmsd_to_wt": 0.9},
+    }
+
+    result = pm.run_selection_round(
+        candidates,
+        score_tables=[esm_scores, structure_scores],
+        weights={
+            "esm_delta": 0.45,
+            "plddt": 0.25,
+            "rmsd_to_wt": 0.15,
+            "property_score": 0.15,
+        },
+        directions={"rmsd_to_wt": "low"},
+        acceptance_thresholds={
+            "composite_score": 0.70,
+            "esm_delta": 1.0,
+            "plddt": 75.0,
+            "rmsd_to_wt": 1.0,
+        },
+        top_k=2,
+    )
+
+    assert result["should_continue"] is False
+    assert result["accepted"][0]["id"] == "A1V+C2D"
+    assert result["ranked"][0]["id"] == "A1V+C2D"
+    assert "property_score" in result["ranked"][0]
+    assert result["ranked"][0]["normalized_scores"]["rmsd_to_wt"] > 0
+
+
+def test_selection_round_continues_when_thresholds_fail(pm):
+    candidates = pm.enumerate_mutants(
+        "ACD",
+        positions=[1, 2],
+        substitutions={1: "V", 2: "D"},
+        max_order=1,
+    )
+    scores = {
+        "A1V": {"esm_delta": 0.2, "plddt": 70.0},
+        "C2D": {"esm_delta": 0.4, "plddt": 71.0},
+    }
+
+    result = pm.run_selection_round(
+        candidates,
+        score_tables=[scores],
+        acceptance_thresholds={"esm_delta": 1.0, "plddt": 80.0},
+        top_k=1,
+    )
+
+    assert result["should_continue"] is True
+    assert result["accepted"] == []
+    assert len(result["next_round_seeds"]) == 1
+
+
+def test_suggest_next_positions_uses_rank_order(pm):
+    ranked = [
+        {"id": "A1V+C2D", "mutations": pm.normalize_mutations("A1V+C2D")},
+        {"id": "C2D", "mutations": pm.normalize_mutations("C2D")},
+        {"id": "D3E", "mutations": pm.normalize_mutations("D3E")},
+    ]
+
+    assert pm.suggest_next_positions(ranked, max_positions=2) == [2, 1]


### PR DESCRIPTION
## Summary

Adds a new Code-as-Action workflow skill for protein gain-of-function mutation design.

This PR introduces `protein-mutation-enhancement`, a deterministic orchestration layer for:

- building single, double, and higher-order mutant libraries;
- assigning stable variant IDs such as `A12V+G47D`;
- merging ESM sequence-effect scores, ESMFold-class structure metrics, property heuristics, and optional functional proxy scores;
- ranking candidates with weighted normalized scoring;
- deciding whether a design loop should stop or continue into the next round.

The heavyweight model work remains in existing skills such as `fair-esm2` and `esmfold2`; this skill only adds stdlib-only workflow helpers and documentation.

## Area

- [ ] Web UI / frontend
- [ ] Agent / loop / delegation
- [ ] Kernel / host RPC / runtime
- [ ] Server / gateway / API
- [ ] Store / provenance / artifacts
- [x] Skills / science runtime
- [ ] Compute / remote execution
- [ ] CLI / config / packaging
- [x] Tests / harness / CI
- [x] Docs

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Test / harness
- [x] Documentation
- [ ] Security-related change
- [ ] Release / packaging

## Verification

Ran:

```text
uv run pytest tests/test_protein_mutation_enhancement_skill.py -q
uv run pytest tests/test_skills.py -q
uv run pytest tests/test_protein_mutation_enhancement_skill.py tests/test_skills.py -q
uv run pytest
uv run pre-commit run --all-files
```

Results:

```text
tests/test_protein_mutation_enhancement_skill.py: 6 passed
tests/test_skills.py: 21 passed
combined focused tests: 27 passed
full offline suite: 1456 passed, 5 skipped, 1 deselected
pre-commit: passed
```

Not run:

```text
Live GPU ESM / ESMFold inference
Live LLM, network, SSH, Docker, or lab-hardware tests
```

Reason:

```text
This PR adds the deterministic stdlib workflow layer. Heavy model execution remains delegated to existing GPU/model skills and is intentionally outside the default offline test suite.
```

## Risk and Reviewer Focus

Risk is limited to skill discovery and the new workflow sidecar. No core engine, kernel protocol, host RPC, gateway, store, or web UI files are modified.

Please review:

- `skills/protein-mutation-enhancement/SKILL.md`
  - whether the workflow contract matches the intended protein mutation design loop;
  - whether the docs avoid overclaiming biological validation.
- `skills/protein-mutation-enhancement/kernel.py`
  - mutation parsing and 1-indexed position validation;
  - deterministic library enumeration and seeded expansion;
  - score normalization, weighting, thresholding, and next-round seed selection.
- `tests/test_protein_mutation_enhancement_skill.py`
  - offline coverage for enumeration, ranking, loop continuation, and next-position suggestion.
- `docs/skills.md`
  - bundled skill count and workflow catalog entry.

## Checklist

### Diff Readiness

- [x] I reviewed and understand the full diff.
- [x] This PR is small and single-purpose.
- [x] No unrelated formatting, broad rewrite, or drive-by refactor is included.
- [x] Hotspot files were edited surgically if touched: `gateway.py`,
      `host_dispatch.py`, `store.py`, `app.js`, `worker.py`, `manager.py`.
- [x] `openai4s/server/webui/vendor/` and `tests/fixtures/` were not
      reformatted.

### Tests

- [x] Relevant tests or manual checks were run and listed above.
- [x] No new test requires live LLM, network, GPU, SSH, Docker, lab hardware,
      or secrets in the default offline suite.
- [x] No tests were deleted without tracked replacements.
- [x] Kernel / host-RPC / gateway changes include focused contract coverage or
      a documented smoke test.

### Core Dependency Policy

- [x] No hard third-party import was added to the core engine, LLM client, or
      stdlib web server.
- [x] Optional science imports are guarded by `try/except ImportError` at every
      in-tree use site.
- [x] New dependencies, if any, are documented and justified.

### Public Disclosure and Security

- [x] No secrets, API keys, tokens, real credentials, private data, model
      weights, or local absolute paths are included.
- [x] No unpublished research roadmap, internal assignment, benchmark detail,
      or unreleased experimental result is disclosed.
- [x] Security-sensitive changes include appropriate synthetic tests or manual
      verification notes.
- [x] Docs do not overstate isolation, sandboxing, privacy, or security
      guarantees.

### Docs

- [x] Docs match actual code behavior.
- [x] User-facing behavior changes are reflected in docs or release notes where
      appropriate.
- [x] `README.md` and `README_zh.md` stay in sync where translated sections are
      affected.