### PR TITLE
fix(skills): re-enumerable protein-mutation loop seeds + clearer parsing errors

### DIFF
--- a/skills/protein-mutation-enhancement/kernel.py
+++ b/skills/protein-mutation-enhancement/kernel.py
@@ -139,8 +139,11 @@ def normalize_mutations(
 ) -> list[dict]:
     """Normalize mutation strings, dicts, or tuples into sorted mutation dicts.
 
-    Accepted forms include `"A12V+G47D"`, `{"from":"A","position":12,"to":"V"}`,
-    `(12, "V")` when `sequence` is available, and `("A", 12, "V")`.
+    Accepted forms: the string `"A12V+G47D"`; a single mapping
+    `{"from":"A","position":12,"to":"V"}`; or a list whose items are each a
+    string, mapping, or tuple such as `("A", 12, "V")` / `(12, "V")` (the
+    2-tuple requires `sequence`). A bare top-level tuple is iterated as a
+    sequence of items, so wrap a single tuple in a list, e.g. `[("A", 12, "V")]`.
     """
     if mutations is None:
         return []
@@ -312,11 +315,11 @@ def rank_mutants(
     acceptance_thresholds: Mapping[str, float] | None = None,
 ) -> list[dict]:
     """Merge score tables, normalize metrics, and rank candidates."""
+    if weights is not None and not weights:
+        raise ValueError("weights must not be empty")
     weights = dict(weights or {"esm_delta": 0.5, "plddt": 0.3, "property_score": 0.2})
     directions = {k: v.lower() for k, v in (directions or {}).items()}
     thresholds = dict(acceptance_thresholds or {})
-    if not weights:
-        raise ValueError("weights must not be empty")
     if any(v < 0 for v in weights.values()):
         raise ValueError("weights must be non-negative; use directions for low metrics")
     total_weight = sum(weights.values())
@@ -381,7 +384,9 @@ def run_selection_round(
         "ranked": ranked,
         "accepted": accepted,
         "should_continue": not bool(accepted),
-        "next_round_seeds": ranked[:top_k] if not accepted else [],
+        "next_round_seeds": (
+            [row["id"] for row in ranked[:top_k]] if not accepted else []
+        ),
     }
 
 
@@ -415,11 +420,14 @@ def _coerce_mutation(item, sequence: str | None) -> dict:
     if isinstance(item, str):
         return parse_mutation(item, sequence)
     if isinstance(item, Mapping):
-        pos = int(item.get("position", item.get("pos")))
+        pos_raw = item.get("position", item.get("pos"))
+        if pos_raw is None:
+            raise ValueError(f"mutation mapping is missing a position: {item!r}")
+        pos = int(pos_raw)
         wt = str(item.get("from", item.get("wt", ""))).upper()
         aa = str(item.get("to", item.get("mutant", item.get("aa", "")))).upper()
         if not wt and sequence is not None:
-            wt = validate_sequence(sequence)[pos - 1]
+            wt = _residue_at(sequence, pos)
         if not wt or not aa:
             raise ValueError(f"mutation mapping is missing from/to: {item!r}")
         return parse_mutation(f"{wt}{pos}{aa}", sequence)
@@ -428,7 +436,7 @@ def _coerce_mutation(item, sequence: str | None) -> dict:
             if sequence is None:
                 raise ValueError("(position, to) mutations require sequence")
             pos = int(item[0])
-            wt = validate_sequence(sequence)[pos - 1]
+            wt = _residue_at(sequence, pos)
             return parse_mutation(f"{wt}{pos}{str(item[1]).upper()}", sequence)
         if len(item) == 3:
             wt, pos, aa = item
@@ -585,3 +593,11 @@ def _is_number(value) -> bool:
 
 def _clamp(value: float, lo: float = 0.0, hi: float = 1.0) -> float:
     return max(lo, min(hi, float(value)))
+
+
+def _residue_at(sequence: str, pos: int) -> str:
+    """Return the 1-indexed wild-type residue, raising on out-of-range positions."""
+    seq = validate_sequence(sequence)
+    if pos < 1 or pos > len(seq):
+        raise ValueError(f"mutation position {pos} exceeds sequence length")
+    return seq[pos - 1]

--- a/tests/test_protein_mutation_enhancement_skill.py
+++ b/tests/test_protein_mutation_enhancement_skill.py
@@ -119,3 +119,51 @@ def test_suggest_next_positions_uses_rank_order(pm):
     ]
 
     assert pm.suggest_next_positions(ranked, max_positions=2) == [2, 1]
+
+
+def test_selection_round_seeds_feed_back_into_enumerate(pm):
+    # Regression: the documented Loop Pattern feeds next_round_seeds straight
+    # back into enumerate_mutants. This previously raised TypeError because the
+    # seeds were ranked dicts without a top-level position.
+    seq = "ACDEFGHIKL"
+    library = pm.enumerate_mutants(seq, positions=[2, 5], max_order=1)
+    scores = {item["id"]: {"esm_delta": 0.0, "plddt": 50.0} for item in library}
+    result = pm.run_selection_round(
+        candidates=library,
+        score_tables=[scores],
+        acceptance_thresholds={"esm_delta": 5.0},
+    )
+    seeds = result["next_round_seeds"]
+    assert seeds
+    assert all(isinstance(s, str) for s in seeds)
+    next_library = pm.enumerate_mutants(
+        seq, positions=[2, 5, 7], max_order=2, seeds=seeds
+    )
+    assert next_library
+    next_ids = {item["id"] for item in next_library}
+    assert set(seeds) <= next_ids
+
+
+def test_rank_mutants_rejects_explicit_empty_weights(pm):
+    candidates = [
+        {
+            "id": "A1V",
+            "sequence": "VCDEF",
+            "mutations": [{"from": "A", "position": 1, "to": "V"}],
+            "order": 1,
+        }
+    ]
+    scores = {"A1V": {"esm_delta": 1.0}}
+    with pytest.raises(ValueError, match="weights must not be empty"):
+        pm.rank_mutants(candidates, score_tables=[scores], weights={})
+
+
+def test_out_of_range_tuple_mutation_raises_clear_error(pm):
+    with pytest.raises(ValueError, match="exceeds sequence length"):
+        pm.normalize_mutations([(99, "V")], "ACDEF")
+
+
+def test_variant_dict_without_position_raises_clear_error(pm):
+    variant = {"id": "A1V", "mutations": [{"from": "A", "position": 1, "to": "V"}]}
+    with pytest.raises(ValueError, match="missing a position"):
+        pm.normalize_mutations(variant)


### PR DESCRIPTION
## Summary

Delivers to `main` the fix that PR #21 was intended to carry but did not: PR #21 merged the original `protein-mutation-enhancement` code **without** this fix, leaving a blocking bug in `main`.

### Fixes
- **[blocking]** `run_selection_round` returned `next_round_seeds` as ranked variant dicts (no top-level `position`); feeding them back into `enumerate_mutants` — exactly as the SKILL Loop Pattern documents — raised `TypeError` on round 2. Now returns canonical variant IDs.
- `_coerce_mutation`: validate 1-indexed positions via a new `_residue_at` helper; raise a clear `ValueError` (instead of `IndexError` / `int(None)` `TypeError`) for out-of-range or position-less inputs.
- `rank_mutants`: move the empty-weights guard ahead of the default substitution so an explicit `weights={}` is actually rejected (was dead code).

### Tests
Adds 4 fixture-based regression tests (loop re-enumeration, empty-weights rejection, out-of-range tuple, position-less variant dict). Targeted suite passes; pre-commit (black/isort/ruff) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)