### PR TITLE
docs: macOS DMG startup guide + README refresh (unblocks stale PyPI-publish governance tests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ host.save_artifact(plot(frames))             # ...only "<DataFrame 100000×20>" 
 
 ## 📣 News
 
+- **`2026-07-15`** 🍎 **`v0.1.0` — macOS app** — a one-click, no-toolchain Apple Silicon `.dmg` with an embedded Python and the full default kernel science stack (rdkit · scanpy · the single-cell stack), plus PyPI packaging (`pip install openai4s`) and release automation. **New here? → [Startup guide](docs/startup-guide.md).**
 - **`2026-07-06`** 🎉 **Open-sourced** — the pure-stdlib Code-as-Action engine, the scientific web app, 24 science Skills, and BYOC remote compute.
 
 ---
@@ -134,6 +135,13 @@ Apple Silicon users can skip the checkout entirely: download `OpenAI4S-<version>
 
 The build is ad-hoc signed but **not notarized**, so Gatekeeper refuses it the first time. On **macOS 15+**, open it once, then allow it under System Settings → Privacy & Security → **Open Anyway**; on **macOS 12–14**, right-click the app → **Open** → **Open**. Either way, `xattr -dr com.apple.quarantine /Applications/OpenAI4S.app` also clears it.
 
+**First run — point it at a model, then at search.** Launching the app opens the workbench at `http://127.0.0.1:8760/`. No key ships, so:
+
+1. **Model API** — open **Settings ⚙ → Models**, pick a protocol (**Ark-compatible** for Doubao/GLM/Kimi/DeepSeek/MiniMax, or **OpenAI-** / **Anthropic-compatible**), paste your **API Key**, click **Add**, then **Set active**. Cheapest path: the `ark` protocol on Volcengine Ark's ¥9.9/mo plan.
+2. **Search API** *(optional, recommended)* — open **Settings ⚙ → Network**, keep **Allow network access** on, register at **[tavily.com](https://tavily.com)**, and paste the key into **Search API key (Tavily)** → **Save**. Without a key, web search still falls back to keyless scrapers.
+
+Full walkthrough (install → Gatekeeper → model → search → R kernel): **[Startup guide](docs/startup-guide.md)**.
+
 The CLI ships inside the app — symlink it if you want it on your PATH:
 
 ```bash
@@ -151,6 +159,7 @@ The canonical bilingual documentation is published at **[openai4s.org/docs](http
 
 | doc | what's inside |
 |---|---|
+| [**Startup guide**](docs/startup-guide.md) | macOS `.dmg` walkthrough: install, Gatekeeper, and configuring the model + Tavily search keys |
 | [**Architecture**](docs/architecture.md) | the hybrid action router, Action Ledger, `host` RPC, and lazy kernels |
 | [**Backend extension guide**](docs/backend-extension-guide.md) | where new Tool classes, host services, repositories, and session behaviour belong |
 | [**Skills**](docs/skills.md) | the 32 bundled Skills + how to write your own |

--- a/README_zh.md
+++ b/README_zh.md
@@ -71,6 +71,7 @@ host.save_artifact(plot(frames))             # ……上下文里只留 "<DataFr
 
 ## 📣 更新
 
+- **`2026-07-15`** 🍎 **`v0.1.0` —— macOS 应用** —— 一键、免工具链的 Apple Silicon `.dmg`，内嵌 Python 与完整默认内核科学栈（rdkit · scanpy · 单细胞栈），并支持 PyPI 安装（`pip install openai4s`）与自动化发布。**第一次用？→ [上手指南](docs/startup-guide.md)。**
 - **`2026-07-06`** 🎉 **代码开源** —— 纯标准库 Code-as-Action 引擎、科研 Web 应用、24 个科学 Skill、BYOC 远程计算。
 
 ---
@@ -123,6 +124,13 @@ Apple Silicon 用户可以完全跳过 clone：从 [最新 Release](https://gith
 
 该构建仅做 ad-hoc 签名、**未做公证（notarization）**，所以首次打开会被 Gatekeeper 拦下。**macOS 15+**：先双击一次，关掉提示，再到「系统设置 → 隐私与安全性」点 **仍要打开**；**macOS 12–14**：右键点应用 → **打开** → **打开**。两个版本都可以直接用 `xattr -dr com.apple.quarantine /Applications/OpenAI4S.app` 解除。
 
+**首次运行 —— 先配模型，再配搜索。** 启动应用后会打开工作台 `http://127.0.0.1:8760/`。启动不带任何 Key，因此：
+
+1. **模型 API** —— 打开 **设置 ⚙ → 模型**，选协议（**ark 兼容协议** 对应豆包/GLM/Kimi/DeepSeek/MiniMax，或 **OpenAI** / **Anthropic 兼容协议**），粘贴 **API Key**，点 **新增**，再点 **设为当前**。最省钱：用火山方舟 ¥9.9/月 套餐的 `ark` 协议。
+2. **搜索 API** *（可选、推荐）* —— 打开 **设置 ⚙ → 网络**，保持 **允许联网** 打开，到 **[tavily.com](https://tavily.com)** 注册，把 Key 粘进 **搜索 API Key（Tavily）** → **保存**。不填 Key，联网搜索仍会退回免密钥抓取。
+
+完整流程（安装 → Gatekeeper → 模型 → 搜索 → R 内核）见：**[上手指南](docs/startup-guide.md)**。
+
 命令行随应用一起打包，想挂到 PATH 上就建个软链：
 
 ```bash
@@ -140,6 +148,7 @@ R 内核未被打包（它需要一个 conda 环境）。Intel Mac 与 Linux 请
 
 | 文档 | 内容 |
 |---|---|
+| [**上手指南**](docs/startup-guide.md) | macOS `.dmg` 全流程：安装、Gatekeeper，以及配置模型 + Tavily 搜索 Key |
 | [**架构**](docs/architecture.md) | 混合动作路由、Action Ledger、`host` RPC 与惰性内核 |
 | [**后端扩展指南**](docs/backend-extension-guide.md) | 新 Tool、Host service、repository 与 session 行为应归属的位置 |
 | [**Skills**](docs/skills.md) | 32 个内置 Skill + 如何自撰 |
@@ -249,5 +258,5 @@ uv run pre-commit run --all-files   # 全量格式化 + lint
 ---
 
 <div align="center">
-<sub><b>OpenAI4S</b> · 代码即行动,内核即环境。 · <a href="README.md">English</a></sub>
+<sub><b>OpenAI4S</b> · 代码即行动,内核即环境。 · <a href="README.md">English</a> · 友情链接 https://linux.do </sub>
 </div>

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ and the internal plans in this directory are not published by that site.
 | `release-validation.md` | The gates a release passes: offline CI, package artifacts, import smoke, and the external gates that deliberately stay outside CI. |
 | `security.md` | Threat model, trust boundaries, enforcement layers, and known coverage gaps. |
 | `skills.md` | Bundled/user Skill format, loading, sidecars, and lifecycle. |
+| `startup-guide.md` | Bilingual macOS `.dmg` walkthrough: install, Gatekeeper, and configuring the model + Tavily search keys in the UI. |
 | `webapp-api.md` | Detailed REST/WebSocket surface and compatibility behavior. |
 | `webapp.md` | Web workbench concepts, projections, status, and operator-facing behavior. |
 

--- a/docs/README_zh.md
+++ b/docs/README_zh.md
@@ -23,6 +23,7 @@
 | `release-validation.md` | 发布要过的几道关卡：离线 CI、发布包检查、import 冒烟，以及有意留在 CI 之外的外部关卡。 |
 | `security.md` | 威胁模型、信任边界、各层防护与已知的覆盖缺口。 |
 | `skills.md` | 内置与用户 Skill 的格式、加载方式、sidecar 与生命周期。 |
+| `startup-guide.md` | 双语 macOS `.dmg` 上手全流程：安装、Gatekeeper，以及在 UI 里配置模型 + Tavily 搜索 Key。 |
 | `webapp-api.md` | REST/WebSocket 功能面的详细契约与兼容行为。 |
 | `webapp.md` | Web workbench 的概念、投影、状态与面向运维的行为。 |
 

--- a/docs/startup-guide.md
+++ b/docs/startup-guide.md
@@ -1,0 +1,246 @@
+<a id="en"></a>
+
+# Startup guide — macOS app (`.dmg`)
+
+**English** · [简体中文](#zh)
+
+This walks a brand-new macOS user from the downloaded disk image to a first
+answer: install the app, get past Gatekeeper, point it at a model, and (so the
+agent can read the live literature and databases) point it at web search. No
+command line and no Python toolchain are required for any of it.
+
+> The `.dmg` is **Apple Silicon only**. On an Intel Mac or on Linux, install
+> from PyPI instead — `pip install openai4s` — then run `openai4s serve`. The
+> in-app steps below (model + search configuration) are identical once the
+> workbench is open.
+
+---
+
+## 1. Install — drag to Applications
+
+1. Download `OpenAI4S-<version>-macos-arm64.dmg` from the
+   [latest release](https://github.com/PKU-YuanGroup/OpenAI4S/releases/latest).
+2. Double-click the `.dmg` to mount it.
+3. **Drag `OpenAI4S` onto the `Applications` folder** in the same window.
+4. Eject the disk image and launch **OpenAI4S** from Applications (or Spotlight).
+
+The image already embeds its own Python plus the default kernel science stack —
+numpy · pandas · scipy · matplotlib · seaborn · plotly · **rdkit**
+(cheminformatics) · **scanpy** and the single-cell stack (anndata · leidenalg ·
+igraph) · umap · numba · scikit-learn · statsmodels · biopython · h5py · zarr ·
+pyarrow — so the first launch needs **no network and no `pip`**. All data
+(SQLite database, artifacts, logs) lives under `~/.openai4s`.
+
+## 2. First launch — get past Gatekeeper
+
+The build is **ad-hoc signed but not notarized** (notarization needs a paid
+Apple Developer identity), so Gatekeeper refuses it the *first* time only. Pick
+the path for your macOS version:
+
+| macOS version | How to open the first time |
+|---|---|
+| **15 Sequoia and newer** | Double-click the app, dismiss the warning, then open **System Settings → Privacy & Security** and click **Open Anyway**. |
+| **12–14 (Monterey–Sonoma)** | **Right-click** (or Control-click) `OpenAI4S.app` → **Open** → **Open**. |
+| **Any version, from Terminal** | `xattr -dr com.apple.quarantine /Applications/OpenAI4S.app`, then open normally. |
+
+Once it opens, the app starts a local daemon and opens the workbench in your
+browser at **`http://127.0.0.1:8760/`**. Everything below happens in that UI.
+
+## 3. Configure your model API
+
+The app boots **without any API key** — a *"configure your API key"* banner
+links straight to the right screen.
+
+1. Click the **Settings** gear (top of the window) and open the **Models** tab
+   (中文 UI: **设置 → 模型**).
+2. Under **Add model / API**, fill in:
+   - **Name** — any label you like (e.g. `Doubao`, `My Claude`).
+   - **Protocol** — one of **Ark-compatible**, **OpenAI-compatible**, or
+     **Anthropic-compatible** (see the table below).
+   - **Base URL** — leave blank to use the protocol's default endpoint.
+   - **Model id** — leave blank to use the protocol's default model.
+   - **API Key** — paste your provider key.
+3. Click **Add**, then click **Set active** on the new profile.
+
+That's it — the workbench now runs on your model.
+
+**Which protocol / key?**
+
+| Protocol in the UI | Provider it talks to | Where to get the key |
+|---|---|---|
+| **Ark-compatible** | Volcengine Ark (火山方舟) — one key serves **Doubao · GLM · Kimi · DeepSeek · MiniMax** | [console.volcengine.com/ark](https://console.volcengine.com/ark) — the entry **"Small" agent plan is ¥9.9 / month (≈ US$1.4)** |
+| **OpenAI-compatible** | OpenAI (`gpt-5`) or any OpenAI-compatible endpoint | your OpenAI / vendor dashboard |
+| **Anthropic-compatible** | Anthropic Claude (`claude-sonnet-4-5`) | [console.anthropic.com](https://console.anthropic.com) |
+
+> **Cheapest path:** pick **Ark-compatible** and paste a Volcengine Ark key —
+> you get a Claude-Science-class agent for the price of the ¥9.9/month plan.
+
+## 4. Configure the web-search API (Tavily)
+
+Web search lets the agent pull live literature, database records, and data
+packages instead of relying only on its training knowledge. The key lives in a
+**different tab from the model key**:
+
+1. Open **Settings → Network** (中文 UI: **设置 → 网络**).
+2. Make sure **Allow network access** is toggled **on** — this master switch
+   gates the agent's `web_search` / `web_fetch` / download tools.
+3. Register a free account at **[tavily.com](https://tavily.com)** and copy your
+   API key from its dashboard.
+4. Paste it into the **Search API key (Tavily)** field
+   (中文: **搜索 API Key（Tavily）**) and click **Save**.
+
+The endpoint is fixed to `api.tavily.com`; the key is stored locally under
+`~/.openai4s` and is never displayed back. **Without a Tavily key, web search
+still works** via keyless scrapers (DuckDuckGo and friends), but Tavily is more
+reliable and rate-limit-resistant, so it is recommended.
+
+## 5. (Optional) Add the R kernel
+
+The `.dmg` bundles **Python only** — the R kernel needs a Conda environment
+that is too large to ship inside an image, so the R channel reports itself
+unavailable rather than silently falling back to Python. To add it, expose the
+bundled CLI and run the setup command:
+
+```bash
+sudo ln -sf /Applications/OpenAI4S.app/Contents/Resources/runtime/bin/openai4s /usr/local/bin/openai4s
+openai4s setup        # needs a Conda-family manager: micromamba / mamba / conda
+```
+
+The same CLI also gives you `openai4s status`, `openai4s stop`, and
+`openai4s url` outside the app.
+
+## 6. You're set
+
+Open a new chat and ask a real question — for example *"Fetch human insulin
+(UniProt P01308), summarize its chains, and plot residue hydrophobicity."* The
+bundled stack runs cheminformatics, single-cell, and dataframe workflows
+offline; with your Tavily key configured, the agent can also reach UniProt,
+RCSB PDB, NCBI, and the wider web.
+
+**Troubleshooting**
+
+- **Nothing opened in the browser** — visit `http://127.0.0.1:8760/` manually.
+- **Logs** — `~/.openai4s/logs/app.out`.
+- **Port already in use** — another instance may be running; quit it, or use the
+  CLI `openai4s stop`.
+- **Model calls fail** — re-check the active profile under **Settings → Models**
+  and confirm the key and (if you set one) the Base URL.
+
+---
+---
+
+<a id="zh"></a>
+
+# 上手指南 — macOS 应用（`.dmg`）
+
+[English](#en) · **简体中文**
+
+本指南带一位全新的 macOS 用户从下载的磁盘镜像走到第一个结果：装好应用、通过
+Gatekeeper、配好模型，再配好联网搜索（让智能体能读实时文献与数据库）。整个过程
+**不需要命令行、也不需要任何 Python 工具链**。
+
+> `.dmg` **仅支持 Apple Silicon**。Intel Mac 或 Linux 请改用 PyPI 安装——
+> `pip install openai4s`，然后 `openai4s serve`。工作台打开之后，下面的应用内步骤
+> （配模型 + 配搜索）完全一致。
+
+---
+
+## 1. 安装 —— 拖进「应用程序」
+
+1. 从 [最新 Release](https://github.com/PKU-YuanGroup/OpenAI4S/releases/latest)
+   下载 `OpenAI4S-<version>-macos-arm64.dmg`。
+2. 双击 `.dmg` 挂载。
+3. 在弹出的窗口里，**把 `OpenAI4S` 拖到 `Applications`（应用程序）文件夹**。
+4. 推出磁盘镜像，从「应用程序」（或聚焦搜索 Spotlight）启动 **OpenAI4S**。
+
+镜像已内嵌自带的 Python 以及默认内核科学栈——numpy · pandas · scipy · matplotlib ·
+seaborn · plotly · **rdkit**（化学信息学）· **scanpy** 及单细胞栈（anndata ·
+leidenalg · igraph）· umap · numba · scikit-learn · statsmodels · biopython ·
+h5py · zarr · pyarrow——所以首次启动**不联网、不 `pip`**。所有数据（SQLite 数据库、
+Artifact、日志）都写在 `~/.openai4s`。
+
+## 2. 首次启动 —— 通过 Gatekeeper
+
+该构建**仅做 ad-hoc 签名、未做公证（notarization）**（公证需要付费的 Apple 开发者
+身份），所以**只有第一次**打开会被 Gatekeeper 拦下。按你的 macOS 版本选一种方式：
+
+| macOS 版本 | 首次打开方式 |
+|---|---|
+| **15 Sequoia 及更新** | 先双击应用、关掉提示，再到「**系统设置 → 隐私与安全性**」点 **仍要打开**。 |
+| **12–14（Monterey–Sonoma）** | **右键**（或按住 Control 点按）`OpenAI4S.app` → **打开** → **打开**。 |
+| **任意版本，用终端** | `xattr -dr com.apple.quarantine /Applications/OpenAI4S.app`，之后正常打开。 |
+
+打开后，应用会启动本地守护进程，并在浏览器里打开工作台
+**`http://127.0.0.1:8760/`**。下面的操作都在这个界面里完成。
+
+## 3. 配置模型 API
+
+应用启动时**不带任何 API Key**——界面上会有一条 *「configure your API key」*
+横幅，直接跳到对应页面。
+
+1. 点右上角的 **设置**（齿轮）图标，打开 **模型** 标签页（Settings → Models）。
+2. 在 **新增模型 / API** 里填：
+   - **名称** —— 任意标签（如 `豆包`、`我的 Claude`）。
+   - **协议** —— 选 **ark 兼容协议**、**OpenAI 兼容协议** 或 **Anthropic 兼容协议**
+     （见下表）。
+   - **Base URL** —— 留空则用该协议默认接入点。
+   - **模型 id** —— 留空则用该协议默认模型。
+   - **API Key** —— 粘贴你的供应商密钥。
+3. 点 **新增**，再在新出现的配置行上点 **设为当前**。
+
+完成——工作台现在就跑在你的模型上了。
+
+**该选哪个协议 / 哪个 Key？**
+
+| UI 里的协议 | 对接的供应商 | 在哪里拿 Key |
+|---|---|---|
+| **ark 兼容协议** | 火山方舟 Volcengine Ark —— 一个 Key 覆盖 **豆包 · GLM · Kimi · DeepSeek · MiniMax** | [console.volcengine.com/ark](https://console.volcengine.com/ark) —— 入门 **「Small」Agent 套餐仅 ¥9.9 / 月** |
+| **OpenAI 兼容协议** | OpenAI（`gpt-5`）或任何 OpenAI 兼容接入点 | 你的 OpenAI / 厂商控制台 |
+| **Anthropic 兼容协议** | Anthropic Claude（`claude-sonnet-4-5`） | [console.anthropic.com](https://console.anthropic.com) |
+
+> **最省钱路线：** 选 **ark 兼容协议** 并粘贴一个火山方舟 Key——用 ¥9.9/月 套餐的价钱，
+> 就能得到一个 Claude Science 级的智能体。
+
+## 4. 配置联网搜索 API（Tavily）
+
+联网搜索让智能体能拉取实时文献、数据库记录和数据包，而不只依赖训练知识。这个 Key
+**和模型 Key 不在同一个标签页**：
+
+1. 打开 **设置 → 网络**（Settings → Network）。
+2. 确认 **允许联网** 开关处于**打开**状态——这个总开关控制智能体的
+   `web_search` / `web_fetch` / 下载工具。
+3. 到 **[tavily.com](https://tavily.com)** 免费注册账号，从控制台复制你的 API Key。
+4. 粘贴到 **搜索 API Key（Tavily）** 输入框（占位提示「输入 Tavily API Key」），点
+   **保存**。
+
+接入点固定为 `api.tavily.com`；Key 保存在本地 `~/.openai4s`，不会回显。**不填 Tavily
+Key，联网搜索仍可用**（走 DuckDuckGo 等免密钥抓取），但 Tavily 更稳定、更抗限流，
+推荐配置。
+
+## 5.（可选）加装 R 内核
+
+`.dmg` 只打包了 **Python**——R 内核需要一个 Conda 环境，体量太大无法塞进镜像，所以
+R 通道会直接报告「解释器不可用」，而不会悄悄退回 Python。要加装它，先把内置 CLI 暴露
+出来，再跑 setup：
+
+```bash
+sudo ln -sf /Applications/OpenAI4S.app/Contents/Resources/runtime/bin/openai4s /usr/local/bin/openai4s
+openai4s setup        # 需要一个 Conda 家族管理器：micromamba / mamba / conda
+```
+
+这个 CLI 同时提供 `openai4s status`、`openai4s stop`、`openai4s url`，可在应用之外使用。
+
+## 6. 大功告成
+
+开一个新对话，问个真实问题——比如 *「拉取人胰岛素（UniProt P01308），概括它的各条链，
+并画出残基疏水性。」* 内置科学栈可离线跑化学信息学、单细胞和 DataFrame 工作流；配好
+Tavily Key 之后，智能体还能访问 UniProt、RCSB PDB、NCBI 以及更广的互联网。
+
+**排障**
+
+- **浏览器没自动打开** —— 手动访问 `http://127.0.0.1:8760/`。
+- **日志** —— `~/.openai4s/logs/app.out`。
+- **端口被占用** —— 可能已有一个实例在跑；退出它，或用 CLI `openai4s stop`。
+- **模型调用失败** —— 到 **设置 → 模型** 复查当前激活的配置，确认 Key 以及（若填过）
+  Base URL 是否正确。
+</content>

--- a/tests/test_governance.py
+++ b/tests/test_governance.py
@@ -53,9 +53,18 @@ def test_release_workflow_pins_every_action_to_a_commit():
     uses = [line for line in workflow.splitlines() if line.lstrip().startswith("uses:")]
 
     assert uses
-    # No moving refs: the OIDC-privileged PyPI publish step must be SHA-pinned
-    # like every other action so a mutable upstream branch cannot inject code.
-    moving = [line for line in uses if not PINNED_ACTION.fullmatch(line)]
+    # Every action is SHA-pinned so a mutable upstream branch cannot inject code.
+    # The one documented exception is pypa/gh-action-pypi-publish: it is a
+    # Docker-container action whose image PyPA publishes tagged by RELEASE ref
+    # only (never by commit SHA), so a SHA pin fails the image pull with
+    # `manifest unknown` before the OIDC exchange starts. It must stay on PyPA's
+    # documented `release/v1` image-backed ref — and nothing else may move.
+    moving = [
+        line
+        for line in uses
+        if not PINNED_ACTION.fullmatch(line)
+        and line.strip() != "uses: pypa/gh-action-pypi-publish@release/v1"
+    ]
     assert moving == []
 
 

--- a/tests/test_release_gates.py
+++ b/tests/test_release_gates.py
@@ -202,7 +202,10 @@ def test_publish_workflow_uses_verified_artifact_and_job_scoped_oidc():
         "environment:",
         "name: pypi",
         "id-token: write",
-        "pypa/gh-action-pypi-publish@7f25271a4aa483500f742f9492b2ab5648d61011",
+        # A Docker-container action PyPA only publishes tagged by release ref,
+        # so this one is intentionally on `release/v1` rather than a SHA pin
+        # (see the justification comment in release.yml and test_governance.py).
+        "pypa/gh-action-pypi-publish@release/v1",
     ):
         assert contract in workflow
 


### PR DESCRIPTION
## Summary

Adds a **bilingual (EN/ZH) startup guide** for the v0.1.0 macOS `.dmg` release and refreshes the READMEs so a first-time DMG user has a clear path from download to first result. It also **unblocks a pre-existing CI failure on `main`** (details below) so this branch — and every other branch — can go green.

### Docs (the main change)

- **New: `docs/startup-guide.md`** — a 6-step walkthrough in English and 简体中文:
  1. Install — drag `OpenAI4S` to Applications
  2. First launch — clear Gatekeeper (macOS 15+ / 12–14 / `xattr` paths)
  3. Configure the **model API** — Settings → Models → pick protocol → paste key → Set active (with a provider/key table incl. Volcengine Ark ¥9.9/mo)
  4. Configure the **web-search API** — Settings → Network → register at [tavily.com](https://tavily.com) → paste Tavily key
  5. (Optional) add the R kernel via the bundled CLI + `openai4s setup`
  6. First question + troubleshooting

  UI labels were verified directly against `openai4s/server/webui/app.js` so the Chinese wording matches the actual interface. Cross-language switching uses explicit `<a id>` anchors.

- **`README.md` / `README_zh.md`** — new `2026-07-15` News entry for the v0.1.0 macOS app; a compact "First run" block (model + Tavily search) plus a pointer to the full guide; a "Startup guide" row in the Documentation table; `README_zh` footer now carries the friend link (EN/ZH parity).
- **`docs/README.md` / `docs/README_zh.md`** — index the new guide.

A README currency audit against the codebase confirmed the rest is already accurate (32 bundled Skills, provider list, roadmap), so no other content was churned.

### Also in this PR — fix a stale governance gate

`main` has been red for every branch since #34: that PR intentionally switched the PyPI publish step to `pypa/gh-action-pypi-publish@release/v1` (a Docker-container action whose image PyPA only publishes tagged by *release* ref — a commit-SHA pin fails the image pull with `manifest unknown` before the OIDC exchange runs), but two governance tests still asserted the old SHA pin. They failed independently of this PR's docs (verified: the same two tests fail on `origin/main`). Bundled here to unblock merge:

- **`tests/test_governance.py`** — still requires every action to be SHA-pinned, but allows the single, exactly-specified `pypa/gh-action-pypi-publish@release/v1` line. Any other moving ref (including a different ref of the same action) still fails, so the security property is preserved.
- **`tests/test_release_gates.py`** — asserts the publish step is on `release/v1` instead of the removed commit SHA.

No workflow/production code changed; only the two test assertions were realigned with the already-merged, documented workflow decision. **Full offline suite passes locally** (1592+ passed).

## Area

- [x] Docs
- [x] Tests / harness / CI

## Change Type

- [x] Documentation
- [x] Test / harness
- [x] Security-related change

## Testing

`uv run pytest` — full offline suite green locally; `tests/test_governance.py` + `tests/test_release_gates.py` pass. Docs are inspection-verified: intra-doc anchors, cross-file links, EN/ZH parity, and pre-commit hooks (end-of-files, trailing-whitespace, black, isort, ruff, mypy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)