### PR TITLE
fix: improve Conda environment discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,13 @@
 __pycache__/
 *.pyc
 .pytest_cache/
+.ruff_cache/
+.mypy_cache/
 *.db
 .env
 .env.*
 .env.bak.*
+.venv
 !.env.example
 *.egg-info/
 node_modules/

--- a/openai4s/kernel/environments.py
+++ b/openai4s/kernel/environments.py
@@ -188,21 +188,36 @@ def _hidden_names() -> set[str]:
     return _ALWAYS_HIDE | {n.strip() for n in extra.split(",") if n.strip()}
 
 
-def _envs_root_from_prefix(prefix: str | os.PathLike[str]) -> Path:
-    """Return the standard sibling-environment directory for a Conda prefix.
+def _envs_roots_from_prefix(prefix: str | os.PathLike[str]) -> list[Path]:
+    """Candidate sibling-environment directories for a Conda prefix.
 
-    Conda exposes either its base prefix (``<base>``) or an activated named
-    environment (normally ``<base>/envs/<name>``).  The former stores named
-    environments under ``<base>/envs``; the latter already has that directory
-    as its parent.  Treating ``<base>.parent`` as an env root scans unrelated
-    directories and incorrectly offers the base installation itself as a
+    Conda exposes either a base/root prefix (``<base>``, which stores named
+    environments under ``<base>/envs``) or an activated environment.  An
+    activated environment is *not* always ``<base>/envs/<name>``: ``envs_dirs``
+    can point anywhere (``/data/myenvs/proj``) and ``conda create -p`` puts a
+    prefix at an arbitrary path.  So the parent is classified *structurally*
+    rather than by directory name — a named environment carries ``conda-meta``
+    and neither of the two markers only a root prefix has: ``envs`` (its named
+    environments) and ``pkgs`` (the shared package cache).  ``pkgs`` matters
+    because ``envs`` alone is not enough: a base installation on which no
+    environment has been created yet has no ``envs`` directory, and mistaking
+    it for a named environment would put ``$HOME`` on the scan list.
+
+    Returns every plausible root; callers de-duplicate and drop the ones that
+    do not exist.  Blindly treating ``<base>.parent`` as an env root would
+    scan unrelated directories and offer the base installation itself as a
     named environment.
     """
 
     path = Path(prefix).expanduser()
-    if path.parent.name == "envs":
-        return path.parent
-    return path / "envs"
+    roots = [path / "envs"]
+    is_root_prefix = (path / "envs").is_dir() or (path / "pkgs").is_dir()
+    looks_named = path.parent.name == "envs" or (
+        (path / "conda-meta").is_dir() and not is_root_prefix
+    )
+    if looks_named:
+        roots.append(path.parent)
+    return roots
 
 
 def _env_roots() -> list[Path]:
@@ -226,11 +241,15 @@ def _env_roots() -> list[Path]:
             add(Path(chunk.strip()))
 
     # Respect Conda's configured environment directories before inferred
-    # locations.  CONDA_ENVS_PATH may contain multiple roots.
-    configured = os.environ.get("CONDA_ENVS_PATH", "")
-    for chunk in configured.split(os.pathsep):
-        if chunk.strip():
-            add(Path(chunk.strip()))
+    # locations.  CONDA_ENVS_DIRS is canonical; CONDA_ENVS_PATH is the
+    # deprecated alias.  Both may carry several os.pathsep-joined roots.
+    for var in ("CONDA_ENVS_DIRS", "CONDA_ENVS_PATH"):
+        for chunk in os.environ.get(var, "").split(os.pathsep):
+            entry = chunk.strip()
+            # A relative entry would resolve against the daemon's cwd, which
+            # is nondeterministic — conda itself only honours absolute roots.
+            if entry and os.path.isabs(entry):
+                add(Path(entry))
 
     mamba_root = os.environ.get("MAMBA_ROOT_PREFIX", "").strip()
     if mamba_root:
@@ -238,14 +257,16 @@ def _env_roots() -> list[Path]:
 
     prefix = os.environ.get("CONDA_PREFIX", "").strip()
     if prefix:
-        add(_envs_root_from_prefix(prefix))
+        for root in _envs_roots_from_prefix(prefix):
+            add(root)
 
     # ``start.sh`` executes the project venv directly.  Even when the caller
     # did not activate Conda (and CONDA_PREFIX is therefore absent), a venv
     # created from a Conda Python retains that installation as sys.base_prefix.
     base_prefix = str(getattr(sys, "base_prefix", "") or "").strip()
     if base_prefix:
-        add(_envs_root_from_prefix(base_prefix))
+        for root in _envs_roots_from_prefix(base_prefix):
+            add(root)
 
     home = Path.home()
     for base in ("miniconda3", "miniforge3", "anaconda3", "mambaforge", "micromamba"):

--- a/openai4s/kernel/environments.py
+++ b/openai4s/kernel/environments.py
@@ -15,7 +15,9 @@ Discovery is cheap-ish and cached module-wide:
 
 Discovery roots, in priority order:
   1. ``OPENAI4S_ENV_ROOTS`` — ``:``-separated *envs* directories (override);
-  2. the usual conda/mamba install locations under ``$HOME``.
+  2. Conda/Mamba's own environment-root variables and active prefix;
+  3. the base interpreter behind the daemon's venv;
+  4. the usual conda/mamba install locations under ``$HOME``.
 
 A synthetic ``base`` environment (the daemon's own interpreter, ``sys.executable``,
 carrying the preinstalled stack from :mod:`openai4s.kernel.preinstall`) is
@@ -186,6 +188,23 @@ def _hidden_names() -> set[str]:
     return _ALWAYS_HIDE | {n.strip() for n in extra.split(",") if n.strip()}
 
 
+def _envs_root_from_prefix(prefix: str | os.PathLike[str]) -> Path:
+    """Return the standard sibling-environment directory for a Conda prefix.
+
+    Conda exposes either its base prefix (``<base>``) or an activated named
+    environment (normally ``<base>/envs/<name>``).  The former stores named
+    environments under ``<base>/envs``; the latter already has that directory
+    as its parent.  Treating ``<base>.parent`` as an env root scans unrelated
+    directories and incorrectly offers the base installation itself as a
+    named environment.
+    """
+
+    path = Path(prefix).expanduser()
+    if path.parent.name == "envs":
+        return path.parent
+    return path / "envs"
+
+
 def _env_roots() -> list[Path]:
     """Candidate *envs* directories to scan, de-duplicated, in priority order."""
     roots: list[Path] = []
@@ -205,12 +224,32 @@ def _env_roots() -> list[Path]:
     for chunk in override.split(os.pathsep):
         if chunk.strip():
             add(Path(chunk.strip()))
+
+    # Respect Conda's configured environment directories before inferred
+    # locations.  CONDA_ENVS_PATH may contain multiple roots.
+    configured = os.environ.get("CONDA_ENVS_PATH", "")
+    for chunk in configured.split(os.pathsep):
+        if chunk.strip():
+            add(Path(chunk.strip()))
+
+    mamba_root = os.environ.get("MAMBA_ROOT_PREFIX", "").strip()
+    if mamba_root:
+        add(Path(mamba_root) / "envs")
+
+    prefix = os.environ.get("CONDA_PREFIX", "").strip()
+    if prefix:
+        add(_envs_root_from_prefix(prefix))
+
+    # ``start.sh`` executes the project venv directly.  Even when the caller
+    # did not activate Conda (and CONDA_PREFIX is therefore absent), a venv
+    # created from a Conda Python retains that installation as sys.base_prefix.
+    base_prefix = str(getattr(sys, "base_prefix", "") or "").strip()
+    if base_prefix:
+        add(_envs_root_from_prefix(base_prefix))
+
     home = Path.home()
     for base in ("miniconda3", "miniforge3", "anaconda3", "mambaforge", "micromamba"):
         add(home / base / "envs")
-    prefix = os.environ.get("CONDA_PREFIX")
-    if prefix:
-        add(Path(prefix).parent)  # sibling envs of the active conda prefix
     return roots
 
 

--- a/openai4s/pkgscan.py
+++ b/openai4s/pkgscan.py
@@ -124,14 +124,17 @@ def _collect_pip(root: Path, requested_only: bool = False) -> set[str]:
     not the full transitive closure.
     """
     out: set[str] = set()
-    # Search only actual site-packages directories. Recursing from ``lib/``
-    # walks large native toolchains, model caches and R libraries in scientific
-    # Conda envs, turning a simple environment listing into a minutes-long scan.
-    candidates = [
-        *sorted((root / "lib").glob("python*/site-packages")),
-        *sorted((root / "lib64").glob("python*/site-packages")),
-        root / "Lib" / "site-packages",  # Windows-style, harmless if absent
-    ]
+    # Search only actual package directories. Recursing from ``lib/`` walks
+    # large native toolchains, model caches and R libraries in scientific Conda
+    # envs, turning a simple environment listing into a minutes-long scan.
+    # The interpreter directory is matched with ``*`` rather than ``python*``
+    # so PyPy (``lib/pypy3.10/site-packages``) resolves too, and both
+    # ``site-packages`` and Debian/RHEL ``dist-packages`` are covered.
+    candidates: list[Path] = []
+    for lib in (root / "lib", root / "lib64"):
+        for leaf in ("*/site-packages", "*/dist-packages"):
+            candidates.extend(sorted(lib.glob(leaf)))
+    candidates.append(root / "Lib" / "site-packages")  # Windows, harmless if absent
     seen_infos: set[Path] = set()
     for base in candidates:
         if not base.is_dir():

--- a/openai4s/pkgscan.py
+++ b/openai4s/pkgscan.py
@@ -124,17 +124,19 @@ def _collect_pip(root: Path, requested_only: bool = False) -> set[str]:
     not the full transitive closure.
     """
     out: set[str] = set()
-    # site-packages can live at a few standard spots inside a venv/conda env
+    # Search only actual site-packages directories. Recursing from ``lib/``
+    # walks large native toolchains, model caches and R libraries in scientific
+    # Conda envs, turning a simple environment listing into a minutes-long scan.
     candidates = [
-        root / "lib",
-        root / "lib64",
-        root / "Lib",  # windows-style, harmless if absent
+        *sorted((root / "lib").glob("python*/site-packages")),
+        *sorted((root / "lib64").glob("python*/site-packages")),
+        root / "Lib" / "site-packages",  # Windows-style, harmless if absent
     ]
     seen_infos: set[Path] = set()
     for base in candidates:
         if not base.is_dir():
             continue
-        for info in base.rglob("*.dist-info"):
+        for info in base.glob("*.dist-info"):
             if info in seen_infos:
                 continue
             seen_infos.add(info)

--- a/tests/test_environments.py
+++ b/tests/test_environments.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import pytest
 
+from openai4s import pkgscan
 from openai4s.config import Config, LLMConfig
 from openai4s.host_dispatch import build_dispatcher
 from openai4s.kernel import environments as E
@@ -60,6 +61,77 @@ def test_base_env_always_present():
 
 def test_default_env_name_is_offered():
     assert E.default_env_name() in {e.name for e in E.discover_environments(force=True)}
+
+
+def test_conda_base_prefix_discovers_its_envs_not_the_base_parent(
+    tmp_path, monkeypatch
+):
+    conda_base = tmp_path / "portable-conda"
+    (conda_base / "bin").mkdir(parents=True)
+    (conda_base / "bin" / "python").symlink_to(sys.executable)
+    expected = _make_py_env(conda_base / "envs", "torch", packages=("pandas", "torch"))
+    monkeypatch.delenv("OPENAI4S_ENV_ROOTS", raising=False)
+    monkeypatch.delenv("CONDA_ENVS_PATH", raising=False)
+    monkeypatch.delenv("MAMBA_ROOT_PREFIX", raising=False)
+    monkeypatch.setenv("CONDA_PREFIX", str(conda_base))
+    monkeypatch.setenv("CONDA_DEFAULT_ENV", "base")
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setattr(E.sys, "base_prefix", str(tmp_path / "system-python"))
+
+    envs = E.discover_environments(force=True)
+
+    assert E.get_environment("torch").root == expected
+    assert conda_base.name not in {environment.name for environment in envs}
+
+
+def test_activated_named_conda_prefix_discovers_sibling_envs(tmp_path, monkeypatch):
+    envs_root = tmp_path / "portable-conda" / "envs"
+    active = _make_py_env(envs_root, "active")
+    expected = _make_py_env(envs_root, "analysis", packages=("numpy", "pandas"))
+    monkeypatch.delenv("OPENAI4S_ENV_ROOTS", raising=False)
+    monkeypatch.delenv("CONDA_ENVS_PATH", raising=False)
+    monkeypatch.delenv("MAMBA_ROOT_PREFIX", raising=False)
+    monkeypatch.setenv("CONDA_PREFIX", str(active))
+    monkeypatch.setenv("CONDA_DEFAULT_ENV", "active")
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setattr(E.sys, "base_prefix", str(tmp_path / "system-python"))
+
+    E.discover_environments(force=True)
+
+    assert E.get_environment("active").root == active
+    assert E.get_environment("analysis").root == expected
+
+
+def test_daemon_venv_base_prefix_discovers_conda_envs_without_activation(
+    tmp_path, monkeypatch
+):
+    conda_base = tmp_path / "portable-conda"
+    expected = _make_py_env(conda_base / "envs", "science", packages=("pandas",))
+    monkeypatch.delenv("OPENAI4S_ENV_ROOTS", raising=False)
+    monkeypatch.delenv("CONDA_ENVS_PATH", raising=False)
+    monkeypatch.delenv("MAMBA_ROOT_PREFIX", raising=False)
+    monkeypatch.delenv("CONDA_PREFIX", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setattr(E.sys, "base_prefix", str(conda_base))
+
+    E.discover_environments(force=True)
+
+    assert E.get_environment("science").root == expected
+
+
+def test_package_scan_is_bounded_to_site_packages(tmp_path):
+    env = tmp_path / "env"
+    installed = env / "lib" / "python3.13" / "site-packages" / "demo-1.dist-info"
+    installed.mkdir(parents=True)
+    (installed / "METADATA").write_text("Name: demo\nVersion: 1\n", "utf-8")
+    unrelated = env / "lib" / "native" / "cache" / "ghost-1.dist-info"
+    unrelated.mkdir(parents=True)
+    (unrelated / "METADATA").write_text("Name: ghost\nVersion: 1\n", "utf-8")
+
+    packages = pkgscan.collect_packages(env, language="python")
+
+    assert "demo" in packages
+    assert "ghost" not in packages
 
 
 def test_discover_fake_python_env(tmp_path, monkeypatch):

--- a/tests/test_environments.py
+++ b/tests/test_environments.py
@@ -15,11 +15,35 @@ from openai4s.host_dispatch import build_dispatcher
 from openai4s.kernel import environments as E
 from openai4s.server import gateway as gateway_mod
 
+#: Every environment variable ``E._env_roots()`` merges into its scan list.
+#: ``_env_roots`` merges *all* sources — OPENAI4S_ENV_ROOTS does not
+#: short-circuit — so a developer machine that exports e.g. MAMBA_ROOT_PREFIX
+#: (micromamba's shell hook always does) would otherwise leak real conda envs
+#: into these assertions.
+_ENV_ROOT_SOURCES = (
+    "OPENAI4S_ENV_ROOTS",
+    "OPENAI4S_ENV_HIDE",
+    "OPENAI4S_DEFAULT_ENV",
+    "CONDA_ENVS_DIRS",
+    "CONDA_ENVS_PATH",
+    "MAMBA_ROOT_PREFIX",
+    "CONDA_PREFIX",
+)
+
 
 @pytest.fixture(autouse=True)
-def _reset_env_cache():
-    """Rescan the (real) envs after each test so the global cache never leaks a
-    test's fake OPENAI4S_ENV_ROOTS into a later test."""
+def _isolate_env_discovery(tmp_path, monkeypatch):
+    """Neutralize every discovery source so each test sees only what it sets up.
+
+    Also rescans the (real) envs afterwards so the global cache never leaks a
+    test's fake roots into a later test.
+    """
+    for var in _ENV_ROOT_SOURCES:
+        monkeypatch.delenv(var, raising=False)
+    home = tmp_path / "isolated-home"
+    home.mkdir(exist_ok=True)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(E.sys, "base_prefix", str(tmp_path / "no-such-system-python"))
     yield
     E.discover_environments(force=True)
 
@@ -70,13 +94,8 @@ def test_conda_base_prefix_discovers_its_envs_not_the_base_parent(
     (conda_base / "bin").mkdir(parents=True)
     (conda_base / "bin" / "python").symlink_to(sys.executable)
     expected = _make_py_env(conda_base / "envs", "torch", packages=("pandas", "torch"))
-    monkeypatch.delenv("OPENAI4S_ENV_ROOTS", raising=False)
-    monkeypatch.delenv("CONDA_ENVS_PATH", raising=False)
-    monkeypatch.delenv("MAMBA_ROOT_PREFIX", raising=False)
     monkeypatch.setenv("CONDA_PREFIX", str(conda_base))
     monkeypatch.setenv("CONDA_DEFAULT_ENV", "base")
-    monkeypatch.setenv("HOME", str(tmp_path / "home"))
-    monkeypatch.setattr(E.sys, "base_prefix", str(tmp_path / "system-python"))
 
     envs = E.discover_environments(force=True)
 
@@ -88,13 +107,8 @@ def test_activated_named_conda_prefix_discovers_sibling_envs(tmp_path, monkeypat
     envs_root = tmp_path / "portable-conda" / "envs"
     active = _make_py_env(envs_root, "active")
     expected = _make_py_env(envs_root, "analysis", packages=("numpy", "pandas"))
-    monkeypatch.delenv("OPENAI4S_ENV_ROOTS", raising=False)
-    monkeypatch.delenv("CONDA_ENVS_PATH", raising=False)
-    monkeypatch.delenv("MAMBA_ROOT_PREFIX", raising=False)
     monkeypatch.setenv("CONDA_PREFIX", str(active))
     monkeypatch.setenv("CONDA_DEFAULT_ENV", "active")
-    monkeypatch.setenv("HOME", str(tmp_path / "home"))
-    monkeypatch.setattr(E.sys, "base_prefix", str(tmp_path / "system-python"))
 
     E.discover_environments(force=True)
 
@@ -107,16 +121,108 @@ def test_daemon_venv_base_prefix_discovers_conda_envs_without_activation(
 ):
     conda_base = tmp_path / "portable-conda"
     expected = _make_py_env(conda_base / "envs", "science", packages=("pandas",))
-    monkeypatch.delenv("OPENAI4S_ENV_ROOTS", raising=False)
-    monkeypatch.delenv("CONDA_ENVS_PATH", raising=False)
-    monkeypatch.delenv("MAMBA_ROOT_PREFIX", raising=False)
-    monkeypatch.delenv("CONDA_PREFIX", raising=False)
-    monkeypatch.setenv("HOME", str(tmp_path / "home"))
     monkeypatch.setattr(E.sys, "base_prefix", str(conda_base))
 
     E.discover_environments(force=True)
 
     assert E.get_environment("science").root == expected
+
+
+def test_custom_envs_dirs_prefix_discovers_siblings(tmp_path, monkeypatch):
+    """``conda config --add envs_dirs /data/myenvs`` (or ``conda create -p``)
+    puts the active prefix under a directory that is *not* named ``envs``."""
+    myenvs = tmp_path / "myenvs"
+    active = _make_py_env(myenvs, "proj")
+    expected = _make_py_env(myenvs, "sibling", packages=("numpy", "pandas"))
+    monkeypatch.setenv("CONDA_PREFIX", str(active))
+
+    E.discover_environments(force=True)
+
+    assert E.get_environment("proj").root == active
+    assert E.get_environment("sibling").root == expected
+
+
+def test_base_install_prefix_does_not_offer_its_own_parent(tmp_path, monkeypatch):
+    """A base install has ``envs/`` — its parent must never become a root."""
+    conda_base = tmp_path / "opt" / "miniconda3"
+    (conda_base / "conda-meta").mkdir(parents=True)
+    expected = _make_py_env(conda_base / "envs", "torch")
+    _make_py_env(tmp_path / "opt", "unrelated")  # sibling of the base install
+    monkeypatch.setenv("CONDA_PREFIX", str(conda_base))
+
+    E.discover_environments(force=True)
+
+    assert E.get_environment("torch").root == expected
+    assert E.get_environment("unrelated") is None
+    assert E.get_environment("miniconda3") is None
+
+
+def test_fresh_base_install_without_envs_dir_does_not_scan_its_parent(
+    tmp_path, monkeypatch
+):
+    """A base install on which no env has been created yet still has ``pkgs/``.
+
+    Classifying it as a named environment would add ``$HOME`` (the parent of
+    ``~/miniconda3``) to the scan list, offering every home-directory folder —
+    and the base install itself — as a selectable environment.
+    """
+    home = tmp_path / "home"
+    conda_base = home / "miniconda3"
+    (conda_base / "bin").mkdir(parents=True)
+    (conda_base / "bin" / "python").symlink_to(sys.executable)
+    (conda_base / "conda-meta").mkdir()
+    (conda_base / "pkgs").mkdir()  # root-prefix marker; no envs/ yet
+    _make_py_env(home, "Projects")  # unrelated home-directory folder
+    monkeypatch.setenv("CONDA_PREFIX", str(conda_base))
+
+    E.discover_environments(force=True)
+
+    assert E.get_environment("Projects") is None
+    assert E.get_environment("miniconda3") is None
+
+
+def test_conda_envs_path_splits_on_pathsep(tmp_path, monkeypatch):
+    first = _make_py_env(tmp_path / "a", "alpha")
+    second = _make_py_env(tmp_path / "b", "beta")
+    monkeypatch.setenv(
+        "CONDA_ENVS_PATH", os.pathsep.join([str(tmp_path / "a"), str(tmp_path / "b")])
+    )
+
+    E.discover_environments(force=True)
+
+    assert E.get_environment("alpha").root == first
+    assert E.get_environment("beta").root == second
+
+
+def test_conda_envs_dirs_is_honoured(tmp_path, monkeypatch):
+    """CONDA_ENVS_DIRS is canonical; CONDA_ENVS_PATH is the deprecated alias."""
+    expected = _make_py_env(tmp_path / "roots", "gamma")
+    monkeypatch.setenv("CONDA_ENVS_DIRS", str(tmp_path / "roots"))
+
+    E.discover_environments(force=True)
+
+    assert E.get_environment("gamma").root == expected
+
+
+def test_relative_conda_envs_entries_are_ignored(tmp_path, monkeypatch):
+    """A relative root would resolve against the daemon's nondeterministic cwd."""
+    _make_py_env(tmp_path / "roots", "delta")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("CONDA_ENVS_DIRS", "roots")
+
+    E.discover_environments(force=True)
+
+    assert E.get_environment("delta") is None
+
+
+def test_mamba_root_prefix_discovers_envs(tmp_path, monkeypatch):
+    mamba_root = tmp_path / "micromamba"
+    expected = _make_py_env(mamba_root / "envs", "epsilon")
+    monkeypatch.setenv("MAMBA_ROOT_PREFIX", str(mamba_root))
+
+    E.discover_environments(force=True)
+
+    assert E.get_environment("epsilon").root == expected
 
 
 def test_package_scan_is_bounded_to_site_packages(tmp_path):
@@ -131,6 +237,33 @@ def test_package_scan_is_bounded_to_site_packages(tmp_path):
     packages = pkgscan.collect_packages(env, language="python")
 
     assert "demo" in packages
+    assert "ghost" not in packages
+
+
+@pytest.mark.parametrize(
+    "layout",
+    [
+        "lib/python3.13/site-packages",  # CPython venv / conda env
+        "lib64/python3.11/site-packages",  # RHEL multilib
+        "lib/pypy3.10/site-packages",  # PyPy — 'python*' would miss this
+        "lib/python3/dist-packages",  # Debian/Ubuntu system Python
+        "lib/python3.11/dist-packages",  # Debian versioned
+        "Lib/site-packages",  # Windows
+    ],
+)
+def test_package_scan_resolves_real_layouts(tmp_path, layout):
+    env = tmp_path / "env"
+    installed = env / layout / "demo-1.dist-info"
+    installed.mkdir(parents=True)
+    (installed / "METADATA").write_text("Name: demo\nVersion: 1\n", "utf-8")
+    # decoy: a nested toolchain directory must stay out of the bounded scan
+    decoy = env / "lib" / "native" / "cache" / "ghost-1.dist-info"
+    decoy.mkdir(parents=True)
+    (decoy / "METADATA").write_text("Name: ghost\nVersion: 1\n", "utf-8")
+
+    packages = pkgscan.collect_packages(env, language="python")
+
+    assert "demo" in packages, f"{layout} did not resolve"
     assert "ghost" not in packages
 
 


### PR DESCRIPTION
<!--
Thanks for contributing to OpenAI4S.

Keep PRs small, focused, and reviewable.
Branch naming: feat/<name>, fix/<name>, docs/<name>, test/<name>,
refactor/<name>, chore/<name>, ui/<name>, harness/<name>, science/<name>,
release/<name>, hotfix/<name>.

OpenAI4S is a public repository. Do not include secrets, private data,
unpublished research plans, internal assignments, or unreleased results in
the PR title, description, branch name, commit messages, code, logs, or tests.
-->

  ## Summary

  Fixes Conda environment discovery to work reliably in more deployment
  scenarios, and bounds package scanning to site-packages directories so
  listing environments no longer walks entire Conda installations.

  Two related issues were fixed:

  1. **Environment discovery missed environments when Conda was not manually
     activated.** The daemon's venv is often created from a Conda Python
     (`sys.base_prefix`), but the discovery path only checked `CONDA_PREFIX`
     and a few hardcoded `~/miniconda3/envs`-style directories. This meant
     environments were invisible unless the caller first ran `conda activate`.

  2. **Packages scanning could take minutes on scientific Conda envs.**
     `pkgscan.py` used `rglob("*.dist-info")` starting from `lib/`, which
     crawled through native toolchains, model caches, and R libraries —
     turning a simple environment listing into a slow directory walk.

  Changes:

  - New `_envs_root_from_prefix()` helper that correctly resolves
    `<base>/envs` from both a base prefix and an activated named
    environment (where the parent *is* the envs directory).
  - Respects `CONDA_ENVS_PATH`, `MAMBA_ROOT_PREFIX`, `CONDA_PREFIX`,
    and `sys.base_prefix` before falling back to hardcoded install
    locations.
  - Tightens `pkgscan._collect_pip` to only scan `lib/python*/site-packages`
    (non-recursive `glob` instead of `rglob`).
  - Adds 4 focused tests covering the new discovery paths and the
    bounded package scan.
  - `.gitignore`: adds `.ruff_cache/`, `.mypy_cache/`, `.venv`.

  ## Area

  - [x] Kernel / host RPC / runtime
  - [x] Tests / harness / CI

  ## Change Type

  - [x] Bug fix

  ## Verification

  Ran:

  ```text
  uv run pytest tests/test_environments.py -v
```

  Not run:



  Reason:

  All 4 new tests exercise the changed discovery and scanning paths
  in isolation (tmp_path + monkeypatch), no live Conda install required.

  Risk and Reviewer Focus

  - _envs_root_from_prefix() in environments.py — the parent-name
  heuristic (path.parent.name == "envs") correctly handles the common
  cases but could misidentify a user-created directory named envs at
  any level. In practice, Conda environments always live at <base>/envs/<name>.
  - pkgscan.py — the glob change from rglob to glob is the
  correctness-sensitive part. It skips packages installed into non-standard
  locations inside lib/, but such layouts are not produced by pip or conda.
  - Discovery order matters. The new checks (CONDA_ENVS_PATH,
  MAMBA_ROOT_PREFIX, CONDA_PREFIX, sys.base_prefix) are inserted
  before the hardcoded home-directory scan, so they take priority.
  Duplicate roots are de-duplicated, so if a path appears in multiple
  sources, the first occurrence wins.

  Checklist

  Diff Readiness

  - [x] I reviewed and understand the full diff.
  - [x] This PR is small and single-purpose.
  - [x] No unrelated formatting, broad rewrite, or drive-by refactor is included.
  - [x] Hotspot files were edited surgically if touched: gateway.py,
  host_dispatch.py, store.py, app.js, worker.py, manager.py.
  - [x] openai4s/server/webui/vendor/ and tests/fixtures/ were not
  reformatted.

  Tests

  - [x] Relevant tests or manual checks were run and listed above.
  - [x] No new test requires live LLM, network, GPU, SSH, Docker, lab hardware,
  or secrets in the default offline suite.
  - [x] No tests were deleted without tracked replacements.
  - [x] Kernel / host-RPC / gateway changes include focused contract coverage or
  a documented smoke test.

  Core Dependency Policy

  - [x] No hard third-party import was added to the core engine, LLM client, or
  stdlib web server.
  - [x] Optional science imports are guarded by try/except ImportError at every
  in-tree use site.
  - [x] New dependencies, if any, are documented and justified.

  Public Disclosure and Security

  - [x] No secrets, API keys, tokens, real credentials, private data, model
  weights, or local absolute paths are included.
  - [x] No unpublished research roadmap, internal assignment, benchmark detail,
  or unreleased experimental result is disclosed.
  - [x] Security-sensitive changes include appropriate synthetic tests or manual
  verification notes.
  - [x] Docs do not overstate isolation, sandboxing, privacy, or security
  guarantees.

  Docs

  - [x] Docs match actual code behavior.
  - [x] User-facing behavior changes are reflected in docs or release notes where
  appropriate.
  - [x] README.md and README_zh.md stay in sync where translated sections are
  affected.