### PR TITLE
fix(webui): route web sharing through the versioned API prefix

### DIFF
--- a/openai4s/server/webui/app.js
+++ b/openai4s/server/webui/app.js
@@ -4237,8 +4237,8 @@ async function openShareDialog(fid, frame = {}) {
   let shares = { shares: [] };
   try {
     [status, shares] = await Promise.all([
-      fetch("/api/share/status").then(r => r.json()),
-      fetch(`/api/frames/${encodeURIComponent(fid)}/shares`).then(r => r.json()),
+      fetch(`${API}/share/status`).then(r => r.json()),
+      fetch(`${API}/frames/${encodeURIComponent(fid)}/shares`).then(r => r.json()),
     ]);
   } catch (error) { hint(t("nb.action.failed", error.message), true); return; }
 
@@ -4268,7 +4268,7 @@ async function openShareDialog(fid, frame = {}) {
     row.style.cssText = "display:flex;gap:8px;justify-content:flex-end;margin-top:16px";
     if (status.configured) {
       row.appendChild(mkBtn(t("share.enable"), async () => {
-        await shareCall("PUT", "/api/share/settings", { enabled: true });
+        await shareCall("PUT", `${API}/share/settings`, { enabled: true });
         close(); openShareDialog(fid, frame);
       }, false, true));
     }
@@ -4306,12 +4306,12 @@ async function openShareDialog(fid, frame = {}) {
     const actions = document.createElement("div");
     actions.style.cssText = "display:flex;gap:8px;justify-content:flex-end;margin-top:16px";
     actions.appendChild(mkBtn(t("share.update"), async () => {
-      await shareCall("PUT", `/api/shares/${encodeURIComponent(active.share_id)}`);
+      await shareCall("PUT", `${API}/shares/${encodeURIComponent(active.share_id)}`);
       hint(t("share.updated")); close();
     }));
     actions.appendChild(mkBtn(t("share.revoke"), async () => {
       if (!confirm(t("share.revokeConfirm"))) return;
-      await shareCall("DELETE", `/api/shares/${encodeURIComponent(active.share_id)}`);
+      await shareCall("DELETE", `${API}/shares/${encodeURIComponent(active.share_id)}`);
       hint(t("share.revoked")); close();
     }, true));
     actions.appendChild(mkBtn(t("share.close"), close));
@@ -4339,7 +4339,7 @@ async function openShareDialog(fid, frame = {}) {
       const body = {};
       const secs = parseInt(sel.value, 10);
       if (secs > 0) body.expires_in = secs;
-      const rec = await shareCall("POST", `/api/frames/${encodeURIComponent(fid)}/shares`, body);
+      const rec = await shareCall("POST", `${API}/frames/${encodeURIComponent(fid)}/shares`, body);
       close();
       if (rec && rec.url) openShareDialog(fid, frame);
     }, false, true));

--- a/tests/test_webui_static_contract.py
+++ b/tests/test_webui_static_contract.py
@@ -243,6 +243,23 @@ def test_frontend_uses_backend_error_envelope() -> None:
     ), "api() must surface the backend's {error: ...} message"
 
 
+def test_frontend_never_hardcodes_an_unversioned_api_path() -> None:
+    """Every request must go through ``API``, never a literal ``/api/...``.
+
+    The un-versioned surface was deleted when the contract moved to ``/api/v1``
+    (there is deliberately no legacy alias), so a hardcoded ``"/api/share/…"``
+    is not a stylistic slip — it is a route that 404s at runtime while every
+    offline test still passes.  Web sharing shipped exactly that way: six
+    literals that no unit test exercised because they only run in a browser.
+    """
+    literals = re.findall(r"""["'`]/api/(?!v\d)[^"'`]*""", APP_JS)
+    assert not literals, (
+        "these frontend paths bypass the API prefix and will 404: "
+        f"{sorted(set(literals))}"
+    )
+    assert 'const API = "/api/v1"' in APP_JS
+
+
 def test_artifact_viewer_consumes_safe_renderer_descriptors() -> None:
     renderer_source = _extract_js_function(APP_JS, "artifactRendererDescriptor")
     body_source = _extract_js_function(APP_JS, "renderArtifactBody")


### PR DESCRIPTION
## What is broken

Web sharing is non-functional on `main` right now. Its six frontend fetches address the un-versioned surface directly:

| `openai4s/server/webui/app.js` | call |
| --- | --- |
| 4240 | `fetch("/api/share/status")` |
| 4241 | `fetch(\`/api/frames/${fid}/shares\`)` |
| 4271 | `shareCall("PUT", "/api/share/settings")` |
| 4309 | `shareCall("PUT", \`/api/shares/${id}\`)` |
| 4314 | `shareCall("DELETE", \`/api/shares/${id}\`)` |
| 4342 | `shareCall("POST", \`/api/frames/${fid}/shares\`)` |

`#41` moved the contract to `/api/v1` and removed the un-versioned surface with no legacy alias (a deliberate, owner-frozen decision — the only clients are first-party). So every one of these 404s, and every sharing control in the UI fails.

Verified against a live daemon:

```
/api/v1/share/status  -> 200  {"state": "disabled", "configured": false}
/api/share/status     -> 404
```

## Why nothing caught it

Both changes were correct in isolation and landed from separate branches (#38 and #41). The share routes have server-side tests, and these six literals only execute in a browser, so the full offline suite stayed green through the merge.

## The fix

Route all six through the existing `API` constant (`app.js:83`, `"/api/v1"`), which every other request in the file already uses.

Plus a static contract test that rejects any `/api/...` literal outside that constant, so the next route added off-prefix fails offline instead of in a user's browser. That test fails on `main` today and passes here.

## Verification

- `tests/test_webui_static_contract.py` — 33 passed
- Full offline suite — 2107 passed, 3 skipped
- Live daemon — the versioned route serves, the un-versioned one 404s (above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)