### PR TITLE
fix(ci): update contributors through pull requests

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -12,10 +12,15 @@ shipped as part of the Python package.
 | File | Purpose |
 | --- | --- |
 | `ci.yml` | The default offline gate. Checks branch naming, runs pre-commit, verifies bilingual per-directory documentation coverage, type-checks the core orchestration boundary, scans tracked sources for credentials, builds the wheel and the sdist and checks what is inside both, then installs the wheel alone into a clean venv and exercises the CLI it puts there, runs the offline suite on Python 3.10 and 3.12 alongside the deterministic harness contracts, and drives the real workbench in Chromium. The macOS job that requires enforced Seatbelt isolation runs only on the schedule or on manual dispatch. |
-| `contributors.yml` | Regenerates the contributor avatars and the contributor wall in the root READMEs, weekly and on pushes to `main`. |
+| `contributors.yml` | Regenerates the contributor avatars and the contributor wall in the root READMEs, weekly and on pushes to `main`, then creates or updates a protected-branch-safe PR and explicitly dispatches its required CI checks. |
 | `release.yml` | Fires when a non-prerelease `v*` GitHub Release is published. Builds the distributions from the tag, matches the tag against both version declarations, rescans the sources, and publishes to PyPI through OIDC from the `pypi` environment. |
 | `scorecard.yml` | Runs OpenSSF Scorecard on pushes to `main` and weekly, publishes the results, and uploads the SARIF to code scanning. |
 | `secret-scan.yml` | Runs Gitleaks over every reachable commit in Git history, not just the diff, on pushes, pull requests, a weekly schedule, and manual dispatch. The binary is checksum-pinned and matches are redacted in the log. |
+
+The contributor automation requires repository rules that leave topic branches
+pushable: the branch-name rule may cover every ref, but required status checks
+must target the protected default branch. The repository's Actions settings
+must also allow `GITHUB_TOKEN` workflows to create pull requests.
 
 The default test suite must remain offline. Live providers, GPU, SSH, package
 publication, and credentials stay in separately authorized paths.

--- a/.github/workflows/README_zh.md
+++ b/.github/workflows/README_zh.md
@@ -11,10 +11,14 @@
 | 文件 | 职责 |
 | --- | --- |
 | `ci.yml` | 默认的离线检查门。检查分支命名、跑 pre-commit、核对双语目录文档是否齐全、对核心编排边界做类型检查、扫描源码中的 secret、构建 wheel 与 sdist 并核对二者的内容、再把 wheel 单独装进一个干净的虚拟环境并跑通装好的 CLI、在 Python 3.10 和 3.12 上跑离线测试套件与确定性的 harness 契约，并在 Chromium 里驱动真实的工作台。要求 Seatbelt 隔离真正生效的 macOS 任务只在定时和手动触发时运行。 |
-| `contributors.yml` | 每周定时以及 `main` 有 push 时，重新生成贡献者头像和根 README 里的贡献者墙。 |
+| `contributors.yml` | 每周定时以及 `main` 有 push 时，重新生成贡献者头像和根 README 里的贡献者墙，再创建或更新符合受保护分支规则的 PR，并显式触发其必需的 CI 检查。 |
 | `release.yml` | 在非预发布的 `v*` GitHub Release 被发布时触发：从该 tag 构建发行包，核对 tag 与两处版本声明是否一致，重新扫一遍源码，再从 `pypi` environment 经由 OIDC 发布到 PyPI。 |
 | `scorecard.yml` | 在 `main` 的 push 和每周定时上运行 OpenSSF Scorecard，公开发布评分结果，并把 SARIF 上传到 code scanning。 |
 | `secret-scan.yml` | 用 Gitleaks 扫描 Git 历史中每一个可达 commit，而不只是本次改动；push、PR、每周定时和手动触发都会跑。Gitleaks 二进制按 checksum 固定，命中内容在日志里做脱敏。 |
+
+贡献者自动化要求仓库规则允许 topic 分支被推送：分支命名规则可以覆盖所有 ref，
+但 required status checks 必须只约束受保护的默认分支。仓库的 Actions 设置也必须允许
+使用 `GITHUB_TOKEN` 的工作流创建 pull request。
 
 默认测试套件必须保持离线。真实 provider、GPU、SSH、包发布与凭据都留在单独授权的
 路径中。

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -8,44 +8,88 @@ name: Contributors
 on:
   push:
     branches: [main]
-    # Do not re-trigger on the workflow's own README commit.
+    # Do not re-trigger after the generated contributor PR is merged.
     paths-ignore:
       - README.md
       - README_zh.md
+      - .github/contributors/**
   schedule:
     - cron: "0 3 * * 1" # weekly, Monday 03:00 UTC
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
-  group: contributors-${{ github.ref }}
-  cancel-in-progress: true
+  group: contributors-update
+  cancel-in-progress: false
 
 jobs:
   update:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
+      pull-request-operation: ${{ steps.cpr.outputs.pull-request-operation }}
+    env:
+      UPDATE_BRANCH: docs/community-contributors
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - name: Check out the protected base branch
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: main
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
       - name: Install Pillow (circular avatar crop)
-        run: python -m pip install --quiet Pillow
+        env:
+          PILLOW_WHEEL: https://files.pythonhosted.org/packages/84/21/a35af28dcc61f37ed850a2d64c65c701321dfbf25085e469d5559360cbbf/pillow-12.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl#sha256=78cb2c6865a35ab8ff8b75fd122f6033b92a62c82801110e48ddd6c936a45d91
+        run: python -m pip install --quiet "$PILLOW_WHEEL"
       - name: Regenerate contributor wall
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: python scripts/update_contributors.py
-      - name: Commit if changed
-        run: |
-          if [ -n "$(git status --porcelain README.md README_zh.md)" ]; then
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add README.md README_zh.md
-            git commit -m "docs(readme): refresh community contributors [skip ci]"
-            git push
-          else
-            echo "Community contributors already up to date."
-          fi
+      - name: Create or update contributor PR
+        id: cpr
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ github.token }}
+          base: main
+          branch: ${{ env.UPDATE_BRANCH }}
+          delete-branch: true
+          add-paths: |
+            README.md
+            README_zh.md
+            .github/contributors/
+          commit-message: "docs(readme): refresh community contributors"
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          title: "docs(readme): refresh community contributors"
+          body: |
+            Automated refresh from the GitHub contributors API.
+            Includes both README walls and the generated circular avatar assets.
+
+  # GITHUB_TOKEN-created PR events wait for manual approval. An explicit
+  # workflow_dispatch is the recursion-safe path that starts required checks.
+  checks:
+    name: Dispatch required checks for the generated PR
+    needs: update
+    if: >-
+      needs.update.outputs.pull-request-number != '' &&
+      needs.update.outputs.pull-request-operation != 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    env:
+      UPDATE_BRANCH: docs/community-contributors
+    steps:
+      - name: Run required checks for the generated PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run ci.yml --ref "$UPDATE_BRANCH"

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -92,4 +92,7 @@ jobs:
       - name: Run required checks for the generated PR
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh workflow run ci.yml --ref "$UPDATE_BRANCH"
+        run: >-
+          gh workflow run ci.yml
+          --repo "$GITHUB_REPOSITORY"
+          --ref "$UPDATE_BRANCH"

--- a/tests/test_governance.py
+++ b/tests/test_governance.py
@@ -109,7 +109,9 @@ def test_contributors_workflow_updates_protected_main_through_a_pr():
         ".github/contributors/",
         "needs.update.outputs.pull-request-number != ''",
         "needs.update.outputs.pull-request-operation != 'closed'",
-        'gh workflow run ci.yml --ref "$UPDATE_BRANCH"',
+        "gh workflow run ci.yml",
+        '--repo "$GITHUB_REPOSITORY"',
+        '--ref "$UPDATE_BRANCH"',
     ):
         assert contract in workflow
 

--- a/tests/test_governance.py
+++ b/tests/test_governance.py
@@ -84,3 +84,36 @@ def test_dependabot_tracks_uv_hooks_and_workflow_actions():
     assert config.count("package-ecosystem:") == 3
     for ecosystem in ('"uv"', '"pre-commit"', '"github-actions"'):
         assert f"package-ecosystem: {ecosystem}" in config
+
+
+def test_contributors_workflow_updates_protected_main_through_a_pr():
+    workflow = (WORKFLOWS / "contributors.yml").read_text(encoding="utf-8")
+    ci_workflow = (WORKFLOWS / "ci.yml").read_text(encoding="utf-8")
+    uses = [line for line in workflow.splitlines() if line.lstrip().startswith("uses:")]
+
+    # This workflow receives write access, so mutable action tags are not safe.
+    assert uses
+    assert all(PINNED_ACTION.fullmatch(line) for line in uses)
+
+    for contract in (
+        "contents: write",
+        "pull-requests: write",
+        "actions: write",
+        "UPDATE_BRANCH: docs/community-contributors",
+        "persist-credentials: false",
+        "pillow-12.3.0-",
+        "#sha256=78cb2c6865a35ab8ff8b75fd122f6033b92a62c82801110e48ddd6c936a45d91",
+        "peter-evans/create-pull-request@",
+        "base: main",
+        "add-paths:",
+        ".github/contributors/",
+        "needs.update.outputs.pull-request-number != ''",
+        "needs.update.outputs.pull-request-operation != 'closed'",
+        'gh workflow run ci.yml --ref "$UPDATE_BRANCH"',
+    ):
+        assert contract in workflow
+
+    assert "[skip ci]" not in workflow
+    assert not re.search(r"(?m)^\s*git push(?:\s|$)", workflow)
+    assert "pull_request_target" not in workflow
+    assert "workflow_dispatch:" in ci_workflow


### PR DESCRIPTION
## Summary
- merge the latest main into this branch
- replace the protected-main push in the contributors workflow with an automatically maintained pull request
- include generated contributor avatars as tracked changes
- dispatch CI explicitly for the update branch and lock the behavior with governance tests
- document the repository settings required for the automation

## Root cause
The workflow committed README.md and README_zh.md and then pushed directly to main. Repository rules require changes to main through a pull request and expect four status checks, so GitHub rejected the push with GH013. The previous changed-file check also ignored .github/contributors/*.png.

## Repository configuration required
Before the scheduled automation can open its own PR successfully:
1. Move the four required status checks out of ruleset 18642584 (branch-name-convention, currently targeting all branches) and into the default-branch/main protection ruleset. Keep only the branch-name regex on all branches.
2. Enable the Actions setting that allows workflows to create and approve pull requests.

Without step 1, creation of docs/community-contributors is rejected before its checks can exist.

## Area
CI / documentation automation

## Change type
Bug fix

## Verification
- uv run pytest: 2105 passed, 6 skipped, 1 deselected
- uv run pytest tests/test_governance.py: 5 passed
- pre-commit on changed files: passed
- documentation directory check: 87 maintained directories, 598 direct files/assets, complete bilingual coverage
- YAML parse and git diff --check: passed

## Risk and reviewer focus
Please verify repository rule placement and the Actions pull-request permission. The workflow pins all third-party actions and scopes write permissions to the update job.