### PR TITLE
chore(deps): declare the dev floors the gate is actually verified against

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,10 +48,22 @@ chemistry = [
 
 [dependency-groups]
 # Dev/test tooling (uv installs these by default with `uv sync`).
+#
+# Floors state what the gate was actually verified against, not merely what
+# once resolved. Every in-repo path goes through `uv sync --locked`, so a loose
+# floor breaks nothing in CI -- it misleads the contributor who installs from
+# this file directly and gets a weaker check than CI runs.
 dev = [
-    "mypy>=1.14,<3",
+    # >=2.3 because mypy 2.0 flipped `local_partial_types` on by default, and
+    # the strict boundary below is only ever checked under 2.x. A range that
+    # still admitted 1.x would make the boundary's semantics depend on which
+    # major the resolver happened to pick.
+    "mypy>=2.3,<3",
     "pytest>=7.4",
-    "pre-commit>=3.0",
+    # >=3.2 because the pre-commit-hooks and isort hooks pinned in
+    # .pre-commit-config.yaml declare `minimum_pre_commit_version: 3.2.0`,
+    # which pre-commit validates at manifest load -- a hard error, not a skip.
+    "pre-commit>=3.2",
 ]
 
 [project.scripts]
@@ -169,6 +181,11 @@ check_untyped_defs = true
 disallow_untyped_defs = true
 no_implicit_optional = true
 strict_equality = true
+# Both of these are mypy 2.x defaults, stated rather than inherited. What the
+# boundary checks should be readable here, not a function of which mypy major
+# the resolver produced -- `local_partial_types` in particular is off under
+# 1.x, so leaving it implicit made the strictness silently version-dependent.
+local_partial_types = true
 strict_bytes = true
 warn_redundant_casts = true
 warn_unused_configs = true

--- a/uv.lock
+++ b/uv.lock
@@ -1070,8 +1070,8 @@ provides-extras = ["science", "chemistry"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=1.14,<3" },
-    { name = "pre-commit", specifier = ">=3.0" },
+    { name = "mypy", specifier = ">=2.3,<3" },
+    { name = "pre-commit", specifier = ">=3.2" },
     { name = "pytest", specifier = ">=7.4" },
 ]
 


### PR DESCRIPTION
Follow-up from the #45…#57 review pass.

Both dev floors currently admit versions that would weaken or break a gate, and **CI cannot catch either**, because every in-repo path goes through `uv sync --locked`. The loose declaration only misleads a contributor who installs from `pyproject.toml` directly — and then gets a weaker check than CI runs.

| declared | becomes | why |
|---|---|---|
| `mypy>=1.14,<3` | `mypy>=2.3,<3` | Dependabot widened the *ceiling* rather than raising the floor when it moved 1.20.2 → 2.3.0 in #50, so the range still admits 1.x — where `local_partial_types` defaults **off**. The strict boundary has only ever been verified under 2.x. |
| `pre-commit>=3.0` | `pre-commit>=3.2` | Two of the pre-commit-hooks hooks (#48) and the isort hooks (#46) now declare `minimum_pre_commit_version: 3.2.0`, which pre-commit validates at manifest load — a hard error, not a skip. The declared floor became unsatisfiable in practice the moment those bumps landed. |

Also adds `local_partial_types = true` to `[tool.mypy]`. It is a mypy 2.x default, so this changes nothing today. The point is that what the strict boundary checks should be readable in the config rather than being a function of which mypy major the resolver produced — the same reason `strict_bytes` is stated explicitly.

## Scope

`uv lock` moves only the two specifier strings in `[package.metadata.requires-dev]`:

```diff
 dev = [
-    { name = "mypy", specifier = ">=1.14,<3" },
-    { name = "pre-commit", specifier = ">=3.0" },
+    { name = "mypy", specifier = ">=2.3,<3" },
+    { name = "pre-commit", specifier = ">=3.2" },
     { name = "pytest", specifier = ">=7.4" },
 ]
```

No resolved version changes — mypy 2.3.0 and pre-commit 4.6.1 already satisfy the new floors.

## Verification

- `uv run mypy` → `Success: no issues found in 6 source files`, with `local_partial_types` now explicit.
- `uv run pre-commit run --all-files` → every hook passes.
- Nothing in `tests/`, `scripts/` or `harness/` asserts on the declared dev-dependency strings, so the change has no test surface beyond the lock consistency CI already enforces.