### PR TITLE
docs(readme): name the originating lab in the citation block

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,11 +243,12 @@ Released under the **MIT License** — see [`LICENSE`](LICENSE).
 
 ```bibtex
 @software{openai4s2026,
-  title  = {OpenAI4S: An Open-Source Code-as-Action Scientific Research Agent},
-  author = {OpenAI4S contributors},
-  year   = {2026},
-  url    = {https://github.com/PKU-YuanGroup/OpenAI4S},
-  note   = {Open AI for Scientist — a pure-stdlib reproduction of the Code-as-Action paradigm}
+  title        = {OpenAI4S: An Open-Source Code-as-Action Scientific Research Agent},
+  author       = {OpenAI4S contributors},
+  organization = {Peking University Shenzhen Graduate School--YuanKong Intelligence AI Agent Joint Research Laboratory},
+  year         = {2026},
+  url          = {https://github.com/PKU-YuanGroup/OpenAI4S},
+  note         = {Open AI for Scientist — a pure-stdlib reproduction of the Code-as-Action paradigm}
 }
 ```
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -227,11 +227,12 @@ uv run pre-commit run --all-files   # 全量格式化 + lint
 
 ```bibtex
 @software{openai4s2026,
-  title  = {OpenAI4S: An Open-Source Code-as-Action Scientific Research Agent},
-  author = {OpenAI4S contributors},
-  year   = {2026},
-  url    = {https://github.com/PKU-YuanGroup/OpenAI4S},
-  note   = {Open AI for Scientist —— 对 Code-as-Action 范式的纯标准库开源复现}
+  title        = {OpenAI4S: An Open-Source Code-as-Action Scientific Research Agent},
+  author       = {OpenAI4S contributors},
+  organization = {Peking University Shenzhen Graduate School--YuanKong Intelligence AI Agent Joint Research Laboratory},
+  year         = {2026},
+  url          = {https://github.com/PKU-YuanGroup/OpenAI4S},
+  note         = {Open AI for Scientist —— 对 Code-as-Action 范式的纯标准库开源复现}
 }
 ```
 


### PR DESCRIPTION
Follow-up from the #45…#57 review pass.

#53 added the lab credit to the header of both READMEs, but the BibTeX entry twelve lines below it still reads:

```bibtex
author = {OpenAI4S contributors},
```

with no affiliation. So the one place where the attribution actually has to *travel* — someone else's bibliography — still cites this project as unaffiliated. Adds `organization` to both entries, using the wording #53 settled on.

## Two deliberate details

- **`--` rather than `–`.** That is BibTeX's own encoding for an en dash. A raw U+2013 in a `.bib` file breaks a non-UTF-8 LaTeX pipeline and buys nothing, since the renderer produces the same glyph from `--`.
- **Both files get the identical English entry.** A BibTeX record is not translated; `README_zh.md` already carries the same English `title` and `author`, and only the `note` differs.

Field alignment is widened so the block stays readable with the longer key.

## Verification

- `uv run python scripts/check_directory_readmes.py` → `100 maintained directories, 731 direct files/assets, complete bilingual coverage`.
- `uv run pre-commit run --all-files` → every hook passes.
- Heading counts stay 18/18 across the two files; the change is entirely inside a fenced code block, so no rendered structure moves.