### PR TITLE
fix(release): stop anchoring the Linux bundle to PyPI, which can never hold it

### DIFF
--- a/scripts/release_pipeline.py
+++ b/scripts/release_pipeline.py
@@ -1305,9 +1305,24 @@ class Pipeline:
         # would still self-validate while PyPI already holds the first run's
         # bytes. PyPI is immutable per version, so it is the anchor: every Python
         # distribution the draft would publish must be on PyPI with a matching
-        # digest. Only wheels and sdists live on PyPI — the dmg, sbom, provenance
-        # and SHA256SUMS are GitHub-only and are not expected there.
-        draft_dists = {name for name in checked if name.endswith((".whl", ".tar.gz"))}
+        # digest. Only wheels and the sdist live on PyPI — the dmg, the Linux
+        # tarball, the Windows zip, sbom, provenance and SHA256SUMS are
+        # GitHub-only and are not expected there.
+        #
+        # The sdist is matched by exact name rather than by `.tar.gz`, because
+        # it is no longer the only tarball on a draft: the Linux desktop bundle
+        # is `OpenAI4S-<version>-linux-<arch>.tar.gz`. Suffix-matching swept it
+        # into the anchor set, where it could never be satisfied — PyPI cannot
+        # hold that filename — so `finalize` would refuse to flip the draft
+        # *after* the immutable PyPI version had already been consumed.
+        #
+        # Case matters and is the whole reason this is `==` and not a
+        # case-folded prefix test: PEP 625 names the sdist `openai4s-...` while
+        # the bundle is `OpenAI4S-...`. The two differ only in case.
+        sdist_name = f"openai4s-{self.version}.tar.gz"
+        draft_dists = {
+            name for name in checked if name.endswith(".whl") or name == sdist_name
+        }
         published = self._pypi_digests("openai4s", self.version)
         if not published:
             # Fail closed: an empty response is not "everything matches". The

--- a/tests/test_release_pipeline.py
+++ b/tests/test_release_pipeline.py
@@ -1188,6 +1188,72 @@ def test_finalize_refuses_a_draft_that_dropped_only_the_wheel(assets):
     assert wheel.name in report["steps"][-1]["detail"]
 
 
+def test_finalize_anchors_only_python_distributions_not_every_tarball(assets):
+    """The desktop bundles ride on the draft; PyPI can never hold them.
+
+    The anchor set was `endswith((".whl", ".tar.gz"))`, written when the sdist
+    was the only tarball a draft carried. The Linux desktop bundle is
+    `OpenAI4S-<version>-linux-<arch>.tar.gz`, so suffix-matching swept it into
+    a set every member of which must be present on PyPI — a condition it can
+    never satisfy.
+
+    The ordering is what made that fatal rather than annoying: `finalize`
+    `needs: [attach, pypi]`, and `--only publish` runs nowhere else. The
+    immutable PyPI version is consumed first, and only then does the flip
+    refuse, leaving the GitHub release a permanent draft that re-staging
+    reproduces exactly.
+
+    Note the Linux bundle differs from the sdist only in case
+    (`OpenAI4S-` vs PEP 625's `openai4s-`), which is why the fix compares the
+    sdist name exactly instead of case-folding a prefix.
+    """
+    _signed_dmg(assets)
+    (assets / "OpenAI4S-0.2.0-linux-x86_64.tar.gz").write_bytes(b"linux-bundle")
+    (assets / "OpenAI4S-0.2.0-windows-x86_64.zip").write_bytes(b"windows-zip")
+    _write_checksums(assets)
+    wheel = assets / "openai4s-0.2.0-py3-none-any.whl"
+    sdist = assets / "openai4s-0.2.0.tar.gz"
+
+    report = _pipeline(
+        assets,
+        mode="release",
+        only="publish",
+        gh=_gh_for(assets),
+        # PyPI holds exactly what PyPI can hold: the wheel and the sdist.
+        pypi_digests=lambda project, version: {
+            wheel.name: sha256_file(wheel),
+            sdist.name: sha256_file(sdist),
+        },
+    ).run()
+
+    assert report["ok"] is True, report["steps"][-1]
+    assert report["published"] is True
+
+
+def test_finalize_still_refuses_when_the_sdist_itself_is_missing_from_pypi(assets):
+    """The narrowed anchor must not become a hole.
+
+    Matching the sdist by exact name rather than by suffix is only safe if the
+    sdist is still anchored. A bundle beside it must not make the check lenient.
+    """
+    _signed_dmg(assets)
+    (assets / "OpenAI4S-0.2.0-linux-x86_64.tar.gz").write_bytes(b"linux-bundle")
+    _write_checksums(assets)
+    wheel = assets / "openai4s-0.2.0-py3-none-any.whl"
+
+    report = _pipeline(
+        assets,
+        mode="release",
+        only="publish",
+        gh=_gh_for(assets),
+        pypi_digests=lambda project, version: {wheel.name: sha256_file(wheel)},
+    ).run()
+
+    assert report["ok"] is False
+    assert report["published"] is False
+    assert "openai4s-0.2.0.tar.gz" in report["steps"][-1]["detail"]
+
+
 def test_finalize_refuses_a_draft_missing_its_checksum_manifest(assets):
     """Without SHA256SUMS there is nothing to re-validate against; publishing
     then would be a blind flip."""


### PR DESCRIPTION
Found by a review pass over #58 (already merged). **This should land before the next release is cut.**

## What breaks

`step_publish` anchors the GitHub draft to PyPI — every Python distribution on the draft must also exist on PyPI with a matching digest. The set was built by suffix:

```python
draft_dists = {name for name in checked if name.endswith((".whl", ".tar.gz"))}
```

which was correct when the sdist was the only tarball a draft carried. #58 now stages `OpenAI4S-<version>-linux-<arch>.tar.gz` (`build_linux_bundle.sh:75`, downloaded into `assets/` by `release.yml`). It is collected (`.gz` ∈ `DISTRIBUTION_SUFFIXES`), checksummed, uploaded, and returned in `checked` — so it landed in an anchor set **every member of which must exist on PyPI**. PyPI can never hold that filename, so the condition is unsatisfiable.

## Why that is worse than a failed job

The ordering is asserted by #58's own new gate: `finalize: needs: [attach, pypi]`, and `--only publish` runs nowhere else. So:

1. `pypi` publishes — the version number is **immutably consumed**
2. `finalize` runs and refuses to flip the draft
3. the GitHub release stays a permanent draft

The error's own suggested remedy ("complete the upload or re-stage the draft") does not work — re-staging reproduces the identical asset set. And `finalize` checks out `ref: ${{ inputs.tag }}`, so fixing this on `main` afterwards is *not* picked up by re-running the workflow at that tag. Recovery would be a hand-run patched script or `gh release edit --draft=false`, bypassing the anchor entirely.

## The fix

The sdist is matched by exact name instead of by suffix. Deliberately `==` and not a case-folded prefix test: PEP 625 names the sdist `openai4s-…` while the bundle is `OpenAI4S-…`, and **they differ only in case**. Verified against the real v0.1.0 release assets (`openai4s-0.1.0.tar.gz` vs `OpenAI4S-0.1.0-macos-arm64.dmg`) and by building an sdist locally.

The dmg and the Windows `.zip` were never affected — only `.tar.gz` collided.

## Tests

Two, and the first was checked against the pre-fix code rather than assumed to be meaningful:

- **`test_finalize_anchors_only_python_distributions_not_every_tarball`** — a draft carrying the Linux tarball and the Windows zip beside the wheel and sdist now publishes. Reverting the one-line change makes it fail with `the GitHub draft and PyPI do not carry the same distributions for 0.2.0`.
- **`test_finalize_still_refuses_when_the_sdist_itself_is_missing_from_pypi`** — narrowing the anchor must not open a hole. With a bundle beside it and the sdist absent from PyPI, publish still refuses.

`uv run pytest tests/test_release_pipeline.py tests/test_release_gates.py` — 103 passed. `uv run pre-commit run --all-files` — every hook passes.

## Why CI could not have caught this

It cannot, structurally: `release.yml` is `workflow_dispatch`-only, and `step_publish` short-circuits under `--dry-run` / `--mode local`, so **no rehearsal can ever exercise the PyPI anchor**. It would have first appeared on a real tag, in the one place where the failure is not recoverable by re-running.

Related: a second #58 defect — `scripts/windows/openai4s.ps1:232` merges `wsl.exe`'s stdout into the function's return value, so the launcher reports failure after a successful install — is filed separately.