### PR TITLE
fix(windows): stop wsl.exe's stdout becoming the launcher's return value

### DIFF
--- a/scripts/windows/openai4s.ps1
+++ b/scripts/windows/openai4s.ps1
@@ -229,7 +229,21 @@ function Invoke-Bootstrap([string] $Distro, [string] $BootstrapLinux, [string[]]
     # re-splits it and breaks on the spaces an unzipped Downloads path is full
     # of. `sh <script>` rather than `./<script>` because the package sits on a
     # DrvFs mount, where the executable bit is not reliably honoured.
-    & wsl.exe -d $Distro --exec sh $BootstrapLinux @BootstrapArgs
+    #
+    # `| Out-Host` is load-bearing, not cosmetic. A native command's stdout
+    # goes to the *success stream*, which in PowerShell is the function's
+    # return value -- so without the pipe, `return $LASTEXITCODE` appends to
+    # bootstrap.sh's own output instead of replacing it, and the caller gets
+    # @('installed /home/.../OpenAI4S-...', 0) rather than 0. bootstrap.sh
+    # prints on bare stdout in every success path ("already-installed",
+    # "installed", "serving http://...") and sends failures to stderr, so this
+    # bites precisely when the install *worked*: `$code -ne 0` filters the
+    # array to one non-zero element, `if` reads a non-empty array as true, and
+    # the launcher reports "the Linux bundle could not be installed" after
+    # installing it. `exit $code` then fails to convert Object[] to Int32.
+    # Out-Host keeps $LASTEXITCODE intact and restores the console message the
+    # failure guidance promises the reader.
+    & wsl.exe -d $Distro --exec sh $BootstrapLinux @BootstrapArgs | Out-Host
     return $LASTEXITCODE
 }
 

--- a/tests/test_release_gates.py
+++ b/tests/test_release_gates.py
@@ -414,6 +414,38 @@ def test_the_windows_package_has_no_native_windows_execution_path():
         assert suffix in verifier
 
 
+def test_the_windows_launcher_does_not_leak_native_stdout_into_its_return_value():
+    """A native command's stdout IS the function's return value in PowerShell.
+
+    `& wsl.exe ...` writes to the success stream, so a bare call followed by
+    `return $LASTEXITCODE` returns @('installed /home/.../OpenAI4S-...', 0),
+    not 0. bootstrap.sh prints on stdout in every *success* path
+    ("already-installed", "installed", "serving http://...") and sends
+    failures to stderr, so the defect fires precisely when the install
+    worked: `$code -ne 0` filters the array to its one non-zero element,
+    `if` reads a non-empty array as true, and the launcher reports "the
+    Linux bundle could not be installed" after installing it. `exit $code`
+    then cannot convert Object[] to Int32.
+
+    Pinned statically because nothing executes this: no CI runner has WSL,
+    so `Invoke-Bootstrap` is unreachable even on the windows-latest job,
+    which parses the file and stops.
+    """
+    launcher = (ROOT / "scripts" / "windows" / "openai4s.ps1").read_text("utf-8")
+    calls = [
+        line.strip()
+        for line in launcher.splitlines()
+        if line.lstrip().startswith("& wsl.exe")
+    ]
+
+    assert calls, "the launcher must still go through wsl.exe"
+    for call in calls:
+        assert call.endswith("| Out-Host"), (
+            "a wsl.exe invocation whose value is not captured must pipe to "
+            f"Out-Host, or its stdout becomes part of the return value: {call}"
+        )
+
+
 def test_the_windows_launcher_sources_stay_pure_ascii():
     """Windows PowerShell 5.1 reads a BOM-less .ps1 as ANSI, not UTF-8.
 


### PR DESCRIPTION
Found by a review pass over #58 (already merged). **The Windows package reports "the Linux bundle could not be installed" after installing it successfully — on every machine that actually has WSL2.**

## The defect

In PowerShell a native command's stdout goes to the **success stream**, which is a function's return value. `Invoke-Bootstrap` had:

```powershell
& wsl.exe -d $Distro --exec sh $BootstrapLinux @BootstrapArgs
return $LASTEXITCODE
```

so `return` *appends to* `bootstrap.sh`'s output rather than replacing it. The caller receives `@('installed /home/.../OpenAI4S-...', 0)`, not `0`.

`bootstrap.sh` prints on bare stdout in every **success** path — `already-installed` (`:52`), `installed` (`:87`), `serving http://...` (`:115`) — and sends every failure to stderr. So this fires precisely when the install *worked*:

| step | what happens |
|---|---|
| `$code = Invoke-Bootstrap …` (`:280`) | `$code` is `Object[]`, not `Int32` |
| `if ($code -ne 0)` (`:281`) | array comparison filters to `@(0)`'s complement → one element → non-empty |
| `if` on a non-empty array | **true** |
| `Stop-WithGuidance 'the Linux bundle could not be installed into WSL.'` | exit 1, after a successful install |

The guidance text is itself evidence of the bug: *"The message above says why"* — the message was swallowed into `$code`.

The CLI passthrough breaks harder. `exit $code` at `:267` is handed an `Object[]` and dies on the `Int32` conversion before the passthrough at `:268` ever runs, so `OpenAI4S.cmd status` cannot work at all.

## The fix

`| Out-Host` — one token. It leaves `$LASTEXITCODE` untouched, keeps the return value a plain `Int32`, and puts `bootstrap.sh`'s message back on the console where the guidance already promises the reader it will be. Pure ASCII, so `test_the_windows_launcher_sources_stay_pure_ascii` is unaffected.

## Honest limits of the verification

**This was NOT executed against a real PowerShell** — there is none on this host, and `pwsh` is not installed. The claim rests on documented success-stream semantics plus strong internal corroboration: the launcher itself relies on exactly this behaviour twice on purpose, capturing a native command's stdout with `$x = & native.exe` at `:133` and `:215`.

Repro on any Windows box:

```powershell
function f { & wsl.exe --exec sh -c 'echo installed; exit 0'; return $LASTEXITCODE }
$code = f
$code.Count   # 2, not 1
```

If the analysis is wrong, `| Out-Host` is harmless. If it is right and this ships, the Windows package is broken for its entire intended audience *and* reports "the install failed" after succeeding — the worst possible text for triage.

## Test

`test_the_windows_launcher_does_not_leak_native_stdout_into_its_return_value` asserts every uncaptured `& wsl.exe` call pipes to `Out-Host`. Reverting the one-token change makes it fail. It is a **static** pin on purpose: nothing executes this code — no runner has WSL, so `Invoke-Bootstrap` is unreachable even on the `windows-latest` job, which parses the file and stops at `:121-131`.

`uv run pytest tests/test_release_gates.py` — 31 passed. `uv run pre-commit run --all-files` — every hook passes.

Companion to #67, which fixes the other #58 defect CI structurally cannot reach (the release pipeline's PyPI anchor).