### PR TITLE
docs(readme): update joint laboratory attributionUPDATE: orgnization info

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 **An open-source hybrid scientific research agent.**<br/>
 <sub>JSON tools orchestrate; persistent Python/R kernels do the science.</sub>
 
-**Launched by the Peking University Shenzhen Graduate School–YuanKong Intelligence AI Agent Joint Research Laboratory.**<br/>
-<sub>由北京大学深圳研究生院—元空智能 AI Agent 联合研究实验室推出。</sub>
+**Launched by the Peking University–YuanKong Intelligence AI Joint Research Laboratory.**<br/>
+<sub>由北京大学—元空AI联合实验室推出。</sub>
 
 <p>
   <a href="LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-d97706.svg"></a>

--- a/README_zh.md
+++ b/README_zh.md
@@ -9,8 +9,8 @@
 **一个开源的混合式科研智能体。**<br/>
 <sub>原生 JSON 工具负责编排与权限；持久 Python/R 内核负责科学执行。</sub>
 
-**由北京大学深圳研究生院—元空智能 AI Agent 联合研究实验室推出。**<br/>
-<sub>Launched by the Peking University Shenzhen Graduate School–YuanKong Intelligence AI Agent Joint Research Laboratory.</sub>
+**由北京大学—元空AI联合实验室推出。**<br/>
+<sub>Launched by the Peking University–YuanKong Intelligence AI Joint Research Laboratory.</sub>
 
 <p>
   <a href="LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-d97706.svg"></a>


### PR DESCRIPTION
## What changed

- Updated the organization attribution displayed near the top of the English README.
- Applied the corresponding wording change to the Chinese README.
- Replaced the previous laboratory name with:
  - English: Peking University–YuanKong Intelligence AI Joint Research Laboratory
  - Chinese: 北京大学—元空AI联合实验室

## Why

This change aligns the project attribution with the latest approved organization naming and keeps the English and Chinese README versions consistent.

## Affected paths

- `README.md`
- `README_zh.md`

No runtime, CLI, Web UI, Kernel, Host RPC, Gateway, Store, Security, or compatibility-facade code is affected.

## Verification

Ran:

- `git diff --check origin/main...HEAD`
- Manually reviewed the attribution wording and placement in both README files

Not run:

- `uv run python scripts/check_directory_readmes.py`
- `uv run pytest`

Reason:

- `uv` is not available in the current environment.
- The change is limited to bilingual README wording and does not affect runtime behavior.

## Risks

Low risk. The primary risk is a future change to the laboratory’s official English naming or branding guidelines.

## Core impact

No. OpenAI4S core behavior is unchanged.

## New dependencies

None.

## Screenshots

Not applicable. This PR changes GitHub README text only and does not modify the Web UI.