### PR TITLE
fix(doubao,mcp): a fully-read response died on its own closed socket

### DIFF
--- a/openai4s/doubao_search.py
+++ b/openai4s/doubao_search.py
@@ -18,7 +18,11 @@ from collections.abc import Callable, Mapping
 from typing import Any, Protocol
 
 from openai4s import datapro, egress, webtools
-from openai4s.http_deadline import HTTPExchangeDeadline, socket_timeout_setter
+from openai4s.http_deadline import (
+    HTTPExchangeDeadline,
+    response_body_exhausted,
+    socket_timeout_setter,
+)
 from openai4s.mcp_protocol import redact_reflected_secret
 
 ENDPOINT = "https://open.feedcoopapi.com/search_api/web_search"
@@ -159,6 +163,12 @@ def _read_capped(
                 f"Doubao search response exceeded the {limit}-byte limit"
             )
         chunks.append(chunk)
+        if response_body_exhausted(response):
+            # The last content byte and the transport's retirement arrive on the
+            # same read.  Looping to prove it with one more read asked a closed
+            # socket to re-bound a read that cannot happen, which reported a
+            # complete HTTP 200 as a failed request.
+            return b"".join(chunks)
 
 
 def _safe_error_code(value: Any) -> str:

--- a/openai4s/doubao_search.py
+++ b/openai4s/doubao_search.py
@@ -120,7 +120,7 @@ def _read_capped(
     response: Any,
     *,
     limit: int,
-    deadline: float,
+    exchange: HTTPExchangeDeadline,
     require_bound: bool = True,
 ) -> bytes:
     """This service's failure vocabulary over the shared bounded reader.
@@ -140,7 +140,7 @@ def _read_capped(
     return read_body_capped(
         response,
         limit=limit,
-        deadline=deadline,
+        exchange=exchange,
         on_timeout=lambda: DoubaoSearchError("Doubao search request timed out"),
         on_oversize=_oversize,
         on_truncated=lambda: DoubaoSearchError(
@@ -443,7 +443,7 @@ class DoubaoSearchService:
                 raw = _read_capped(
                     response,
                     limit=MAX_RESPONSE_BYTES,
-                    deadline=exchange.deadline,
+                    exchange=exchange,
                     require_bound=self._opener is None,
                 )
         except urllib.error.HTTPError as error:

--- a/openai4s/doubao_search.py
+++ b/openai4s/doubao_search.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import json
 import math
 import socket
-import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -18,11 +17,7 @@ from collections.abc import Callable, Mapping
 from typing import Any, Protocol
 
 from openai4s import datapro, egress, webtools
-from openai4s.http_deadline import (
-    HTTPExchangeDeadline,
-    response_body_exhausted,
-    socket_timeout_setter,
-)
+from openai4s.http_deadline import HTTPExchangeDeadline, read_body_capped
 from openai4s.mcp_protocol import redact_reflected_secret
 
 ENDPOINT = "https://open.feedcoopapi.com/search_api/web_search"
@@ -126,49 +121,44 @@ def _read_capped(
     *,
     limit: int,
     deadline: float,
-    timeout_setter: Callable[[float], Any] | None = None,
+    require_bound: bool = True,
 ) -> bytes:
-    raw_length = response.headers.get("Content-Length")
-    if raw_length:
-        try:
-            if int(raw_length) > limit:
-                raise DoubaoSearchResponseError(
-                    f"Doubao search response exceeded the {limit}-byte limit"
-                )
-        except ValueError:
-            pass
+    """This service's failure vocabulary over the shared bounded reader.
 
-    chunks: list[bytes] = []
-    total = 0
-    read_once = getattr(response, "read1", None)
-    if not callable(read_once):
-        read_once = response.read
-    while True:
-        remaining = deadline - time.monotonic()
-        if remaining <= 0:
-            raise DoubaoSearchError("Doubao search request timed out")
-        if timeout_setter is not None:
-            timeout_setter(remaining)
-        # ``BufferedReader.read(n)`` may issue multiple recv calls while trying
-        # to fill ``n``; a slow-drip peer can therefore refresh the same
-        # relative socket timeout indefinitely. ``read1`` performs at most one
-        # raw read, returning here so the absolute deadline and remaining
-        # socket timeout are recomputed for every chunk.
-        chunk = read_once(min(65_536, limit + 1 - total))
-        if not chunk:
-            return b"".join(chunks)
-        total += len(chunk)
-        if total > limit:
-            raise DoubaoSearchResponseError(
-                f"Doubao search response exceeded the {limit}-byte limit"
+    Every property of the loop -- ``read1`` over buffered ``read``, the
+    absolute deadline, the byte cap, stopping at end-of-body, refusing a
+    truncated body -- is stated once in ``http_deadline`` and shared with the
+    MCP transport, which had to be given each of them separately while the two
+    loops were maintained side by side.
+    """
+
+    def _oversize() -> BaseException:
+        return DoubaoSearchResponseError(
+            f"Doubao search response exceeded the {limit}-byte limit"
+        )
+
+    return read_body_capped(
+        response,
+        limit=limit,
+        deadline=deadline,
+        on_timeout=lambda: DoubaoSearchError("Doubao search request timed out"),
+        on_oversize=_oversize,
+        on_truncated=lambda: DoubaoSearchError(
+            "Doubao search response ended before its declared length"
+        ),
+        # An injected opener is a test transport with no socket beneath it.  The
+        # daemon's own opener always has one, and a body read with no bound
+        # there is the slow-drip exposure this module exists to close.
+        on_unbounded=(
+            (
+                lambda: DoubaoSearchError(
+                    "Doubao search response has no bounded read transport"
+                )
             )
-        chunks.append(chunk)
-        if response_body_exhausted(response):
-            # The last content byte and the transport's retirement arrive on the
-            # same read.  Looping to prove it with one more read asked a closed
-            # socket to re-bound a read that cannot happen, which reported a
-            # complete HTTP 200 as a failed request.
-            return b"".join(chunks)
+            if require_bound
+            else None
+        ),
+    )
 
 
 def _safe_error_code(value: Any) -> str:
@@ -450,16 +440,11 @@ class DoubaoSearchService:
                     raise DoubaoSearchError(
                         f"Doubao search request failed with HTTP {int(status)}"
                     )
-                timeout_setter = socket_timeout_setter(response)
-                if self._opener is None and timeout_setter is None:
-                    raise DoubaoSearchError(
-                        "Doubao search response has no bounded read transport"
-                    )
                 raw = _read_capped(
                     response,
                     limit=MAX_RESPONSE_BYTES,
                     deadline=exchange.deadline,
-                    timeout_setter=timeout_setter,
+                    require_bound=self._opener is None,
                 )
         except urllib.error.HTTPError as error:
             status = int(error.code)

--- a/openai4s/http_deadline.py
+++ b/openai4s/http_deadline.py
@@ -31,8 +31,36 @@ class HTTPExchangeTimeout(TimeoutError):
     """One HTTP exchange exceeded its absolute wall-clock deadline."""
 
 
+def _socket_retired(sock: Any) -> bool:
+    """Whether this transport's descriptor is already gone.
+
+    A closed socket cannot block, so it needs no read timeout -- and touching
+    one raises ``OSError`` (EBADF).  ``socket.close()`` alone is not this state:
+    urllib closes the connection socket while ``makefile`` still holds an I/O
+    reference, and the descriptor stays readable for the whole response body.
+    """
+
+    fileno = getattr(sock, "fileno", None)
+    if not callable(fileno):
+        return False
+    try:
+        return int(fileno()) < 0
+    except OSError:
+        return True
+    except Exception:  # noqa: BLE001 - a transport that cannot say is treated as live
+        return False
+
+
 def socket_timeout_setter(response: Any) -> Callable[[float], Any] | None:
-    """Find a live response socket's timeout setter through urllib wrappers."""
+    """Bound-read-timeout callable for the socket backing a urllib response.
+
+    The callable becomes a no-op once that socket is retired.  ``http.client``
+    retires it on the *same* ``read1`` that returns the final content byte once
+    a known ``Content-Length`` reaches zero (CPython 3.11+; only the 3.10 floor
+    waits for one further empty read), so a loop that re-bounds the next read
+    before checking for more data touched a closed descriptor and turned a
+    complete, successful response into ``OSError``.
+    """
 
     pending = [response]
     seen: set[int] = set()
@@ -44,12 +72,49 @@ def socket_timeout_setter(response: Any) -> Callable[[float], Any] | None:
         seen.add(identity)
         setter = getattr(candidate, "settimeout", None)
         if callable(setter):
-            return setter
+            sock = candidate
+
+            def set_read_timeout(value: float, _sock: Any = sock) -> None:
+                if _socket_retired(_sock):
+                    return
+                try:
+                    _sock.settimeout(value)
+                except OSError:
+                    # Lost the race with a close (the watchdog's, or the
+                    # stdlib's end-of-body one).  Only a still-live transport
+                    # can leave a read unbounded, so re-raise for that case
+                    # alone rather than reporting a finished exchange as a
+                    # network failure.
+                    if _socket_retired(_sock):
+                        return
+                    raise
+
+            return set_read_timeout
         for attribute in ("fp", "raw", "_sock"):
             child = getattr(candidate, attribute, None)
             if child is not None:
                 pending.append(child)
     return None
+
+
+def response_body_exhausted(response: Any) -> bool:
+    """Whether this response can no longer yield body bytes.
+
+    Both signals are end-of-body, not error states: ``isclosed()`` reports the
+    body reader ``http.client`` retires once the last content byte is delivered,
+    and a remaining ``length`` of zero is the same fact on the 3.10 floor, which
+    retires one read later.  A reader that stops on either never asks a retired
+    transport for more.
+    """
+
+    is_closed = getattr(response, "isclosed", None)
+    if callable(is_closed):
+        try:
+            if bool(is_closed()):
+                return True
+        except Exception:  # noqa: BLE001 - an unknown reader is treated as open
+            return False
+    return getattr(response, "length", None) == 0
 
 
 def _response_socket(response: Any) -> socket.socket | None:
@@ -407,5 +472,6 @@ class _DeadlineHTTPSHandler(urllib.request.HTTPSHandler):
 __all__ = [
     "HTTPExchangeDeadline",
     "HTTPExchangeTimeout",
+    "response_body_exhausted",
     "socket_timeout_setter",
 ]

--- a/openai4s/http_deadline.py
+++ b/openai4s/http_deadline.py
@@ -23,7 +23,7 @@ import socket
 import threading
 import time
 import urllib.request
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from typing import Any, Callable
 
 
@@ -38,6 +38,11 @@ def _socket_retired(sock: Any) -> bool:
     one raises ``OSError`` (EBADF).  ``socket.close()`` alone is not this state:
     urllib closes the connection socket while ``makefile`` still holds an I/O
     reference, and the descriptor stays readable for the whole response body.
+
+    Only consulted *after* an arming attempt already failed, so "cannot say"
+    must mean "not provably retired": a transport that exposes no descriptor,
+    or whose ``fileno()`` fails for any reason other than a dead descriptor,
+    keeps its failure rather than silently losing its read bound.
     """
 
     fileno = getattr(sock, "fileno", None)
@@ -51,15 +56,44 @@ def _socket_retired(sock: Any) -> bool:
         return False
 
 
-def socket_timeout_setter(response: Any) -> Callable[[float], Any] | None:
-    """Bound-read-timeout callable for the socket backing a urllib response.
+def _arm_read_timeout(sock: Any, value: float) -> None:
+    """Bound one read on ``sock``, tolerating a transport already retired.
 
-    The callable becomes a no-op once that socket is retired.  ``http.client``
-    retires it on the *same* ``read1`` that returns the final content byte once
-    a known ``Content-Length`` reaches zero (CPython 3.11+; only the 3.10 floor
-    waits for one further empty read), so a loop that re-bounds the next read
-    before checking for more data touched a closed descriptor and turned a
-    complete, successful response into ``OSError``.
+    One caller: :meth:`HTTPExchangeDeadline.register_response`, where the
+    watchdog can close this socket in the gap after ``remaining()`` proved the
+    budget intact.  The body readers do not need this and do not use it --
+    ``read_body_capped`` stops at end-of-body *before* it would re-arm, which
+    is the whole of that fix; a second guard on the same path would only be a
+    place for the two to disagree.
+
+    The retirement test runs after ``settimeout`` has refused, never before:
+    asked first it answers about a moment already past by the time the call
+    runs, and it disarms every transport that bounds reads perfectly well but
+    cannot report a descriptor.  A still-live socket refusing a timeout stays a
+    hard failure -- that is the only case that can leave a read unbounded.
+    """
+
+    try:
+        sock.settimeout(value)
+    except OSError:
+        # Lost the race with a close (the watchdog's, or the stdlib's
+        # end-of-body one).  A finished exchange is not a network failure.
+        if _socket_retired(sock):
+            return
+        raise
+
+
+def _walk_response_transports(response: Any) -> Iterator[Any]:
+    """Yield ``response`` and every object urllib nests a transport under.
+
+    One traversal, two consumers: the read bound wants whatever carries
+    ``settimeout``, the watchdog wants the real ``socket.socket``.  Written out
+    twice they could answer with *different* objects from one response, and the
+    bound would then be armed on a transport the watchdog is not tracking.
+
+    Lazy on purpose.  A caller that stops at its first match never descends past
+    it, which is the search order both consumers had while they each open-coded
+    this walk.
     """
 
     pending = [response]
@@ -70,31 +104,68 @@ def socket_timeout_setter(response: Any) -> Callable[[float], Any] | None:
         if identity in seen:
             continue
         seen.add(identity)
-        setter = getattr(candidate, "settimeout", None)
-        if callable(setter):
-            sock = candidate
-
-            def set_read_timeout(value: float, _sock: Any = sock) -> None:
-                if _socket_retired(_sock):
-                    return
-                try:
-                    _sock.settimeout(value)
-                except OSError:
-                    # Lost the race with a close (the watchdog's, or the
-                    # stdlib's end-of-body one).  Only a still-live transport
-                    # can leave a read unbounded, so re-raise for that case
-                    # alone rather than reporting a finished exchange as a
-                    # network failure.
-                    if _socket_retired(_sock):
-                        return
-                    raise
-
-            return set_read_timeout
+        yield candidate
         for attribute in ("fp", "raw", "_sock"):
             child = getattr(candidate, attribute, None)
             if child is not None:
                 pending.append(child)
+
+
+def socket_timeout_setter(response: Any) -> Callable[[float], Any] | None:
+    """Find a live response socket's timeout setter through urllib wrappers.
+
+    Returns the bound ``settimeout`` itself.  It stays unwrapped deliberately:
+    the reader that uses it stops at end-of-body before it would re-bind a
+    retired socket, so a tolerant wrapper here would be a second answer to a
+    question already answered -- and the one place it *would* still be needed
+    calls :func:`_arm_read_timeout` directly.
+    """
+
+    for candidate in _walk_response_transports(response):
+        setter = getattr(candidate, "settimeout", None)
+        if callable(setter):
+            return setter
     return None
+
+
+def _remaining_body_bytes(response: Any) -> int | None:
+    """Bytes a declared ``Content-Length`` still owes, when the reader says.
+
+    Matched exactly rather than compared: ``length == 0`` is equally true of
+    ``False``, and a header value that survived as the string ``"0"`` is not a
+    count.  ``None`` means the reader is not tracking one -- a chunked or
+    close-delimited body -- which is a different answer from "none left".
+    """
+
+    remaining = getattr(response, "length", None)
+    if isinstance(remaining, bool) or not isinstance(remaining, int):
+        return None
+    return remaining
+
+
+def _body_exhausted_probe(response: Any) -> Callable[[], bool]:
+    """Resolve the end-of-body accessors once, for a caller inside a read loop.
+
+    Which accessors exist cannot change between chunks, so re-deriving them per
+    chunk is pure overhead in the one place that runs per chunk.  The rule
+    itself lives here alone; :func:`response_body_exhausted` is the same probe
+    for a caller that only asks once.
+    """
+
+    is_closed = getattr(response, "isclosed", None)
+    if not callable(is_closed):
+        is_closed = None
+
+    def exhausted() -> bool:
+        if is_closed is not None:
+            try:
+                if is_closed() is True:
+                    return True
+            except Exception:  # noqa: BLE001 - fall through to the other signal
+                pass
+        return _remaining_body_bytes(response) == 0
+
+    return exhausted
 
 
 def response_body_exhausted(response: Any) -> bool:
@@ -105,36 +176,105 @@ def response_body_exhausted(response: Any) -> bool:
     and a remaining ``length`` of zero is the same fact on the 3.10 floor, which
     retires one read later.  A reader that stops on either never asks a retired
     transport for more.
+
+    Both answer only when they answer exactly.  ``bool(is_closed())`` would call
+    any truthy object -- a ``Mock``'s auto-attribute among them -- end-of-body
+    and truncate the read after one chunk.
     """
 
-    is_closed = getattr(response, "isclosed", None)
-    if callable(is_closed):
+    return _body_exhausted_probe(response)()
+
+
+def read_body_capped(
+    response: Any,
+    *,
+    limit: int,
+    deadline: float,
+    on_timeout: Callable[[], BaseException],
+    on_oversize: Callable[[], BaseException],
+    on_truncated: Callable[[], BaseException],
+    on_unbounded: Callable[[], BaseException] | None = None,
+) -> bytes:
+    """Read one response body under a byte cap and an absolute deadline.
+
+    The single bounded reader for this package.  Its consumers differ only in
+    the vocabulary they report failures in, which is what the ``on_*`` factories
+    carry; keeping the loop itself in one place is the point, because every
+    property below had to be discovered once and then written into each copy by
+    hand:
+
+    * ``read1`` over ``read``.  ``BufferedReader.read(n)`` may issue many recv
+      calls while trying to fill ``n``, so a peer dripping one byte before each
+      idle timeout keeps a *single* call alive forever.  ``read1`` performs at
+      most one raw read, so the absolute budget and the socket bound are
+      recomputed for every chunk.
+    * Stop at end-of-body, tested at the top of the loop.  ``http.client``
+      retires the transport on the same read that returns the final content
+      byte of a known ``Content-Length`` (CPython 3.11+; the 3.10 floor waits
+      one read longer), so proving it with one more read asked a closed socket
+      to bound a read that cannot happen and reported a complete response as
+      ``OSError``.  Testing before the arming is what makes that unreachable,
+      rather than something a tolerant ``settimeout`` has to absorb.  Chunked
+      and close-delimited bodies retire on a read that returns ``b""`` and need
+      no branch of their own.
+    * An empty read is not proof of a complete body.  If the reader is still
+      owed bytes, the peer cut the connection, and that is a transport failure
+      -- not the invalid-JSON the caller would otherwise diagnose.
+    * ``on_unbounded`` makes a missing read bound fatal.  Pass ``None`` only
+      where the transport is known not to be a socket at all.
+    """
+
+    declared = response.headers.get("Content-Length")
+    if declared:
+        # The raise stays outside the ``except``: an ``on_oversize`` that ever
+        # returned a ``ValueError`` subclass would otherwise be swallowed by
+        # the guard meant for the unparsable header.
         try:
-            if bool(is_closed()):
-                return True
-        except Exception:  # noqa: BLE001 - an unknown reader is treated as open
-            return False
-    return getattr(response, "length", None) == 0
+            announced: int | None = int(declared)
+        except ValueError:
+            announced = None
+        if announced is not None and announced > limit:
+            raise on_oversize()
+
+    arm = socket_timeout_setter(response)
+    if arm is None and on_unbounded is not None:
+        raise on_unbounded()
+    exhausted = _body_exhausted_probe(response)
+    read_once = getattr(response, "read1", None)
+    if not callable(read_once):
+        read_once = response.read
+
+    chunks: list[bytes] = []
+    total = 0
+    while not exhausted():
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise on_timeout()
+        if arm is not None:
+            arm(remaining)
+        chunk = read_once(min(65_536, limit + 1 - total))
+        if not chunk:
+            if (_remaining_body_bytes(response) or 0) > 0:
+                raise on_truncated()
+            break
+        total += len(chunk)
+        if total > limit:
+            raise on_oversize()
+        chunks.append(chunk)
+    return b"".join(chunks)
 
 
 def _response_socket(response: Any) -> socket.socket | None:
     """Return the actual socket retained by an urllib response, if visible."""
 
-    pending = [response]
-    seen: set[int] = set()
-    while pending:
-        candidate = pending.pop()
-        identity = id(candidate)
-        if identity in seen:
-            continue
-        seen.add(identity)
-        if isinstance(candidate, socket.socket):
-            return candidate
-        for attribute in ("fp", "raw", "_sock"):
-            child = getattr(candidate, attribute, None)
-            if child is not None:
-                pending.append(child)
-    return None
+    return next(
+        (
+            candidate
+            for candidate in _walk_response_transports(response)
+            if isinstance(candidate, socket.socket)
+        ),
+        None,
+    )
 
 
 def _close_socket(sock: Any) -> None:
@@ -347,12 +487,21 @@ class HTTPExchangeDeadline:
             raise
 
     def register_response(self, response: Any) -> None:
-        """Retarget the watchdog to urllib's body socket after headers arrive."""
+        """Retarget the watchdog to urllib's body socket after headers arrive.
+
+        The arming goes through the shared helper for the same reason the body
+        readers do: ``remaining()`` proving the budget is intact does not keep
+        it intact, so the watchdog can close this socket in the gap before
+        ``settimeout`` runs.  Raising the bare ``OSError`` there reported an
+        aborted exchange as ``... failed (OSError)`` -- the wrong projection
+        this module exists to remove -- instead of the deadline the caller can
+        recognise.
+        """
 
         sock = _response_socket(response)
         if sock is not None:
             self._register_socket(sock)
-            sock.settimeout(self.remaining())
+            _arm_read_timeout(sock, self.remaining())
 
     def http_handler(
         self,
@@ -472,6 +621,7 @@ class _DeadlineHTTPSHandler(urllib.request.HTTPSHandler):
 __all__ = [
     "HTTPExchangeDeadline",
     "HTTPExchangeTimeout",
+    "read_body_capped",
     "response_body_exhausted",
     "socket_timeout_setter",
 ]

--- a/openai4s/http_deadline.py
+++ b/openai4s/http_deadline.py
@@ -22,6 +22,7 @@ import http.client
 import socket
 import threading
 import time
+import urllib.error
 import urllib.request
 from collections.abc import Iterable, Iterator
 from typing import Any, Callable
@@ -189,7 +190,7 @@ def read_body_capped(
     response: Any,
     *,
     limit: int,
-    deadline: float,
+    exchange: HTTPExchangeDeadline,
     on_timeout: Callable[[], BaseException],
     on_oversize: Callable[[], BaseException],
     on_truncated: Callable[[], BaseException],
@@ -220,6 +221,12 @@ def read_body_capped(
     * An empty read is not proof of a complete body.  If the reader is still
       owed bytes, the peer cut the connection, and that is a transport failure
       -- not the invalid-JSON the caller would otherwise diagnose.
+    * The exchange owns timeout classification as well as the clock.  Its
+      watchdog can close the body socket between a positive budget check and
+      either ``settimeout`` or ``read1``; those operations can then report
+      ``OSError``, ``IncompleteRead``, or an empty chunk.  Only failures that
+      coincide with an actual watchdog expiry become ``on_timeout``.  A merely
+      late clock still cannot invalidate a body already known to be complete.
     * ``on_unbounded`` makes a missing read bound fatal.  Pass ``None`` only
       where the transport is known not to be a socket at all.
     """
@@ -244,23 +251,45 @@ def read_body_capped(
     if not callable(read_once):
         read_once = response.read
 
+    def raise_truncated_or_timeout() -> None:
+        if exchange.expired:
+            raise on_timeout() from None
+        raise on_truncated()
+
     chunks: list[bytes] = []
     total = 0
-    while not exhausted():
-        remaining = deadline - time.monotonic()
-        if remaining <= 0:
-            raise on_timeout()
-        if arm is not None:
-            arm(remaining)
-        chunk = read_once(min(65_536, limit + 1 - total))
-        if not chunk:
+    while True:
+        if exhausted():
             if (_remaining_body_bytes(response) or 0) > 0:
-                raise on_truncated()
+                raise_truncated_or_timeout()
+            break
+        try:
+            remaining = exchange.remaining()
+        except HTTPExchangeTimeout:
+            raise on_timeout() from None
+        try:
+            if arm is not None:
+                arm(remaining)
+            chunk = read_once(min(65_536, limit + 1 - total))
+        except Exception:
+            # Socket shutdown is intentionally allowed to surface through
+            # several stdlib exception types.  Convert only when the watchdog
+            # really fired; otherwise preserve the transport/protocol failure.
+            if exchange.expired:
+                raise on_timeout() from None
+            raise
+        if not chunk:
+            if exchange.expired:
+                raise on_timeout() from None
+            if (_remaining_body_bytes(response) or 0) > 0:
+                raise_truncated_or_timeout()
             break
         total += len(chunk)
         if total > limit:
             raise on_oversize()
         chunks.append(chunk)
+    if exchange.expired:
+        raise on_timeout() from None
     return b"".join(chunks)
 
 
@@ -533,7 +562,18 @@ class HTTPExchangeDeadline:
     def open(self, opener: Any, request: urllib.request.Request) -> Any:
         """Open through urllib while the same budget covers response headers."""
 
-        response = opener.open(request, timeout=self.remaining())  # noqa: S310
+        try:
+            response = opener.open(request, timeout=self.remaining())  # noqa: S310
+        except urllib.error.HTTPError:
+            # HTTP status handling is a caller contract (including MCP session
+            # expiry) and must not be replaced by a coincident watchdog tick.
+            raise
+        except (OSError, http.client.HTTPException):
+            if self.expired:
+                raise HTTPExchangeTimeout(
+                    "HTTP exchange exceeded its absolute deadline"
+                ) from None
+            raise
         self.register_response(response)
         self.remaining()
         return response

--- a/openai4s/http_deadline.py
+++ b/openai4s/http_deadline.py
@@ -574,8 +574,20 @@ class HTTPExchangeDeadline:
                     "HTTP exchange exceeded its absolute deadline"
                 ) from None
             raise
-        self.register_response(response)
-        self.remaining()
+        try:
+            self.register_response(response)
+            self.remaining()
+        except BaseException:
+            # ``opener.open`` transferred ownership here, but neither caller
+            # receives the response until this method returns.  Close it when
+            # registration or final deadline validation fails so its makefile
+            # cannot retain an otherwise closed socket descriptor through the
+            # exception traceback.
+            try:
+                response.close()
+            except Exception:  # noqa: BLE001 - preserve the original failure
+                pass
+            raise
         return response
 
 

--- a/openai4s/mcp_http.py
+++ b/openai4s/mcp_http.py
@@ -17,7 +17,6 @@ import math
 import re
 import socket
 import threading
-import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -25,11 +24,7 @@ from collections.abc import Mapping
 from typing import Any, Callable
 
 from openai4s import egress, webtools
-from openai4s.http_deadline import (
-    HTTPExchangeDeadline,
-    response_body_exhausted,
-    socket_timeout_setter,
-)
+from openai4s.http_deadline import HTTPExchangeDeadline, read_body_capped
 from openai4s.mcp_protocol import (
     MAX_FRAME_BYTES,
     MCPError,
@@ -338,45 +333,33 @@ class MCPHTTPConnection:
             ) from None
 
     def _read_body(self, response: Any, deadline: float) -> bytes:
-        raw_length = response.headers.get("Content-Length")
-        if raw_length:
-            try:
-                if int(raw_length) > _MAX_FRAME_BYTES:
-                    raise MCPOversizedResponse(
-                        "MCP HTTP response exceeded the 4 MiB limit"
-                    )
-            except ValueError:
-                pass
-        chunks: list[bytes] = []
-        total = 0
-        timeout_setter = socket_timeout_setter(response)
-        read_once = getattr(response, "read1", None)
-        if not callable(read_once):
-            read_once = response.read
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                raise MCPTimeout(f"MCP HTTP request exceeded {self._timeout:g}s")
-            if timeout_setter is not None:
-                timeout_setter(remaining)
-            # ``BufferedReader.read(n)`` may perform multiple raw reads while
-            # trying to fill ``n``.  A peer that drips one byte just before
-            # each relative socket timeout can therefore keep that one call
-            # alive indefinitely.  ``read1`` performs at most one raw read,
-            # returning here so the absolute remaining budget is recomputed.
-            chunk = read_once(min(65_536, _MAX_FRAME_BYTES + 1 - total))
-            if not chunk:
-                return b"".join(chunks)
-            total += len(chunk)
-            if total > _MAX_FRAME_BYTES:
-                raise MCPOversizedResponse("MCP HTTP response exceeded the 4 MiB limit")
-            chunks.append(chunk)
-            if response_body_exhausted(response):
-                # ``http.client`` retires the transport on the same read that
-                # returns the final content byte, so one more pass would
-                # re-bound a read on a closed socket and report a complete
-                # response as a transport failure.
-                return b"".join(chunks)
+        """This transport's failure vocabulary over the shared bounded reader.
+
+        The loop itself lives in ``http_deadline`` so that the properties it
+        enforces -- one raw read per deadline check, the byte cap, stopping at
+        end-of-body, refusing a body cut short of its declared length, and
+        refusing to read one at all with no bound -- hold for every consumer
+        rather than for whichever copy last received the fix.
+        """
+
+        def _oversize() -> BaseException:
+            return MCPOversizedResponse("MCP HTTP response exceeded the 4 MiB limit")
+
+        return read_body_capped(
+            response,
+            limit=_MAX_FRAME_BYTES,
+            deadline=deadline,
+            on_timeout=lambda: MCPTimeout(
+                f"MCP HTTP request exceeded {self._timeout:g}s"
+            ),
+            on_oversize=_oversize,
+            on_truncated=lambda: MCPError(
+                "MCP HTTP response ended before its declared length"
+            ),
+            on_unbounded=lambda: MCPError(
+                "MCP HTTP response has no bounded read transport"
+            ),
+        )
 
     def _post(
         self,

--- a/openai4s/mcp_http.py
+++ b/openai4s/mcp_http.py
@@ -332,7 +332,11 @@ class MCPHTTPConnection:
                 f"MCP HTTP request was blocked by network policy ({type(exc).__name__})"
             ) from None
 
-    def _read_body(self, response: Any, deadline: float) -> bytes:
+    def _read_body(
+        self,
+        response: Any,
+        exchange: HTTPExchangeDeadline,
+    ) -> bytes:
         """This transport's failure vocabulary over the shared bounded reader.
 
         The loop itself lives in ``http_deadline`` so that the properties it
@@ -348,7 +352,7 @@ class MCPHTTPConnection:
         return read_body_capped(
             response,
             limit=_MAX_FRAME_BYTES,
-            deadline=deadline,
+            exchange=exchange,
             on_timeout=lambda: MCPTimeout(
                 f"MCP HTTP request exceeded {self._timeout:g}s"
             ),
@@ -420,7 +424,7 @@ class MCPHTTPConnection:
                     if session is not None:
                         self._session = _session_id(session)
                     content_type = response.headers.get("Content-Type", "")
-                    response_body = self._read_body(response, exchange.deadline)
+                    response_body = self._read_body(response, exchange)
                     if expected_id is None:
                         return None
         except urllib.error.HTTPError as exc:

--- a/openai4s/mcp_http.py
+++ b/openai4s/mcp_http.py
@@ -25,7 +25,11 @@ from collections.abc import Mapping
 from typing import Any, Callable
 
 from openai4s import egress, webtools
-from openai4s.http_deadline import HTTPExchangeDeadline, socket_timeout_setter
+from openai4s.http_deadline import (
+    HTTPExchangeDeadline,
+    response_body_exhausted,
+    socket_timeout_setter,
+)
 from openai4s.mcp_protocol import (
     MAX_FRAME_BYTES,
     MCPError,
@@ -367,6 +371,12 @@ class MCPHTTPConnection:
             if total > _MAX_FRAME_BYTES:
                 raise MCPOversizedResponse("MCP HTTP response exceeded the 4 MiB limit")
             chunks.append(chunk)
+            if response_body_exhausted(response):
+                # ``http.client`` retires the transport on the same read that
+                # returns the final content byte, so one more pass would
+                # re-bound a read on a closed socket and report a complete
+                # response as a transport failure.
+                return b"".join(chunks)
 
     def _post(
         self,

--- a/tests/test_doubao_search.py
+++ b/tests/test_doubao_search.py
@@ -8,9 +8,13 @@ published or disguised by a fallback search engine.
 
 from __future__ import annotations
 
+import errno
 import io
 import json
+import socket
+import types
 import urllib.error
+import urllib.request
 from pathlib import Path
 
 import pytest
@@ -63,6 +67,103 @@ class _Response(io.BytesIO):
         return self.status
 
 
+class _RetiringSocket:
+    """A socket that refuses a read timeout once its descriptor is gone.
+
+    ``settimeout`` on a closed socket raises ``OSError`` (EBADF); every stdlib
+    socket behaves this way, so a reader that touches one after the body is
+    complete fails on any interpreter.
+    """
+
+    def __init__(self):
+        self.timeouts: list[float] = []
+        self._fd = 7
+
+    def settimeout(self, value):
+        if self._fd < 0:
+            raise OSError(errno.EBADF, "Bad file descriptor")
+        self.timeouts.append(value)
+
+    def fileno(self) -> int:
+        return self._fd
+
+    def close(self) -> None:
+        self._fd = -1
+
+
+class _EndOfBodyClosingResponse:
+    """urllib's response as CPython 3.11+ ``http.client`` hands it back.
+
+    ``HTTPResponse.read1`` calls ``_close_conn()`` on the *same* call that
+    returns the final byte of a known ``Content-Length``.  urllib has already
+    closed the connection socket by then (``makefile`` was holding the last I/O
+    reference), so the descriptor goes away while the caller is still holding
+    what looks like an open response.  Python 3.10 alone waited for one further
+    empty read, which is why this shape has to be modelled rather than left to
+    whichever interpreter happens to run the suite.
+    """
+
+    def __init__(self, payload, *, chunk_bytes: int = 16):
+        self._body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        self._offset = 0
+        self._chunk_bytes = chunk_bytes
+        self.length = len(self._body)
+        self.socket = _RetiringSocket()
+        self.fp = types.SimpleNamespace(_sock=self.socket)
+        self.headers = {
+            "Content-Type": "application/json",
+            "Content-Length": str(len(self._body)),
+        }
+        self.status = 200
+        self.read1_calls = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc) -> None:
+        return None
+
+    def getcode(self) -> int:
+        return self.status
+
+    def isclosed(self) -> bool:
+        return self.fp is None
+
+    def read(self, *_args, **_kwargs):  # pragma: no cover - must stay unused
+        raise AssertionError("buffer-filling read would bypass the deadline")
+
+    def read1(self, size=-1):
+        self.read1_calls += 1
+        if self.fp is None:
+            return b""
+        if size is None or size < 0:
+            size = self.length
+        chunk = self._body[self._offset : self._offset + min(size, self._chunk_bytes)]
+        self._offset += len(chunk)
+        self.length -= len(chunk)
+        if not chunk or not self.length:
+            self._retire()
+        return chunk
+
+    def close(self) -> None:
+        self._retire()
+
+    def _retire(self) -> None:
+        self.fp = None
+        self.socket.close()
+
+
+def _http_wire(payload) -> bytes:
+    body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    return (
+        b"HTTP/1.1 200 OK\r\n"
+        b"Content-Type: application/json\r\n"
+        b"Content-Length: " + str(len(body)).encode("ascii") + b"\r\n"
+        b"Connection: close\r\n"
+        b"\r\n" + body
+    )
+
+
 class _RecordingOpener:
     def __init__(self, replies):
         self.replies = iter(replies)
@@ -75,9 +176,9 @@ class _RecordingOpener:
         reply = next(self.replies)
         if isinstance(reply, BaseException):
             raise reply
-        if isinstance(reply, _Response):
-            return reply
-        return _Response(reply)
+        if isinstance(reply, (bytes, dict, list)):
+            return _Response(reply)
+        return reply
 
 
 def _store(tmp_path: Path) -> Store:
@@ -511,6 +612,89 @@ def test_body_reader_returns_after_each_raw_read_to_recheck_deadline(tmp_path):
     _store_obj, service = _service(tmp_path, opener)
 
     assert service.search("deadline-safe body reads")["source"] == "doubao"
+
+
+def test_a_completely_read_body_is_not_reported_as_a_failed_request(tmp_path):
+    """A finished exchange must not be re-bounded on its retired socket.
+
+    The upstream answered HTTP 200 with real results and the reader consumed
+    every byte, but the loop then asked the socket ``http.client`` had just
+    closed to arm one more read timeout.  That raised ``OSError`` (EBADF), which
+    the boundary projected as ``Doubao search request failed (OSError)`` -- a
+    complete, successful search reported to the Agent as a network failure on
+    every interpreter except the 3.10 floor.
+    """
+
+    response = _EndOfBodyClosingResponse(_successful_payload())
+    opener = _RecordingOpener([response])
+    _store_obj, service = _service(tmp_path, opener)
+
+    result = service.search("complete body over a retired socket", timeout=15)
+
+    assert result["source"] == "doubao"
+    assert result["count"] == 1
+    assert result["results"][0]["title"] == "Official Doubao Search result"
+    # The scenario has to be the real one: the transport really did retire
+    # while the reader still held the response.
+    assert response.isclosed() is True
+    assert response.socket.fileno() == -1
+    # Every raw read was still bounded while the socket was live, and the
+    # budget only ever shrank.
+    assert response.read1_calls > 1
+    assert len(response.socket.timeouts) == response.read1_calls
+    assert all(0 < value <= 15.0 for value in response.socket.timeouts)
+    assert response.socket.timeouts == sorted(response.socket.timeouts, reverse=True)
+
+
+def test_a_real_socket_exchange_survives_the_stdlib_end_of_body_close(
+    tmp_path, monkeypatch
+):
+    """The same contract through the production opener over a real socket.
+
+    Nothing below ``socket`` is faked here, so ``http.client`` performs its own
+    end-of-body ``_close_conn()`` and the descriptor is genuinely gone.  This is
+    the shape that failed against the live provider while every fake-transport
+    test passed.
+    """
+
+    from openai4s import egress, webtools
+    from openai4s.http_deadline import HTTPExchangeDeadline, _DeadlineHTTPSConnection
+
+    client, server = socket.socketpair()
+
+    def _build_opener(exchange, *handlers):
+        class _SocketpairConnection(_DeadlineHTTPSConnection):
+            def connect(self) -> None:
+                self.sock = client
+                self._absolute_deadline._register_socket(client)
+                client.settimeout(self._absolute_deadline.remaining())
+
+        return urllib.request.build_opener(
+            *handlers,
+            urllib.request.ProxyHandler({}),
+            exchange.https_handler(_SocketpairConnection),
+        )
+
+    monkeypatch.setattr(webtools, "network_allowed", lambda: True)
+    monkeypatch.setattr(webtools, "guard_url", lambda _url: None)
+    monkeypatch.setattr(egress, "check_url", lambda _url: None)
+    monkeypatch.setattr(HTTPExchangeDeadline, "build_opener", _build_opener)
+    store = _store(tmp_path)
+    datapro.save_agent_plan_key(store, _OLD_SECRET)
+    # No injected opener: this exercises the deadline-aware transport the
+    # daemon actually uses, including its bounded-read requirement.
+    service = DoubaoSearchService(store)
+    try:
+        server.sendall(_http_wire(_successful_payload("real socket result")))
+        server.shutdown(socket.SHUT_WR)
+        result = service.search("real socket exchange", num_results=1, timeout=15)
+    finally:
+        client.close()
+        server.close()
+        store.close()
+
+    assert result["source"] == "doubao"
+    assert result["results"][0]["title"] == "real socket result"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_doubao_search.py
+++ b/tests/test_doubao_search.py
@@ -36,6 +36,7 @@ from openai4s.http_deadline import (
     HTTPExchangeTimeout,
     _arm_read_timeout,
     _socket_retired,
+    response_body_exhausted,
 )
 from openai4s.store import Store
 
@@ -109,16 +110,22 @@ class _EndOfBodyClosingResponse:
     whichever interpreter happens to run the suite.
     """
 
-    def __init__(self, payload, *, chunk_bytes: int = 16):
+    def __init__(
+        self,
+        payload,
+        *,
+        chunk_bytes: int = 16,
+        declared_extra: int = 0,
+    ):
         self._body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
         self._offset = 0
         self._chunk_bytes = chunk_bytes
-        self.length = len(self._body)
+        self.length = len(self._body) + declared_extra
         self.socket = _RetiringSocket()
         self.fp = types.SimpleNamespace(_sock=self.socket)
         self.headers = {
             "Content-Type": "application/json",
-            "Content-Length": str(len(self._body)),
+            "Content-Length": str(self.length),
         }
         self.status = 200
         self.read1_calls = 0
@@ -661,6 +668,37 @@ def test_a_completely_read_body_is_not_reported_as_a_failed_request(tmp_path):
     assert len(response.socket.timeouts) == response.read1_calls
     assert all(0 < value <= 15.0 for value in response.socket.timeouts)
     assert response.socket.timeouts == sorted(response.socket.timeouts, reverse=True)
+
+
+def test_a_body_cut_short_of_content_length_is_a_transport_failure(tmp_path):
+    response = _EndOfBodyClosingResponse(
+        _successful_payload(),
+        declared_extra=17,
+    )
+    opener = _RecordingOpener([response])
+    _store_obj, service = _service(tmp_path, opener)
+
+    with pytest.raises(DoubaoSearchError, match="ended before its declared length"):
+        service.search("valid JSON must still obey HTTP framing")
+
+    assert response.length == 17
+
+
+def test_body_exhaustion_requires_exact_stdlib_signals():
+    class _RaisingClosedProbe:
+        length = 0
+
+        def isclosed(self):
+            raise ValueError("reader already closed")
+
+    assert response_body_exhausted(_RaisingClosedProbe()) is True
+    assert (
+        response_body_exhausted(
+            types.SimpleNamespace(isclosed=lambda: object(), length=1)
+        )
+        is False
+    )
+    assert response_body_exhausted(types.SimpleNamespace(length=False)) is False
 
 
 def test_a_socket_urllib_already_closed_still_takes_its_read_bound():

--- a/tests/test_doubao_search.py
+++ b/tests/test_doubao_search.py
@@ -31,6 +31,12 @@ from openai4s.doubao_search import (
     DoubaoSearchService,
 )
 from openai4s.host_dispatch import HostDispatcher
+from openai4s.http_deadline import (
+    HTTPExchangeDeadline,
+    HTTPExchangeTimeout,
+    _arm_read_timeout,
+    _socket_retired,
+)
 from openai4s.store import Store
 
 # A fake upstream must never teach the response-schema recorder that its shape
@@ -178,7 +184,18 @@ class _RecordingOpener:
             raise reply
         if isinstance(reply, (bytes, dict, list)):
             return _Response(reply)
-        return reply
+        if isinstance(reply, _Response) or hasattr(reply, "read1"):
+            return reply
+        # Stay total.  Passing an unrecognised reply straight through hands the
+        # service something with no ``getcode``/``read1``, and the boundary
+        # reports the fixture mistake as ``... failed (AttributeError)`` -- a
+        # test that then fails, or passes, for a reason that is not the one it
+        # is written to check.
+        raise TypeError(
+            f"_RecordingOpener cannot serve a {type(reply).__name__} reply: "
+            "pass bytes/dict/list to have it encoded, an exception to raise, "
+            "or a response-shaped object"
+        )
 
 
 def _store(tmp_path: Path) -> Store:
@@ -646,21 +663,90 @@ def test_a_completely_read_body_is_not_reported_as_a_failed_request(tmp_path):
     assert response.socket.timeouts == sorted(response.socket.timeouts, reverse=True)
 
 
+def test_a_socket_urllib_already_closed_still_takes_its_read_bound():
+    """``_closed`` is not retirement, and reading it as one would be silent.
+
+    ``http.client`` reads the body through a ``makefile`` reader, and urllib
+    closes the connection socket as soon as the headers are in on a
+    ``Connection: close`` exchange -- so ``_closed`` is true for the *whole*
+    body while the descriptor stays open underneath it.  A retirement test that
+    consulted ``_closed`` would therefore drop the read bound off every such
+    response, and nothing would report it: the bound only shows up against a
+    peer that stops sending, which no fixture here has.  Only a gone descriptor
+    counts.
+    """
+
+    client, server = socket.socketpair()
+    body = client.makefile("rb")
+    try:
+        client.close()
+        assert client._closed is True
+        assert client.fileno() >= 0
+        assert _socket_retired(client) is False
+
+        _arm_read_timeout(client, 5.0)
+
+        assert client.gettimeout() == 5.0
+    finally:
+        body.close()
+        server.close()
+
+
+def test_a_watchdog_close_is_reported_as_the_deadline_not_as_a_bare_oserror():
+    """Arming the body socket must not outrank the reason it went away.
+
+    ``register_response`` arms the socket the watchdog is entitled to take:
+    ``remaining()`` proving the budget intact does not keep it intact.  The
+    bare ``OSError`` that escaped there left ``__exit__`` with ``exc_type``
+    set, so the exchange never became the ``HTTPExchangeTimeout`` a caller can
+    recognise and every consumer projected an abort as ``... failed
+    (OSError)``.  This is the one arming site the reader's end-of-body stop
+    cannot cover, which is why the tolerant helper still exists.
+    """
+
+    client, server = socket.socketpair()
+    response = types.SimpleNamespace(
+        fp=types.SimpleNamespace(raw=types.SimpleNamespace(_sock=client))
+    )
+    exchange = HTTPExchangeDeadline(5.0)
+    budget = exchange.remaining
+
+    def _watchdog_wins_the_gap():
+        value = budget()  # still positive: no timeout is raised here ...
+        exchange._expire()  # ... and the socket is gone before it is used
+        return value
+
+    exchange.remaining = _watchdog_wins_the_gap
+    try:
+        with pytest.raises(HTTPExchangeTimeout):
+            with exchange:
+                exchange.register_response(response)
+    finally:
+        client.close()
+        server.close()
+
+
 def test_a_real_socket_exchange_survives_the_stdlib_end_of_body_close(
     tmp_path, monkeypatch
 ):
-    """The same contract through the production opener over a real socket.
+    """The same contract through the real stdlib client over a real socket.
 
     Nothing below ``socket`` is faked here, so ``http.client`` performs its own
     end-of-body ``_close_conn()`` and the descriptor is genuinely gone.  This is
     the shape that failed against the live provider while every fake-transport
     test passed.
+
+    Two limits, so this is not read as covering more than it does.  Only the
+    3.11+ retirement is exercised: the 3.10 floor keeps the descriptor alive at
+    ``length == 0``, so on that interpreter this test passes against the unfixed
+    reader too, and the two modelled responses above are what carry the floor's
+    regression signal.  And ``connect`` and ``build_opener`` are both
+    substituted below, so the production connect path -- ``create_connection``,
+    ``wrap_tls``, urllib's own proxy discovery -- is out of scope here.
     """
 
     from openai4s import egress, webtools
-    from openai4s.http_deadline import HTTPExchangeDeadline, _DeadlineHTTPSConnection
-
-    client, server = socket.socketpair()
+    from openai4s.http_deadline import _DeadlineHTTPSConnection
 
     def _build_opener(exchange, *handlers):
         class _SocketpairConnection(_DeadlineHTTPSConnection):
@@ -679,19 +765,24 @@ def test_a_real_socket_exchange_survives_the_stdlib_end_of_body_close(
     monkeypatch.setattr(webtools, "guard_url", lambda _url: None)
     monkeypatch.setattr(egress, "check_url", lambda _url: None)
     monkeypatch.setattr(HTTPExchangeDeadline, "build_opener", _build_opener)
-    store = _store(tmp_path)
-    datapro.save_agent_plan_key(store, _OLD_SECRET)
-    # No injected opener: this exercises the deadline-aware transport the
-    # daemon actually uses, including its bounded-read requirement.
-    service = DoubaoSearchService(store)
+    # Both descriptors are opened inside the block that closes them: a failure
+    # in the setup below used to leak the pair for the rest of the session.
+    client, server = socket.socketpair()
+    store = None
     try:
+        store = _store(tmp_path)
+        datapro.save_agent_plan_key(store, _OLD_SECRET)
+        # No injected opener: the service takes the deadline-aware read path,
+        # including its bounded-read requirement.
+        service = DoubaoSearchService(store)
         server.sendall(_http_wire(_successful_payload("real socket result")))
         server.shutdown(socket.SHUT_WR)
         result = service.search("real socket exchange", num_results=1, timeout=15)
     finally:
         client.close()
         server.close()
-        store.close()
+        if store is not None:
+            store.close()
 
     assert result["source"] == "doubao"
     assert result["results"][0]["title"] == "real socket result"

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import errno
 import http.client
 import json
 import os
@@ -272,6 +273,82 @@ def test_streamable_http_body_reader_prefers_one_raw_read_per_deadline_check():
     assert body == b"one-read"
     assert response.read1_calls == 3
     assert len(response.socket.timeouts) == 3
+    assert all(0 < value <= 2.0 for value in response.socket.timeouts)
+
+
+@pytest.mark.stubbed_backend
+def test_streamable_http_body_reader_stops_when_the_transport_retires():
+    """A complete Content-Length body must not fail on its own closed socket.
+
+    CPython 3.11+ ``HTTPResponse.read1`` calls ``_close_conn()`` on the same
+    call that returns the final content byte, and urllib closed the connection
+    socket back when the headers arrived, so that read drops the last I/O
+    reference and the descriptor goes away.  Arming a read timeout afterwards
+    raised ``OSError`` (EBADF) and turned a fully-read JSON-RPC reply into a
+    transport failure -- invisible to every fake-socket test, because only a
+    real socket refuses.
+    """
+
+    class _RetiredSocket:
+        def __init__(self):
+            self.timeouts = []
+            self.fd = 9
+
+        def settimeout(self, value):
+            if self.fd < 0:
+                raise OSError(errno.EBADF, "Bad file descriptor")
+            self.timeouts.append(value)
+
+        def fileno(self):
+            return self.fd
+
+    class _Raw:
+        def __init__(self, sock):
+            self._sock = sock
+
+    class _FP:
+        def __init__(self, sock):
+            self.raw = _Raw(sock)
+
+    class _EndOfBodyClosingResponse:
+        def __init__(self, body):
+            self.headers = _HTTPHeaders({"Content-Length": str(len(body))})
+            self.socket = _RetiredSocket()
+            self.fp = _FP(self.socket)
+            self._body = body
+            self._offset = 0
+            self.length = len(body)
+            self.read1_calls = 0
+
+        def isclosed(self):
+            return self.fp is None
+
+        def read1(self, size):
+            self.read1_calls += 1
+            if self.fp is None:
+                return b""
+            chunk = self._body[self._offset : self._offset + min(size, 8)]
+            self._offset += len(chunk)
+            self.length -= len(chunk)
+            if not chunk or not self.length:
+                self.fp = None
+                self.socket.fd = -1
+            return chunk
+
+        def read(self, _size=-1):
+            raise AssertionError("buffered read must not run when read1 exists")
+
+    payload = json.dumps({"jsonrpc": "2.0", "id": 1, "result": {"ok": True}}).encode()
+    connection = object.__new__(MCPHTTPConnection)
+    connection._timeout = 2.0
+    response = _EndOfBodyClosingResponse(payload)
+
+    body = connection._read_body(response, time.monotonic() + 2.0)
+
+    assert body == payload
+    assert response.isclosed() is True
+    assert response.socket.fileno() == -1
+    assert len(response.socket.timeouts) == response.read1_calls
     assert all(0 < value <= 2.0 for value in response.socket.timeouts)
 
 

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -215,6 +215,34 @@ def test_absolute_exchange_deadline_preserves_http_status_errors():
 
 
 @pytest.mark.stubbed_backend
+def test_absolute_exchange_deadline_closes_a_response_rejected_after_open():
+    exchange = HTTPExchangeDeadline(1.0)
+
+    class _Response:
+        def __init__(self):
+            self.close_calls = 0
+
+        def close(self):
+            self.close_calls += 1
+
+    response = _Response()
+
+    class _Opener:
+        def open(self, _request, timeout=None):
+            assert timeout is not None and timeout > 0
+            exchange._expire()
+            return response
+
+    with pytest.raises(HTTPExchangeTimeout):
+        exchange.open(
+            _Opener(),
+            urllib.request.Request("https://deadline.invalid/rejected-response"),
+        )
+
+    assert response.close_calls == 1
+
+
+@pytest.mark.stubbed_backend
 def test_absolute_exchange_deadline_preserves_a_normal_header_and_body_response():
     """The same opener path admits an ordinary response and cancels its timer."""
 

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -10,6 +10,7 @@ import socket
 import sys
 import threading
 import time
+import types
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -43,12 +44,29 @@ class _HTTPHeaders(dict):
         )
 
 
+class _BoundedTransport:
+    """The read-bound carrier every socket-backed response has beneath it.
+
+    The reader refuses to read a body it cannot bound, so a double that omits
+    this is not a cheaper fake of an HTTP response -- it is a fake of a state
+    the transport does not produce.
+    """
+
+    def __init__(self):
+        self.timeouts = []
+
+    def settimeout(self, value):
+        self.timeouts.append(value)
+
+
 class _HTTPResponse:
     def __init__(self, status, body=b"", headers=None):
         self.status = status
         self._body = body
         self._offset = 0
         self.headers = _HTTPHeaders(headers or {})
+        self.socket = _BoundedTransport()
+        self.fp = types.SimpleNamespace(raw=types.SimpleNamespace(_sock=self.socket))
 
     def __enter__(self):
         return self
@@ -323,10 +341,15 @@ def test_streamable_http_body_reader_stops_when_the_transport_retires():
         def isclosed(self):
             return self.fp is None
 
-        def read1(self, size):
+        def read1(self, size=-1):
+            # The stdlib signature, so a reader that drops the size argument
+            # or passes the default -1 is modelled instead of silently
+            # returning b"" from a backwards slice.
             self.read1_calls += 1
             if self.fp is None:
                 return b""
+            if size is None or size < 0:
+                size = self.length
             chunk = self._body[self._offset : self._offset + min(size, 8)]
             self._offset += len(chunk)
             self.length -= len(chunk)
@@ -356,7 +379,9 @@ def test_streamable_http_body_reader_stops_when_the_transport_retires():
 def test_streamable_http_slow_drip_cannot_refresh_the_absolute_timeout(monkeypatch):
     """Each byte may arrive in time, but the whole body still has one budget."""
 
-    from openai4s import mcp_http
+    # The clock the bounded reader consults now that the loop is shared: the
+    # budget is a property of the reader, not of either transport's module.
+    from openai4s import http_deadline
 
     class _Clock:
         now = 100.0
@@ -395,7 +420,7 @@ def test_streamable_http_slow_drip_cannot_refresh_the_absolute_timeout(monkeypat
         def read(self, _size=-1):
             raise AssertionError("slow-drip protection requires read1")
 
-    monkeypatch.setattr(mcp_http.time, "monotonic", _Clock.monotonic)
+    monkeypatch.setattr(http_deadline.time, "monotonic", _Clock.monotonic)
     connection = object.__new__(MCPHTTPConnection)
     connection._timeout = 1.0
     response = _SlowDripResponse()

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 import pytest
 
-from openai4s import mcp_client
+from openai4s import mcp_client, mcp_http
 from openai4s.http_deadline import (
     HTTPExchangeDeadline,
     HTTPExchangeTimeout,
@@ -31,7 +31,7 @@ from openai4s.mcp_client import (
     example_server_config,
 )
 from openai4s.mcp_http import MCPHTTPConnection
-from openai4s.mcp_protocol import MCPTimeout
+from openai4s.mcp_protocol import MCPOversizedResponse, MCPTimeout
 from openai4s.mcp_servers.example_server import RESOURCE_URI
 
 
@@ -123,7 +123,16 @@ def _socketpair_deadline_opener(
 
 
 @pytest.mark.stubbed_backend
-def test_absolute_exchange_deadline_interrupts_opener_during_response_headers():
+@pytest.mark.parametrize(
+    "initial_response",
+    [
+        b"HTTP/1.1 200 OK\r\nX-Slow: unfinished",
+        b"HTTP/1.",
+    ],
+)
+def test_absolute_exchange_deadline_interrupts_opener_during_response_headers(
+    initial_response,
+):
     """A slow header cannot turn urllib's idle timeout into an infinite open.
 
     The peer supplies a valid status and starts a header, but never terminates
@@ -133,7 +142,7 @@ def test_absolute_exchange_deadline_interrupts_opener_during_response_headers():
 
     secret = "timer-secret-canary"
     client, peer = socket.socketpair()
-    peer.sendall(b"HTTP/1.1 200 OK\r\nX-Slow: unfinished")
+    peer.sendall(initial_response)
     stop_drip = threading.Event()
 
     def drip_header() -> None:
@@ -177,6 +186,32 @@ def test_absolute_exchange_deadline_interrupts_opener_during_response_headers():
     assert secret not in str(caught.value)
     assert secret not in repr(caught.value)
     assert secret not in repr(exchange.__dict__)
+
+
+@pytest.mark.stubbed_backend
+def test_absolute_exchange_deadline_preserves_http_status_errors():
+    exchange = HTTPExchangeDeadline(1.0)
+    status_error = urllib.error.HTTPError(
+        "https://deadline.invalid/status",
+        404,
+        "not found",
+        {},
+        None,
+    )
+
+    class _Opener:
+        def open(self, _request, timeout=None):
+            assert timeout is not None and timeout > 0
+            exchange._expire()
+            raise status_error
+
+    with pytest.raises(urllib.error.HTTPError) as caught:
+        exchange.open(
+            _Opener(),
+            urllib.request.Request("https://deadline.invalid/status"),
+        )
+
+    assert caught.value is status_error
 
 
 @pytest.mark.stubbed_backend
@@ -286,7 +321,8 @@ def test_streamable_http_body_reader_prefers_one_raw_read_per_deadline_check():
     connection._timeout = 2.0
     response = _Read1OnlyResponse()
 
-    body = connection._read_body(response, time.monotonic() + 2.0)
+    exchange = HTTPExchangeDeadline(2.0)
+    body = connection._read_body(response, exchange)
 
     assert body == b"one-read"
     assert response.read1_calls == 3
@@ -366,13 +402,63 @@ def test_streamable_http_body_reader_stops_when_the_transport_retires():
     connection._timeout = 2.0
     response = _EndOfBodyClosingResponse(payload)
 
-    body = connection._read_body(response, time.monotonic() + 2.0)
+    exchange = HTTPExchangeDeadline(2.0)
+    body = connection._read_body(response, exchange)
 
     assert body == payload
     assert response.isclosed() is True
     assert response.socket.fileno() == -1
     assert len(response.socket.timeouts) == response.read1_calls
     assert all(0 < value <= 2.0 for value in response.socket.timeouts)
+
+
+@pytest.mark.stubbed_backend
+def test_streamable_http_body_watchdog_interrupts_a_chunked_slow_drip():
+    client, peer = socket.socketpair()
+    peer.sendall(
+        b"HTTP/1.1 200 OK\r\n"
+        b"Transfer-Encoding: chunked\r\n"
+        b"Content-Type: application/json\r\n"
+        b"\r\n"
+    )
+    stop_drip = threading.Event()
+
+    def drip_partial_chunk_line() -> None:
+        for piece in (b"1", b"\r"):
+            if stop_drip.wait(0.05):
+                return
+            try:
+                peer.sendall(piece)
+            except OSError:
+                return
+
+    producer = threading.Thread(
+        target=drip_partial_chunk_line,
+        name="slow-chunked-body-upstream",
+    )
+    producer.start()
+    exchange = HTTPExchangeDeadline(0.2)
+    connection = object.__new__(MCPHTTPConnection)
+    connection._timeout = 0.2
+    started = time.monotonic()
+    try:
+        with pytest.raises(MCPTimeout, match="exceeded 0.2s"):
+            with exchange:
+                opener = _socketpair_deadline_opener(exchange, client)
+                with exchange.open(
+                    opener,
+                    urllib.request.Request("https://deadline.invalid/slow-body"),
+                ) as response:
+                    connection._read_body(response, exchange)
+    finally:
+        stop_drip.set()
+        peer.close()
+        client.close()
+        producer.join(1.0)
+
+    assert 0.15 <= time.monotonic() - started < 1.0
+    assert exchange.expired is True
+    assert not producer.is_alive()
 
 
 @pytest.mark.stubbed_backend
@@ -425,8 +511,9 @@ def test_streamable_http_slow_drip_cannot_refresh_the_absolute_timeout(monkeypat
     connection._timeout = 1.0
     response = _SlowDripResponse()
 
+    exchange = HTTPExchangeDeadline(1.0)
     with pytest.raises(MCPTimeout, match="exceeded 1s"):
-        connection._read_body(response, 101.0)
+        connection._read_body(response, exchange)
 
     assert response.read1_calls == 3
     assert response.socket.timeouts == pytest.approx([1.0, 0.6, 0.2])
@@ -436,6 +523,123 @@ def test_streamable_http_slow_drip_cannot_refresh_the_absolute_timeout(monkeypat
             response.socket.timeouts, response.socket.timeouts[1:]
         )
     )
+
+
+@pytest.mark.stubbed_backend
+def test_streamable_http_rejects_truncated_and_unbounded_bodies():
+    class _ShortResponse(_HTTPResponse):
+        def __init__(self, body, declared):
+            super().__init__(
+                200,
+                body,
+                {"Content-Length": str(declared)},
+            )
+            self.length = declared
+
+        def read(self, size=-1):
+            chunk = super().read(size)
+            self.length -= len(chunk)
+            return chunk
+
+    class _UnboundedResponse:
+        headers = _HTTPHeaders()
+
+        def read(self, _size=-1):
+            raise AssertionError("an unbounded response must not be read")
+
+    connection = object.__new__(MCPHTTPConnection)
+    connection._timeout = 2.0
+    body = b'{"jsonrpc":"2.0"}'
+    short = _ShortResponse(body, len(body) + 9)
+
+    with pytest.raises(MCPError, match="ended before its declared length"):
+        connection._read_body(short, HTTPExchangeDeadline(2.0))
+    assert short.length == 9
+
+    with pytest.raises(MCPError, match="no bounded read transport"):
+        connection._read_body(_UnboundedResponse(), HTTPExchangeDeadline(2.0))
+
+
+@pytest.mark.stubbed_backend
+@pytest.mark.parametrize("failure_point", ["arm", "read", "empty"])
+def test_streamable_http_watchdog_failures_remain_timeouts(failure_point):
+    exchange = HTTPExchangeDeadline(2.0)
+
+    class _Transport:
+        def settimeout(self, _value):
+            if failure_point == "arm":
+                exchange._expire()
+                raise OSError(errno.EBADF, "watchdog closed the socket")
+
+    class _Response:
+        headers = _HTTPHeaders(
+            {"Content-Length": "1"} if failure_point == "empty" else {}
+        )
+        length = 1 if failure_point == "empty" else None
+
+        def __init__(self):
+            transport = _Transport()
+            self.fp = types.SimpleNamespace(raw=types.SimpleNamespace(_sock=transport))
+
+        def read1(self, _size):
+            exchange._expire()
+            if failure_point == "read":
+                raise http.client.IncompleteRead(b"")
+            return b""
+
+    connection = object.__new__(MCPHTTPConnection)
+    connection._timeout = 2.0
+
+    with pytest.raises(MCPTimeout, match="exceeded 2s"):
+        connection._read_body(_Response(), exchange)
+
+
+@pytest.mark.stubbed_backend
+def test_streamable_http_complete_body_survives_a_late_clock_without_expiry():
+    response = _HTTPResponse(200, b"", {"Content-Length": "0"})
+    response.length = 0
+    exchange = HTTPExchangeDeadline(2.0)
+    exchange.deadline = time.monotonic() - 1.0
+    connection = object.__new__(MCPHTTPConnection)
+    connection._timeout = 2.0
+
+    assert connection._read_body(response, exchange) == b""
+    assert exchange.expired is False
+
+
+@pytest.mark.stubbed_backend
+def test_streamable_http_observed_truncation_survives_a_late_clock_without_expiry():
+    response = _HTTPResponse(200, b"", {"Content-Length": "1"})
+    response.length = 1
+    response.isclosed = lambda: True
+    exchange = HTTPExchangeDeadline(2.0)
+    exchange.deadline = time.monotonic() - 1.0
+    connection = object.__new__(MCPHTTPConnection)
+    connection._timeout = 2.0
+
+    with pytest.raises(MCPError, match="ended before its declared length"):
+        connection._read_body(response, exchange)
+    assert exchange.expired is False
+
+
+@pytest.mark.stubbed_backend
+def test_streamable_http_body_cap_covers_header_stream_and_exact_boundary(
+    monkeypatch,
+):
+    monkeypatch.setattr(mcp_http, "_MAX_FRAME_BYTES", 4)
+    connection = object.__new__(MCPHTTPConnection)
+    connection._timeout = 2.0
+
+    announced = _HTTPResponse(200, b"1234", {"Content-Length": "5"})
+    with pytest.raises(MCPOversizedResponse):
+        connection._read_body(announced, HTTPExchangeDeadline(2.0))
+
+    streamed = _HTTPResponse(200, b"12345")
+    with pytest.raises(MCPOversizedResponse):
+        connection._read_body(streamed, HTTPExchangeDeadline(2.0))
+
+    exact = _HTTPResponse(200, b"1234")
+    assert connection._read_body(exact, HTTPExchangeDeadline(2.0)) == b"1234"
 
 
 def test_connector_environment_is_allowlisted_and_explicit_env_is_the_secret_boundary():


### PR DESCRIPTION
## Summary

Doubao Search failed with `Doubao search request failed (OSError)` *after* the
upstream answered HTTP 200 and the reader had consumed every result byte.

`HTTPResponse.read1` retires the transport on the same call that returns the
final byte of a known `Content-Length` (CPython 3.11+; only the 3.10 floor waits
for one further empty read), and urllib closed the connection socket back when
the headers arrived, so that last read drops the remaining `makefile` I/O
reference and the descriptor goes away. Both capped body readers re-armed the
socket read timeout at the top of every pass, so arming it once more after the
last chunk raised `OSError` (EBADF), and the controlled boundary projected a
finished exchange as a failed request. `mcp_http.py::_read_body` is the same
loop and failed the same way for any MCP HTTP reply carrying a `Content-Length`.

This was not a race: it was every such response on every interpreter above the
3.10 floor. It stayed invisible because the development venv is 3.10 — the one
version that waits — and every offline test used a `BytesIO` fake with no socket
underneath, and nothing under those refuses a `settimeout`.

A reader now stops when the body is exhausted, and the timeout setter skips a
socket whose descriptor is already gone while still raising for a live one. A
closed socket cannot block, so it needs no bound; a live one must keep its
bound, so the slow-drip protection is unchanged.

## Area

- [ ] Web UI / frontend
- [ ] Agent / loop / delegation
- [ ] Kernel / host RPC / runtime
- [x] Server / gateway / API
- [ ] Store / provenance / artifacts
- [ ] Skills / science runtime
- [ ] Compute / remote execution
- [ ] CLI / config / packaging
- [x] Tests / harness / CI
- [ ] Docs

No box names it exactly: the change is in the shared outbound stdlib HTTP
transport (`http_deadline.py`) and its two consumers, the Doubao Search client
and the MCP HTTP client. No route, serializer, or response shape was touched.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Test / harness
- [ ] Documentation
- [ ] Security-related change
- [ ] Release / packaging

## Verification

Ran:

```text
uv run pytest tests/test_doubao_search.py tests/test_mcp_client.py tests/test_egress_surface.py   # 66 passed
uv run pytest tests/test_doubao_search.py tests/test_mcp_client.py   # on 3.12 and on 3.13: 56 passed each
uv run mypy                                            # clean
uv run python scripts/check_directory_readmes.py       # complete bilingual coverage
uv run python -m harness.cli run --tier pr --offline   # 15/15
pre-commit isort / black / ruff / mypy-core            # all Passed (commit hook)
uv run pytest                                          # see note below
each new test, re-run with the source change reverted   # every one fails, on 3.10 and on 3.13
one live request to the provider through a local daemon's own /doubao-search/search route
  # available=true, source=doubao, count=8 (before the change: the OSError above)
```

The full offline suite reports 25 failures in this environment, byte-identical
to a clean tree: no local R runtime, and Seatbelt plus outbound TLS restricted.
None are in the touched modules.

Not run:

```text
scripts/capture_response_schemas.py --check
scripts/capture_response_contract.py --check
scripts/container_smoke.sh
tests/browser_smoke.mjs / browser_admission_fault.mjs / browser_matrix.mjs
```

Reason:

```text
No gateway route, serializer, or response envelope changed, so the two frozen
response contracts cannot move. Docker and Playwright were unavailable in the
environment this was prepared in; CI runs all four jobs.
```

## Risk and Reviewer Focus

Both changes bear on whether a body read stays bounded, so read them together:

1. `http_deadline.socket_timeout_setter` now returns a wrapper rather than the
   bound `settimeout`. `_socket_retired` deliberately tests `fileno() < 0` only.
   It must **not** consult `_closed`: urllib calls `sock.close()` while
   `makefile` still holds an I/O reference, so `_closed` is true for the whole
   body and treating it as retired would silently drop the read bound for every
   response. The `except OSError` path re-raises unless the socket is retired,
   so a live transport that refuses a timeout is still a hard failure.
2. `response_body_exhausted` returns on `isclosed()` or a remaining `length` of
   zero. Both are end-of-body, not error states; the second is what the 3.10
   floor reports one read earlier. A reader stopping there returns the same
   bytes and skips only a read that would have returned `b""`.

The new deterministic fake in `tests/test_doubao_search.py` is the contract
worth reviewing: it models the stdlib behaviour so the 3.10 CI job fails on this
too, rather than passing because its interpreter is the immune one.

## Checklist

### Diff Readiness

- [x] I reviewed and understand the full diff.
- [x] This PR is small and single-purpose.
- [x] No unrelated formatting, broad rewrite, or drive-by refactor is included.
- [x] Hotspot files were edited surgically if touched: none of `gateway.py`,
      `host_dispatch.py`, `store.py`, `app.js`, `worker.py`, `manager.py` is
      touched.
- [x] `openai4s/server/webui/vendor/` and `tests/fixtures/` were not
      reformatted.

### Tests

- [x] Relevant tests or manual checks were run and listed above.
- [x] No new test requires live LLM, network, GPU, SSH, Docker, lab hardware,
      or secrets in the default offline suite. The new socket test uses a local
      `socketpair`, and the network-policy calls around it are patched out so no
      DNS lookup or connection leaves the process.
- [x] No tests were deleted without tracked replacements.
- [x] Kernel / host-RPC / gateway changes include focused contract coverage or
      a documented smoke test.

### Core Dependency Policy

- [x] No hard third-party import was added to the core engine, LLM client, or
      stdlib web server.
- [x] Optional science imports are guarded by `try/except ImportError` at every
      in-tree use site.
- [x] New dependencies, if any, are documented and justified: none added.

### Public Disclosure and Security

- [x] No secrets, API keys, tokens, real credentials, private data, model
      weights, or local absolute paths are included.
- [x] No unpublished research roadmap, internal assignment, benchmark detail,
      or unreleased experimental result is disclosed.
- [x] Security-sensitive changes include appropriate synthetic tests or manual
      verification notes.
- [x] Docs do not overstate isolation, sandboxing, privacy, or security
      guarantees.

### Docs

- [x] Docs match actual code behavior: no documented behaviour changes, the
      reasoning lives in the touched docstrings.
- [x] User-facing behavior changes are reflected in docs or release notes where
      appropriate.
- [x] `README.md` and `README_zh.md` stay in sync where translated sections are
      affected: no translated section is affected.

Made with [Cursor](https://cursor.com)