### PR TITLE
fix(team,orchestration,kernel): the defects a max-effort review found

### DIFF
--- a/docs/plan-crosswalk.json
+++ b/docs/plan-crosswalk.json
@@ -149,7 +149,7 @@
       "tests": "tests/test_compute_owner_and_harvest.py,tests/test_compute_harvest_safety.py,tests/test_artifact_scope_closure.py,tests/test_materialisation_atomicity.py",
       "browser_evidence": "",
       "external_evidence": "",
-      "evidence_digest": "3986e2a5927d9a747e365a13e2cba9829f1965a4c8d96cceff7e2b5b23497359"
+      "evidence_digest": "c486248a50380f9698f135a6f658eb2c2df8cfaaed6c84ccd149bd41e018d32d"
     },
     {
       "source": "R2",
@@ -524,7 +524,7 @@
       "tests": "tests/test_public_exception_projector.py",
       "browser_evidence": "",
       "external_evidence": "",
-      "evidence_digest": "736afa942985e7f56b1c887a9428972da21d43b72775672f079bd5cc6f507f7c"
+      "evidence_digest": "2c803240bb401db1406857d9ed478607a17cc53632f85f44351bce8e08d1dba9"
     },
     {
       "source": "R5",
@@ -593,7 +593,7 @@
       "tests": "tests/test_artifact_scope_closure.py",
       "browser_evidence": "",
       "external_evidence": "",
-      "evidence_digest": "531ec346056953cfc093292b169b339a42f02d83c5d0617d7bafa875c36e8110"
+      "evidence_digest": "d8c2d62117a0eb8cd24fef4dae743a54e2cfce73a0dd829caeea68ac5c0090da"
     },
     {
       "source": "R6",
@@ -607,7 +607,7 @@
       "tests": "tests/test_artifact_scope_closure.py,tests/test_materialisation_atomicity.py,tests/test_model_profile_identity.py,tests/test_compute_owner_and_harvest.py,tests/test_upload_scope_resolution.py",
       "browser_evidence": "",
       "external_evidence": "",
-      "evidence_digest": "b5cb389c0692ae2732bb8302dce059bb46d0f061e66d6f46c9cdf7efa259aa54"
+      "evidence_digest": "2539931c7aefd485e4feee37910f49d347984c5b33e87120062826fdcfa4cd4c"
     },
     {
       "source": "R6",
@@ -718,7 +718,7 @@
       "tests": "tests/test_public_exception_projector.py",
       "browser_evidence": "",
       "external_evidence": "",
-      "evidence_digest": "736afa942985e7f56b1c887a9428972da21d43b72775672f079bd5cc6f507f7c"
+      "evidence_digest": "2c803240bb401db1406857d9ed478607a17cc53632f85f44351bce8e08d1dba9"
     },
     {
       "source": "R7",

--- a/docs/response-schemas.json
+++ b/docs/response-schemas.json
@@ -11911,7 +11911,10 @@
                 "type": "integer"
               },
               "ended_reason": {
-                "type": "null"
+                "type": [
+                  "null",
+                  "string"
+                ]
               },
               "env": {
                 "properties": {
@@ -31065,6 +31068,158 @@
           "error",
           "request_id",
           "status"
+        ],
+        "type": "object"
+      }
+    },
+    "POST /sessions/([^/]+)/compute [ok]": {
+      "schema": {
+        "properties": {
+          "allocation": {
+            "properties": {
+              "allocation_id": {
+                "type": "string"
+              },
+              "epoch": {
+                "type": "integer"
+              },
+              "phase": {
+                "type": "string"
+              },
+              "reason": {
+                "type": "null"
+              }
+            },
+            "required": [
+              "allocation_id",
+              "epoch",
+              "phase",
+              "reason"
+            ],
+            "type": [
+              "null",
+              "object"
+            ]
+          },
+          "lease": {
+            "properties": {
+              "created_at": {
+                "type": "integer"
+              },
+              "idle_ttl_s": {
+                "type": "integer"
+              },
+              "last_active_at": {
+                "type": "integer"
+              },
+              "max_lifetime_s": {
+                "type": "integer"
+              },
+              "released_at": {
+                "type": "null"
+              }
+            },
+            "required": [
+              "created_at",
+              "idle_ttl_s",
+              "last_active_at",
+              "max_lifetime_s",
+              "released_at"
+            ],
+            "type": "object"
+          },
+          "location": {
+            "type": "string"
+          },
+          "readiness": {
+            "properties": {
+              "allocation_granted": {
+                "type": "boolean"
+              },
+              "blocked_on": {
+                "type": "string"
+              },
+              "kernel_ready": {
+                "type": "boolean"
+              },
+              "ready": {
+                "type": "boolean"
+              },
+              "worker_registered": {
+                "type": "boolean"
+              },
+              "workers_expected": {
+                "type": "integer"
+              },
+              "workers_registered": {
+                "type": "integer"
+              },
+              "workspace_ready": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "allocation_granted",
+              "blocked_on",
+              "kernel_ready",
+              "ready",
+              "worker_registered",
+              "workers_expected",
+              "workers_registered",
+              "workspace_ready"
+            ],
+            "type": "object"
+          },
+          "session_id": {
+            "type": "string"
+          },
+          "state_lost_epochs": {
+            "type": "array"
+          },
+          "workload": {
+            "properties": {
+              "desired_state": {
+                "type": "string"
+              },
+              "execution_epoch": {
+                "type": "integer"
+              },
+              "id": {
+                "type": "string"
+              },
+              "phase": {
+                "type": "string"
+              },
+              "profile": {
+                "type": "string"
+              },
+              "reason": {
+                "type": "null"
+              },
+              "recovery": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "desired_state",
+              "execution_epoch",
+              "id",
+              "phase",
+              "profile",
+              "reason",
+              "recovery"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "allocation",
+          "lease",
+          "location",
+          "readiness",
+          "session_id",
+          "state_lost_epochs",
+          "workload"
         ],
         "type": "object"
       }

--- a/docs/team-server.md
+++ b/docs/team-server.md
@@ -50,6 +50,16 @@ An admin reading a private session writes a `admin_read_private` row to
 the audit log. That is the whole of what admin access costs, and it is
 per view rather than per session.
 
+Read access is not namespace control. For a project-visible session, only
+its owner or an admin may Start, Stop, or Restart the Notebook kernel,
+interrupt or cancel an active execution, switch its runtime environment,
+or release its interactive compute allocation. Requesting interactive compute
+is stricter — admin only —
+because the scheduler uses the daemon's identity and site credential.
+Installing packages through either the global or frame-scoped kernel route
+is also admin only: both mutate a runtime environment shared by the instance,
+even when the frame belongs to the caller.
+
 Quotas are set per user or per project, per kind, per window:
 
 ```bash
@@ -92,19 +102,23 @@ operator's regardless of who is logged in:
 - the legacy compute-job runner (`/compute/jobs`), which executes
   `bash -c <command>` as the daemon's own uid — reads included, since a
   job's row is somebody's command line;
-- submitting a batch job to the **`local` backend**
-  (`POST /orchestration/jobs`), for the same reason: it runs the argv as
-  the daemon, outside the kernel sandbox. Members keep the *cluster*
-  backends, where the scheduler runs the job under their own account —
-  the privilege is a property of the backend, not of the route, so
-  `{"backend": "cluster"}` is a member's call and `{"backend": "local"}`
-  is not;
+- submitting a batch job to either built-in backend
+  (`POST /orchestration/jobs`). `local` runs the argv as the daemon,
+  outside the kernel sandbox; `cluster` invokes the scheduler with the
+  daemon's Unix identity and site credential. OpenAI4S has no authenticated
+  mapping from a browser member to a scheduler account, so neither backend
+  may be treated as that member's own execution identity;
+- requesting interactive cluster placement for a session
+  (`POST /sessions/{id}/compute`), which invokes the same daemon-managed
+  scheduler identity. The session owner may release an existing allocation,
+  but only an admin may request one;
 - registering remote compute, installing packages into the venv every
-  kernel shares, configuring connectors that carry the group's
-  credentials, publishing skills into the directory every member's agent
-  loads recipes from, resetting standing permission rules, and creating a
-  *global* permission rule (a member may create rules scoped to their own
-  session or a project they participate in).
+  kernel shares (through `/kernel/install` or
+  `/frames/{fid}/kernel/install`), configuring connectors that carry the
+  group's credentials, publishing skills into the directory every member's
+  agent loads recipes from, resetting standing permission rules, and
+  creating a *global* permission rule (a member may create rules scoped to
+  their own session or a project they participate in).
 
 Members keep every read the UI needs. The full list is
 `openai4s/server/team_policy.py`, and a route not on it is a member's.
@@ -231,14 +245,13 @@ supported ways to reach it from elsewhere, in order of preference:
    is exposed, authentication is your existing SSH setup, and there is no
    new component to operate.
 2. **Reverse proxy with TLS** on the lab network, with team mode on. The
-   proxy terminates TLS and forwards to loopback; the `Host` allowlist
-   stays on, and it is built from `OPENAI4S_HOST` plus `127.0.0.1`,
-   `localhost` and `::1` — there is no separate list to add names to. So
-   either set `OPENAI4S_HOST` to the hostname the proxy forwards (the
-   daemon still binds only that address) or configure the proxy to rewrite
-   `Host` to `127.0.0.1:8760`. A proxy that passes the client's `Host`
-   through unchanged to a loopback daemon gets `403 host not allowed` on
-   every request.
+   proxy terminates TLS and forwards to loopback. Keep `OPENAI4S_HOST` at
+   `127.0.0.1`; it is the daemon's **bind address**, not an extra allowlist.
+   Configure the proxy to rewrite `Host` to the exact loopback upstream,
+   for example `127.0.0.1:8760`. A proxy that passes the client's `Host`
+   through unchanged gets `403 host not allowed` on every request. Setting
+   `OPENAI4S_HOST` to a proxy hostname can make the daemon bind beyond
+   loopback and is not a supported way to admit that hostname.
 
 **The relay is not a third way to run a lab server.** `openai4s relay` and
 `openai4s share` exist for a different purpose — a read-only, redacted

--- a/docs/team-server.md
+++ b/docs/team-server.md
@@ -232,8 +232,13 @@ supported ways to reach it from elsewhere, in order of preference:
    new component to operate.
 2. **Reverse proxy with TLS** on the lab network, with team mode on. The
    proxy terminates TLS and forwards to loopback; the `Host` allowlist
-   stays on, so you must include the proxy's hostname in
-   `OPENAI4S_ALLOWED_HOSTS`.
+   stays on, and it is built from `OPENAI4S_HOST` plus `127.0.0.1`,
+   `localhost` and `::1` — there is no separate list to add names to. So
+   either set `OPENAI4S_HOST` to the hostname the proxy forwards (the
+   daemon still binds only that address) or configure the proxy to rewrite
+   `Host` to `127.0.0.1:8760`. A proxy that passes the client's `Host`
+   through unchanged to a loopback daemon gets `403 host not allowed` on
+   every request.
 
 **The relay is not a third way to run a lab server.** `openai4s relay` and
 `openai4s share` exist for a different purpose — a read-only, redacted

--- a/docs/team-server_zh.md
+++ b/docs/team-server_zh.md
@@ -123,7 +123,7 @@ export OPENAI4S_WORKER_ADVERTISE=head01.lab     # 告诉它们去拨哪里
 daemon 默认绑 loopback，这也是推荐做法。从别处访问，两条受支持的路，按优先级：
 
 1. **SSH 隧道。** `ssh -N -L 8760:127.0.0.1:8760 you@lab-host`。什么都不暴露，鉴权用你已有的 SSH 配置，也没有新组件要运维。
-2. **实验室网内带 TLS 的反向代理**，并打开团队模式。代理终结 TLS 后转发到 loopback；`Host` 白名单仍然生效，所以要把代理的主机名加进 `OPENAI4S_ALLOWED_HOSTS`。
+2. **实验室网内带 TLS 的反向代理**，并打开团队模式。代理终结 TLS 后转发到 loopback；`Host` 白名单仍然生效，而这份白名单是由 `OPENAI4S_HOST` 加上 `127.0.0.1`、`localhost`、`::1` 组成的，并没有另一个可以往里加名字的变量。所以要么把 `OPENAI4S_HOST` 设成代理转发过来的主机名（daemon 仍然只绑这一个地址），要么让代理把 `Host` 改写成 `127.0.0.1:8760`。如果代理原样透传客户端的 `Host`，每个请求都会拿到 `403 host not allowed`。
 
 **relay 不是跑实验室服务器的第三条路。** `openai4s relay` 与 `openai4s share` 是另一件事——**单个**会话的只读、已脱敏快照，经由 daemon 主动拨出的隧道发送（见 [`webshare.md`](webshare.md)）。relay 看得到明文，而 share 投影刻意不是一个登录面：它不带 cookie、没有写路由、也没有活的内核。把它指向团队部署，得到的是某一个会话的投影，而不是把工作台开出去。
 

--- a/docs/team-server_zh.md
+++ b/docs/team-server_zh.md
@@ -29,6 +29,8 @@ loopback CLI 按决策 D2 等同管理员——能读到宿主上 access-token �
 
 管理员读一个 private 会话会往审计日志写一行 `admin_read_private`。这就是管理员权限的全部代价，而且是**每次查看**一行而不是每个会话一行。
 
+读权限不等于命名空间控制权。对于项目内可见的会话，只有会话属主或管理员可以启动、停止、重启 Notebook kernel，中断或取消 active execution，切换 runtime environment，或释放交互式算力分配。请求交互式算力更严格——仅管理员可做——因为调度器使用的是 daemon 身份与站点凭据。通过全局或 frame-scoped kernel 路由安装包也仅管理员可做：即使 frame 属于调用者，两条路由改动的都是实例共享的运行环境。
+
 配额按用户或项目、按种类、按窗口设置：
 
 ```bash
@@ -54,8 +56,9 @@ export OPENAI4S_DATA_ROOTS=/lab/datasets=ro:/lab/scratch
 
 - 写实例配置——LLM 提供方、它的端点与凭据、模型 profile、默认模型。改一下 `llm_base_url`，全员的流量就指向了写的人选的主机；
 - 旧的 compute-job 运行器（`/compute/jobs`），它以 daemon 自己的 uid 执行 `bash -c <command>`——读也不给，因为一条作业行就是某个人敲下的命令；
-- 向 **`local` backend** 提交批处理作业（`POST /orchestration/jobs`），理由相同：它以 daemon 的身份、在 kernel 沙箱之外执行该 argv。成员保留*集群* backend，因为调度器会以成员自己的账号运行作业——特权属于 backend 而非路由，所以 `{"backend": "cluster"}` 是成员可以做的，`{"backend": "local"}` 不是；
-- 注册远程算力、往所有内核共用的 venv 里装包、配置携带组凭据的连接器、往每位成员的 agent 都会加载的目录里发布 skill、重置常设权限规则，以及创建**全局**权限规则（成员可以为自己的会话、或自己参与的项目建规则）。
+- 向任一内置 backend 提交批处理作业（`POST /orchestration/jobs`）。`local` 以 daemon 身份、在 kernel 沙箱之外执行 argv；`cluster` 则用 daemon 的 Unix 身份和站点凭据调用调度器。OpenAI4S 没有经过鉴权的“浏览器成员 → 调度器账号”映射，因此两种 backend 都不能当作该成员自己的执行身份；
+- 为会话请求交互式集群放置（`POST /sessions/{id}/compute`），它调用的是同一套 daemon 管理的调度器身份。会话属主可以释放一份已有的分配，但只有管理员可以请求分配；
+- 注册远程算力、通过 `/kernel/install` 或 `/frames/{fid}/kernel/install` 往所有内核共用的 venv 里装包、配置携带组凭据的连接器、往每位成员的 agent 都会加载的目录里发布 skill、重置常设权限规则，以及创建**全局**权限规则（成员可以为自己的会话、或自己参与的项目建规则）。
 
 成员保留 UI 需要的每一项读取。完整清单在 `openai4s/server/team_policy.py`；不在其上的路由就是成员的。
 
@@ -123,7 +126,7 @@ export OPENAI4S_WORKER_ADVERTISE=head01.lab     # 告诉它们去拨哪里
 daemon 默认绑 loopback，这也是推荐做法。从别处访问，两条受支持的路，按优先级：
 
 1. **SSH 隧道。** `ssh -N -L 8760:127.0.0.1:8760 you@lab-host`。什么都不暴露，鉴权用你已有的 SSH 配置，也没有新组件要运维。
-2. **实验室网内带 TLS 的反向代理**，并打开团队模式。代理终结 TLS 后转发到 loopback；`Host` 白名单仍然生效，而这份白名单是由 `OPENAI4S_HOST` 加上 `127.0.0.1`、`localhost`、`::1` 组成的，并没有另一个可以往里加名字的变量。所以要么把 `OPENAI4S_HOST` 设成代理转发过来的主机名（daemon 仍然只绑这一个地址），要么让代理把 `Host` 改写成 `127.0.0.1:8760`。如果代理原样透传客户端的 `Host`，每个请求都会拿到 `403 host not allowed`。
+2. **实验室网内带 TLS 的反向代理**，并打开团队模式。代理终结 TLS 后转发到 loopback。保持 `OPENAI4S_HOST=127.0.0.1`：它是 daemon 的**绑定地址**，不是额外白名单。代理必须把 `Host` 改写为确切的 loopback upstream，例如 `127.0.0.1:8760`。如果原样透传客户端的 `Host`，每个请求都会拿到 `403 host not allowed`。把 `OPENAI4S_HOST` 设成代理主机名可能使 daemon 绑定到 loopback 之外，不是放行该主机名的支持方式。
 
 **relay 不是跑实验室服务器的第三条路。** `openai4s relay` 与 `openai4s share` 是另一件事——**单个**会话的只读、已脱敏快照，经由 daemon 主动拨出的隧道发送（见 [`webshare.md`](webshare.md)）。relay 看得到明文，而 share 投影刻意不是一个登录面：它不带 cookie、没有写路由、也没有活的内核。把它指向团队部署，得到的是某一个会话的投影，而不是把工作台开出去。
 

--- a/docs/webapp-api.md
+++ b/docs/webapp-api.md
@@ -360,14 +360,14 @@ Nothing here submits synchronously. A request writes a durable row; the reconcil
 
 | Method & path | Behavior |
 | --- | --- |
-| `POST /orchestration/jobs` | Body `{command: [...], profile?, backend?, workdir?, environment?, project_id?}`. `202 {id, phase, ...}` — accepted, not started; `201` would promise a resource that has not been granted. `command` **must** be a list: a string is refused with `400 invalid_command`, because splitting a command line is where quoting bugs become injection. Unknown profile → `400 unknown_profile`; unknown backend → `400 unknown_backend` with the available ones. In team mode the `local` backend is **admin only** (`403 admin_only`, with the refused `backend` named) — see below. |
+| `POST /orchestration/jobs` | Body `{command: [...], profile?, backend?, workdir?, environment?, project_id?}`. `202 {id, phase, ...}` — accepted, not started; `201` would promise a resource that has not been granted. `command` **must** be a list: a string is refused with `400 invalid_command`, because splitting a command line is where quoting bugs become injection. Unknown profile → `400 unknown_profile`; unknown backend → `400 unknown_backend` with the available ones. In team mode both built-in backends are **admin only** (`403 admin_only`, with the refused `backend` named) — see below. |
 | `GET /orchestration/jobs` | `{jobs: [...]}`, filtered to the caller's own unless they are an admin. `project_id`, `limit` and `all=0` (hide terminal) narrow it. |
 | `GET /orchestration/jobs/{id}` | One job plus its `allocation` (the live attempt) and `allocations` (every epoch). Someone else's job is `404`, not `403` — which jobs exist is itself information about what a colleague is working on. |
 | `POST /orchestration/jobs/{id}/cancel` | Records the desire to stop and returns `{ok, reason}`; the reconciler runs the cancel barrier. `409 already_final` when the job has already ended. An admin cancelling another user's job is recorded as `ADMIN_CANCELLED` rather than `USER_CANCELLED`. |
 | `GET /orchestration/jobs/{id}/logs` | `{allocation_id, stdout, stderr}` — the tail (64 KiB) of what the job wrote. |
 | `GET /orchestration/profiles` | `{cluster, configured, profiles: [{name, cpus, memory_mb, gpus, walltime_s, nodes}]}`. The queue and service-class each profile maps to are **not** in this payload: they live in `cluster.toml` and nowhere else. |
 
-**Which backends a member may name.** Privilege here is a property of the *backend*, not of the route. A scheduler backend hands the work to the site's scheduler, which runs it under the submitting user's own account and accounting — so a member submitting to a cluster is submitting as themselves, and keeps it. The built-in `local` backend runs `Popen(argv)` as the **daemon's** uid, outside the kernel sandbox, with the daemon's filesystem access: in team mode that is every tenant's sessions, the access-token file and the group LLM credential. It is therefore admin only, by the same rule that makes `/compute/jobs` admin only.
+**Which backends a member may name.** Neither built-in backend is available to a member in team mode. `local` runs `Popen(argv)` as the **daemon's** uid, outside the kernel sandbox, with the daemon's filesystem access. `cluster` invokes the scheduler with the daemon's Unix identity and site credential; OpenAI4S has no authenticated mapping from a browser member to a scheduler account. Both therefore spend or expose instance resources and are admin only, by the same rule that makes `/compute/jobs` admin only.
 
 The check runs *after* the backend name is validated and *before* anything is written, so a misspelled backend still reads as `400 unknown_backend` rather than a permission problem, and a refused submission leaves no workload row and no audit entry behind.
 
@@ -382,8 +382,8 @@ A session's kernel is on the daemon by default. Asking for it to be on a granted
 | Method & path | Behavior |
 | --- | --- |
 | `GET /sessions/{id}/compute` | `{session_id, location}` — `location:"local"` with `workload:null` when this session runs on the daemon, which is the default and is not an error. On a cluster session: `readiness:{ready, blocked_on, allocation_granted, worker_registered, workspace_ready, kernel_ready}`, `workload:{id, profile, phase, desired_state, reason, execution_epoch}`, `allocation:{allocation_id, epoch, phase, reason}`, `lease:{idle_ttl_s, max_lifetime_s, last_active_at, created_at, released_at}`, and `state_lost_epochs` — the epochs whose kernel memory was lost to a node failure. Someone else's session is `404`, not `403`. |
-| `POST /sessions/{id}/compute` | Body `{profile}`. `201` with the same status payload. A profile the operator has not configured is `400 unknown_profile` rather than a guess: guessing is how a session lands on resources its owner never chose. A daemon with no worker listener answers `409 not_configured` and says which variable turns one on — the feature is off by default because a listener on every laptop that will never run a cluster job is an attack surface, not a convenience. |
-| `POST /sessions/{id}/compute/release` | Records the desire to stop and ends the lease; the reconciler runs the cancel barrier. `{ok, session_id}`. |
+| `POST /sessions/{id}/compute` | Body `{profile}`. `201` with the same status payload. A profile the operator has not configured is `400 unknown_profile` rather than a guess: guessing is how a session lands on resources its owner never chose. A daemon with no worker listener answers `409 not_configured` and says which variable turns one on — the feature is off by default because a listener on every laptop that will never run a cluster job is an attack surface, not a convenience. In team mode this request is **admin only**: the scheduler is invoked with daemon-managed identity or credentials, not an authenticated account belonging to the browser member. |
+| `POST /sessions/{id}/compute/release` | Records the desire to stop and ends the lease; the reconciler runs the cancel barrier. `{ok, session_id}`. In team mode only the session owner or an admin may release it; project visibility alone does not confer control of another user's allocation. |
 
 `state_lost_epochs` is what the UI turns into a banner. When a node dies the kernel's memory dies with it — variables, imports, the seed somebody set three cells ago — and the session continues on a new epoch. Saying so is mandatory (INV-11): the results afterwards look exactly like results from the session that was lost.
 
@@ -417,14 +417,14 @@ The first Agent/user Cell starts only the selected language; a native-tool or
 | --- | --- |
 | `GET /frames/{fid}/execution-log` | `{"kernels":[id…],"entries":[cell…]}`; entries include stable `producing_cell_id`, `cell_index`, session-monotonic `state_revision`, attempt-derived `generation_id` (nullable for legacy rows or when no worker was acquired), `kernel_id`, `language`, `origin`, source/output/error, files/figures, usage, and immutable retry metadata when recorded. |
 | `POST /frames/{fid}/kernel/execute` | Body `{code,language?,execution_id?,wait?}` where language is `python` (default) or `r`; the shipped UI supplies a portable execution ID. Default/`wait:false` returns HTTP 202 `{status:"accepted",job_id,execution_id,owner,queue_position}` immediately, so a queued cell remains addressable. `wait:true` blocks for the completed FIFO-owned Cell result. Execution always appends and never edits history. |
-| `POST /frames/{fid}/kernel/restart` | → `{"ok":true,"status":"restarted","generation","generation_id","frame_id"}` + `kernel_status` WS event. |
-| `POST /frames/{fid}/kernel/stop` | → `{"ok":true,"state":"stopped"|"none","frame_id"}`. |
-| `POST /frames/{fid}/kernel/start` | → `{"ok":true,"state":"running","generation","frame_id",…}`. |
-| `POST /frames/{fid}/kernel/interrupt` | Exact ticket stop. Body `{execution_id,owner:{kind,id}}` (or owner aliases) identifies one ticket: a queued ticket is cancelled without touching the active writer; an active ticket requests a signal only for its frozen lease. The result's `interrupted` flag says whether a lease was actually signalled. Missing identity returns HTTP 400; stale/wrong-owner requests return `ok:false`. The shipped Notebook Stop control selects only `user_repl` tickets. |
+| `POST /frames/{fid}/kernel/restart` | → `{"ok":true,"status":"restarted","generation","generation_id","frame_id"}` + `kernel_status` WS event. In team mode this is owner/admin only. |
+| `POST /frames/{fid}/kernel/stop` | → `{"ok":true,"state":"stopped"|"none","frame_id"}`. In team mode this is owner/admin only. |
+| `POST /frames/{fid}/kernel/start` | → `{"ok":true,"state":"running","generation","frame_id",…}`. In team mode this is owner/admin only. |
+| `POST /frames/{fid}/kernel/interrupt` | Exact ticket stop. Body `{execution_id,owner:{kind,id}}` (or owner aliases) identifies one ticket: a queued ticket is cancelled without touching the active writer; an active ticket requests a signal only for its frozen lease. The result's `interrupted` flag says whether a lease was actually signalled. Missing identity returns HTTP 400; stale/wrong-owner requests return `ok:false`. The shipped Notebook Stop control selects only `user_repl` tickets. In team mode this is owner/admin only. |
 | `GET /frames/{fid}/kernel` | Kernel status: `{frame_id,state("none"|"running"|"stopped"|"ended"),alive,generation,generation_id,generation_ordinal,last_activity_at,ended_reason,turn_running,cell_count,manual_stop,repl_enabled,env:{name,language,python_version,pending,kernel_id}}`. `repl_enabled` mirrors `OPENAI4S_NOTEBOOK_REPL`. |
-| `POST /frames/{fid}/kernel/install` | Body `{packages:[…]}` or `{package}` (+`restart`, default true) → pip-install report (`{ok,installed,…,restarted}`). |
+| `POST /frames/{fid}/kernel/install` | Body `{packages:[…]}` or `{package}` (+`restart`, default true) → pip-install report (`{ok,installed,…,restarted}`). In team mode this is admin only, including when the caller owns the session, because the installation changes a shared runtime environment. |
 | `GET /frames/{fid}/environments` | `{"environments":[…],"current","default","pending"}`. |
-| `POST /frames/{fid}/kernel/env` | Body `{env}` (or `{name}`) — switches the kernel to a prebuilt env (restart) → `{"ok":true,"state","env","generation","language","python_version","frame_id"}`. |
+| `POST /frames/{fid}/kernel/env` | Body `{env}` (or `{name}`) — switches the kernel to a prebuilt env (restart) → `{"ok":true,"state","env","generation","language","python_version","frame_id"}`. In team mode this is owner/admin only. |
 
 **Notebook REPL gate:** the Notebook is a **read-only execution trace** by
 default. The mutating `kernel/*` routes — `execute`, `env`, `restart`, `stop`,
@@ -432,6 +432,11 @@ default. The mutating `kernel/*` routes — `execute`, `env`, `restart`, `stop`,
 `OPENAI4S_NOTEBOOK_REPL` is set. `kernel/install` is intentionally not gated:
 it backs Customize → Compute rather than arbitrary Notebook execution. The
 read-only `GET /frames/{fid}/kernel` and `GET /frames/{fid}/execution-log` stay available.
+The REPL flag is not an authorization grant: project members may read a
+project-visible session, but only its owner or an admin may Stop, Restart,
+Start, interrupt an execution, or change its runtime environment. WebSocket
+execution cancellation follows the same owner/admin rule. Package installation
+remains admin only in team mode.
 `GET /frames/{fid}/kernel` reports the current state in `repl_enabled`. When
 enabled, the shipped UI provides multiline Python/R input and Shift+Enter;
 every submission appends a Cell through the same FIFO coordinator as Agent and
@@ -639,7 +644,7 @@ kept is the tail; `output` is prefixed with a notice when anything was dropped.
 | `GET /environments` | Same shape as `GET /frames/{fid}/environments`, without a session. |
 | `GET /kernel/packages` | `{"packages":[…],"preinstall":{…}}`. |
 | `GET /kernel/environment` | Full env freeze for Provenance → Environment. |
-| `POST /kernel/install` | Body `{packages}` or `{package}` → install report (no kernel restart). |
+| `POST /kernel/install` | Body `{packages}` or `{package}` → install report (no kernel restart). Admin only in team mode because it mutates the shared runtime environment. |
 
 ### Memory / network / web-search config
 

--- a/harness/orchestration.py
+++ b/harness/orchestration.py
@@ -96,6 +96,16 @@ class _MemoryStore:
     def save_workload(self, workload: Workload) -> None:
         return None
 
+    def save_allocation_and_workload(
+        self, allocation: Allocation, workload: Workload
+    ) -> None:
+        # The production repository commits these two rows atomically.  This
+        # in-memory harness has no split persistence boundary: both objects
+        # are the rows, and the reconciler mutates them before calling us.
+        # Keeping the method explicit makes the harness implement the real
+        # WorkloadStore protocol without re-implementing transition policy.
+        return None
+
     def open_recovery_epoch(self, allocation: Allocation, workload: Workload) -> None:
         # One durable fact in the real store; here the objects *are* the
         # rows, so both mutations are already visible and this is a no-op

--- a/harness/scenarios/orchestration/alloc_unknown_submission_resubmits_only_after_asking.json
+++ b/harness/scenarios/orchestration/alloc_unknown_submission_resubmits_only_after_asking.json
@@ -48,6 +48,7 @@
     "event_kinds": [
       "run_started",
       "allocation_submission_unknown",
+      "allocation_submitted",
       "workload_phase",
       "run_finished"
     ],

--- a/harness/scenarios/orchestration/cancel_an_unplaced_allocation_still_finishes.json
+++ b/harness/scenarios/orchestration/cancel_an_unplaced_allocation_still_finishes.json
@@ -36,6 +36,7 @@
       "run_started",
       "stop_requested",
       "workload_releasing",
+      "workload_terminal",
       "run_finished"
     ],
     "invariants": [

--- a/openai4s/execution/watchdog.py
+++ b/openai4s/execution/watchdog.py
@@ -23,6 +23,15 @@ def _never() -> bool:
     return False
 
 
+class KernelNotResetTimeout(TimeoutError):
+    """A cell was stopped, but its worker was not respawned.
+
+    A `TimeoutError` subclass so every existing `except TimeoutError` keeps
+    catching it; a distinct type so the surfaces that tell a user what
+    happened to their variables can tell the two apart.
+    """
+
+
 @dataclass(frozen=True)
 class WatchdogPolicy:
     """Timing policy for a long-running persistent-kernel cell."""
@@ -118,22 +127,44 @@ def execute_with_watchdog(
 
     supervisor.kill_if_current(lease)
     worker.join(max(0.0, policy.kill_grace_s))
+    # Whether the ladder actually finished. It was assumed, and the assumption
+    # is false for a worker this daemon did not spawn: `kill_if_current` drops
+    # a remote worker's *socket*, `restart()` refuses to respawn something that
+    # dialled in from elsewhere, and the refusal was swallowed one line below.
+    # The message then told the user their kernel had been reset and their
+    # variables cleared, while the interpreter was untouched on a compute node
+    # and the cell was very possibly still running there. Reporting a reset
+    # that did not happen is worse than reporting a timeout, because the user
+    # stops looking for the work.
+    was_reset = False
     if worker.is_alive():
         supervisor.abandon_if_current(lease)
     else:
         try:
             restarted = supervisor.restart_if_current(lease)
+            was_reset = restarted is not None
             if restarted is not None and after_restart is not None:
                 try:
                     after_restart(restarted.kernel)
                 except Exception:
                     supervisor.shutdown_if_current(restarted)
+                    was_reset = False
         except Exception:  # noqa: BLE001 — next ensure lazily recovers the slot
             pass
-    raise TimeoutError(
-        f"cell exceeded {int(policy.timeout_s)}s with no result and was stopped; "
-        "the kernel was reset (variables from earlier cells were cleared). Break "
-        "the work into smaller steps, or raise OPENAI4S_CELL_TIMEOUT."
+    if was_reset:
+        raise TimeoutError(
+            f"cell exceeded {int(policy.timeout_s)}s with no result and was "
+            "stopped; the kernel was reset (variables from earlier cells were "
+            "cleared). Break the work into smaller steps, or raise "
+            "OPENAI4S_CELL_TIMEOUT."
+        )
+    raise KernelNotResetTimeout(
+        f"cell exceeded {int(policy.timeout_s)}s with no result and was "
+        "stopped here, but its worker could not be reset from this daemon. If "
+        "the session runs on a cluster the work may still be running on its "
+        "allocation; recover or release the session rather than assuming it "
+        "stopped. Break the work into smaller steps, or raise "
+        "OPENAI4S_CELL_TIMEOUT."
     )
 
 

--- a/openai4s/execution/watchdog.py
+++ b/openai4s/execution/watchdog.py
@@ -13,6 +13,7 @@ import threading
 from dataclasses import dataclass
 from typing import Any, Callable, Mapping, TypeVar
 
+from openai4s.kernel.errors import KernelRestartFailed
 from openai4s.kernel.supervisor import KernelLease, KernelSupervisor
 
 T = TypeVar("T")
@@ -29,6 +30,15 @@ class KernelNotResetTimeout(TimeoutError):
     A `TimeoutError` subclass so every existing `except TimeoutError` keeps
     catching it; a distinct type so the surfaces that tell a user what
     happened to their variables can tell the two apart.
+    """
+
+
+class KernelResetUnavailableTimeout(TimeoutError):
+    """The timed-out namespace was cleared, but its replacement is unusable.
+
+    This is distinct from :class:`KernelNotResetTimeout`: the old local worker
+    was destroyed, so no cluster allocation may still be running the cell, but
+    bootstrap failed and the replacement was detached rather than left ready.
     """
 
 
@@ -137,6 +147,7 @@ def execute_with_watchdog(
     # that did not happen is worse than reporting a timeout, because the user
     # stops looking for the work.
     was_reset = False
+    replacement_unavailable = False
     if worker.is_alive():
         supervisor.abandon_if_current(lease)
     else:
@@ -148,9 +159,28 @@ def execute_with_watchdog(
                     after_restart(restarted.kernel)
                 except Exception:
                     supervisor.shutdown_if_current(restarted)
-                    was_reset = False
-        except Exception:  # noqa: BLE001 — next ensure lazily recovers the slot
+                    replacement_unavailable = True
+        except KernelRestartFailed:
+            # Local restart tears down the old namespace before spawning its
+            # replacement. A spawn/generation failure is therefore a reset
+            # that left no usable worker, not the remote/no-reset case whose
+            # warning says cluster work may still be running.
+            supervisor.shutdown_if_current(
+                lease,
+                reason="watchdog_restart_failed",
+                terminal_state="crashed",
+            )
+            replacement_unavailable = True
+        except Exception:  # noqa: BLE001 — remote/no-reset stays distinguishable
             pass
+    if replacement_unavailable:
+        raise KernelResetUnavailableTimeout(
+            f"cell exceeded {int(policy.timeout_s)}s with no result and was "
+            "stopped; the old kernel was reset and its variables were cleared, "
+            "but the replacement failed to initialize and is unavailable. "
+            "Retry to start a fresh kernel, break the work into smaller steps, "
+            "or raise OPENAI4S_CELL_TIMEOUT."
+        )
     if was_reset:
         raise TimeoutError(
             f"cell exceeded {int(policy.timeout_s)}s with no result and was "

--- a/openai4s/host/data.py
+++ b/openai4s/host/data.py
@@ -426,6 +426,16 @@ class HostDataService:
         parent = store.get_artifact(str(metadata.get("artifact_id") or ""))
         if parent is None or parent.get("project_id") != project_id:
             raise unknown
+        # A project bound is the right one for "may I reach a sibling
+        # session", and it is not the whole rule in team mode: a session in
+        # this project may still be `private`, and a session with no ownership
+        # row is admin-only. Every other reader of an artifact consults
+        # `session_visible_to`; this one did not, so a version id learned from
+        # a since-revoked share -- or from before the owner made the session
+        # private -- still hardlinked their frozen bytes into the caller's
+        # workspace and inlined them into the caller's prompt.
+        if not self._session_visible(store, str(parent.get("root_frame_id") or "")):
+            raise unknown
 
         snapshot = metadata.get("snapshot_path") or ""
         if not snapshot or not Path(str(snapshot)).is_file():
@@ -703,6 +713,28 @@ class HostDataService:
                 visible_to_user_id=viewer,
             ),
         }
+
+    def _session_visible(self, store: Any, root_frame_id: str) -> bool:
+        """May the principal running this execution read that session?
+
+        Fail-closed on an undecidable answer, the same way `team_policy` does:
+        an ownership row we cannot read is not an open door. Single-user and
+        service principals are unrestricted, so this is inert off team mode
+        (INV-1).
+        """
+        principal = execution_principal.resolve()
+        if principal.unrestricted:
+            return True
+        if not root_frame_id:
+            return False
+        try:
+            return bool(
+                store.team.session_visible_to(
+                    root_frame_id, principal.as_visibility_user()
+                )
+            )
+        except Exception:  # noqa: BLE001 — undecidable is refused
+            return False
 
     def _visibility_filter(self) -> str | None:
         """The user id these reads are scoped to, or None for unrestricted.

--- a/openai4s/kernel/environment.py
+++ b/openai4s/kernel/environment.py
@@ -138,6 +138,18 @@ _INJECTION_NAMES = frozenset(
 )
 
 
+def name_can_carry_a_secret(name: str) -> bool:
+    """Public spelling of `_forbidden_name`, for callers outside the kernel.
+
+    The scheduler path needs the same answer -- a job's environment is
+    readable with `scontrol show job` -- and had grown its own narrower
+    regex, which is how `AWS_ACCESS_KEY_ID`, `*_OAUTH`, `*_BEARER` and
+    `*_COOKIE` reached a queue record that INV-9 exists to keep them out of.
+    One list, so adding a marker protects every child the daemon starts.
+    """
+    return _forbidden_name(name)
+
+
 def _forbidden_name(name: str) -> bool:
     """Return whether an environment name can carry a secret or inject code.
 
@@ -227,4 +239,4 @@ def build_kernel_environment(
     return env
 
 
-__all__ = ["build_kernel_environment"]
+__all__ = ["build_kernel_environment", "name_can_carry_a_secret"]

--- a/openai4s/kernel/errors.py
+++ b/openai4s/kernel/errors.py
@@ -10,7 +10,11 @@ module some future caller reaches first.
 
 from __future__ import annotations
 
-__all__ = ["KernelBusyError", "KernelInterruptUnavailable"]
+__all__ = [
+    "KernelBusyError",
+    "KernelInterruptUnavailable",
+    "KernelRestartFailed",
+]
 
 
 class KernelBusyError(RuntimeError):
@@ -28,4 +32,14 @@ class KernelInterruptUnavailable(RuntimeError):
     transient errors interruption really is best-effort about -- so a bare
     RuntimeError was swallowed by all of them, and the cancel API answered
     `interrupted: true` for a cell still running on the cluster.
+    """
+
+
+class KernelRestartFailed(RuntimeError):
+    """The old local namespace was destroyed but no replacement is usable.
+
+    A remote kernel refuses restart before touching its worker and must not use
+    this type. Local restart raises it only after teardown, allowing watchdog
+    callers to say variables were cleared without claiming a replacement is
+    ready or that cluster work may still be running.
     """

--- a/openai4s/kernel/manager.py
+++ b/openai4s/kernel/manager.py
@@ -657,7 +657,15 @@ class Kernel:
         except Exception:  # noqa: BLE001
             pass
         self.authorization_generation = f"kernel:{uuid.uuid4()}"
-        self._proc = self._spawn()
+        try:
+            self._proc = self._spawn()
+        except Exception as exc:
+            from openai4s.kernel.errors import KernelRestartFailed
+
+            raise KernelRestartFailed(
+                "the old kernel was cleared but its replacement could not "
+                f"start: {exc}"
+            ) from exc
         # Every respawn bumps the generation: a lease, a watchdog or an
         # in-flight interrupt naming the previous incarnation has to be
         # refused, and this counter is the whole of how it is refused.
@@ -667,7 +675,9 @@ class Kernel:
             # refused at the top of this method, before the old worker is
             # torn down, so reaching here means the fresh local process did
             # not come up.
-            raise RuntimeError(
+            from openai4s.kernel.errors import KernelRestartFailed
+
+            raise KernelRestartFailed(
                 "the restarted worker is not alive: its process failed to "
                 "start or exited immediately"
             )

--- a/openai4s/kernel/supervisor.py
+++ b/openai4s/kernel/supervisor.py
@@ -174,7 +174,13 @@ class KernelSupervisor:
                     # interrupted", and a worker with no signal path was not.
                     continue
                 except Exception:  # noqa: BLE001 — interruption is best-effort
-                    pass
+                    # Nor is one whose signal delivery raised. Best-effort is
+                    # about not propagating the error, not about counting the
+                    # attempt as a success: an OSError out of `interrupt()`
+                    # answered a nonzero count for a cell that was still
+                    # running, which is the same silence the branch above was
+                    # added to close.
+                    continue
                 count += 1
             return count
 
@@ -386,7 +392,10 @@ class KernelSupervisor:
                 # the silence `Kernel.interrupt` started raising to prevent.
                 return False
             except Exception:  # noqa: BLE001 — interruption is best-effort
-                pass
+                # Same reasoning as `interrupt()` above: the caller reads this
+                # as "the interrupt was delivered", so a delivery that raised
+                # is False rather than swallowed-and-affirmed.
+                return False
             return True
 
     def touch(

--- a/openai4s/kernel/supervisor.py
+++ b/openai4s/kernel/supervisor.py
@@ -10,10 +10,11 @@ from __future__ import annotations
 import threading
 import time
 import uuid
+from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any, Callable, Hashable
 
-from openai4s.kernel.errors import KernelInterruptUnavailable
+from openai4s.kernel.errors import KernelInterruptUnavailable, KernelRestartFailed
 
 KernelFactory = Callable[[], Any]
 
@@ -61,12 +62,61 @@ class KernelSupervisor:
         clock_ms: Callable[[], int] | None = None,
     ) -> None:
         self._slots: dict[str, _Slot] = {}
+        self._preparing: dict[str, tuple[str, Any]] = {}
         self._lock = threading.RLock()
         self._root_frame_id = root_frame_id
         self._branch_id = branch_id or root_frame_id
         self._generations = generations
         self._owner_instance_id = owner_instance_id
         self._clock_ms = clock_ms or (lambda: int(time.time() * 1000))
+
+    @contextmanager
+    def publication_guard(self):
+        """Establish the supervisor-first lock order for cross-owner commits."""
+
+        with self._lock:
+            yield
+
+    @contextmanager
+    def preparing_candidate(self, language: str, kernel: Any):
+        """Expose an unpublished bootstrap candidate to exact cancellation.
+
+        The current slot remains untouched until validation succeeds, but a
+        Stop/cancel must still be able to interrupt a slow bootstrap.  A token
+        prevents an older context from removing a newer candidate.
+        """
+
+        token = str(uuid.uuid4())
+        with self._lock:
+            if language in self._preparing:
+                raise RuntimeError(
+                    f"a {language} kernel candidate is already preparing"
+                )
+            self._preparing[language] = (token, kernel)
+        try:
+            yield token
+        finally:
+            with self._lock:
+                current = self._preparing.get(language)
+                if current is not None and current[0] == token:
+                    self._preparing.pop(language, None)
+
+    def interrupt_preparing(self, language: str | None = None) -> int:
+        """Interrupt unpublished candidates without changing current leases."""
+
+        with self._lock:
+            names = [language] if language is not None else list(self._preparing)
+            interrupted = 0
+            for name in names:
+                entry = self._preparing.get(name)
+                if entry is None:
+                    continue
+                try:
+                    entry[1].interrupt()
+                except Exception:  # noqa: BLE001
+                    continue
+                interrupted += 1
+            return interrupted
 
     def ensure(
         self, language: str, key: Hashable | None, factory: KernelFactory
@@ -160,28 +210,36 @@ class KernelSupervisor:
 
     def interrupt(self, language: str | None = None) -> int:
         with self._lock:
-            names = [language] if language is not None else list(self._slots)
+            names = (
+                [language]
+                if language is not None
+                else sorted(set(self._slots) | set(self._preparing))
+            )
             count = 0
+            seen: set[int] = set()
             for name in names:
                 slot = self._slots.get(name)
-                if slot is None or slot.kernel is None:
-                    continue
-                try:
-                    slot.kernel.interrupt()
-                    self._touch_slot(slot)
-                except KernelInterruptUnavailable:
-                    # Not counted: the return value is "how many kernels were
-                    # interrupted", and a worker with no signal path was not.
-                    continue
-                except Exception:  # noqa: BLE001 — interruption is best-effort
-                    # Nor is one whose signal delivery raised. Best-effort is
-                    # about not propagating the error, not about counting the
-                    # attempt as a success: an OSError out of `interrupt()`
-                    # answered a nonzero count for a cell that was still
-                    # running, which is the same silence the branch above was
-                    # added to close.
-                    continue
-                count += 1
+                targets = []
+                if slot is not None and slot.kernel is not None:
+                    targets.append((slot.kernel, slot))
+                preparing = self._preparing.get(name)
+                if preparing is not None:
+                    targets.append((preparing[1], None))
+                for kernel, published_slot in targets:
+                    if id(kernel) in seen:
+                        continue
+                    seen.add(id(kernel))
+                    try:
+                        kernel.interrupt()
+                        if published_slot is not None:
+                            self._touch_slot(published_slot)
+                    except KernelInterruptUnavailable:
+                        # Not counted: the return value is "how many kernels
+                        # were interrupted", and this one had no signal path.
+                        continue
+                    except Exception:  # noqa: BLE001 — best-effort delivery
+                        continue
+                    count += 1
             return count
 
     def stop(
@@ -199,10 +257,13 @@ class KernelSupervisor:
                 self._slot(language)
                 names = [language]
             else:
-                names = list(self._slots)
+                names = sorted(set(self._slots) | set(self._preparing))
             kernels: list[Any] = []
             ended: list[str] = []
             for name in names:
+                preparing = self._preparing.pop(name, None)
+                if preparing is not None:
+                    kernels.append(preparing[1])
                 slot = self._slots.get(name)
                 if slot is None:
                     continue
@@ -219,7 +280,8 @@ class KernelSupervisor:
                     state="manually_stopped" if manual else "released",
                     reason=reason or ("manual_stop" if manual else "released"),
                 )
-        for kernel in kernels:
+        unique_kernels = {id(kernel): kernel for kernel in kernels}
+        for kernel in unique_kernels.values():
             self._shutdown(kernel)
         return len(kernels)
 
@@ -234,9 +296,33 @@ class KernelSupervisor:
                     raise RuntimeError(f"no {language} kernel factory configured")
                 slot.kernel = self._create_live(language, slot.factory)
             else:
-                slot.kernel.restart()
+                try:
+                    slot.kernel.restart()
+                except KernelRestartFailed:
+                    failed = slot.kernel
+                    slot.kernel = None
+                    slot.ended_reason = "restart_failed"
+                    self._finish_generation(
+                        old_generation_id,
+                        state="crashed",
+                        reason="restart_failed",
+                    )
+                    self._shutdown(failed)
+                    raise
                 if not self._alive(slot.kernel):
-                    raise RuntimeError(f"restarted {language} kernel is not alive")
+                    failed = slot.kernel
+                    slot.kernel = None
+                    slot.ended_reason = "restart_failed"
+                    self._finish_generation(
+                        old_generation_id,
+                        state="crashed",
+                        reason="restart_failed",
+                    )
+                    self._shutdown(failed)
+                    raise KernelRestartFailed(
+                        f"the restarted {language} kernel exited before its "
+                        "replacement generation could be recorded"
+                    )
             try:
                 identity = self._begin_generation(
                     language,
@@ -244,7 +330,7 @@ class KernelSupervisor:
                     slot.key,
                     parent_generation_id=old_generation_id,
                 )
-            except Exception:
+            except Exception as exc:
                 failed = slot.kernel
                 slot.kernel = None
                 slot.ended_reason = "generation_record_failed"
@@ -254,7 +340,10 @@ class KernelSupervisor:
                     reason="generation_record_failed",
                 )
                 self._shutdown(failed)
-                raise
+                raise KernelRestartFailed(
+                    f"the restarted {language} kernel could not record "
+                    "its replacement generation"
+                ) from exc
             if old_generation_id is not None:
                 self._finish_generation(
                     old_generation_id,
@@ -325,9 +414,33 @@ class KernelSupervisor:
             if not self._matches(slot, lease):
                 return None
             old_generation_id = slot.generation_id
-            slot.kernel.restart()
+            try:
+                slot.kernel.restart()
+            except KernelRestartFailed:
+                failed = slot.kernel
+                slot.kernel = None
+                slot.ended_reason = "watchdog_restart_failed"
+                self._finish_generation(
+                    old_generation_id,
+                    state="crashed",
+                    reason="watchdog_restart_failed",
+                )
+                self._shutdown(failed)
+                raise
             if not self._alive(slot.kernel):
-                raise RuntimeError(f"restarted {lease.language} kernel is not alive")
+                failed = slot.kernel
+                slot.kernel = None
+                slot.ended_reason = "watchdog_restart_failed"
+                self._finish_generation(
+                    old_generation_id,
+                    state="crashed",
+                    reason="watchdog_restart_failed",
+                )
+                self._shutdown(failed)
+                raise KernelRestartFailed(
+                    f"the restarted {lease.language} kernel exited before its "
+                    "replacement generation could be recorded"
+                )
             try:
                 identity = self._begin_generation(
                     lease.language,
@@ -335,7 +448,7 @@ class KernelSupervisor:
                     slot.key,
                     parent_generation_id=old_generation_id,
                 )
-            except Exception:
+            except Exception as exc:
                 failed = slot.kernel
                 slot.kernel = None
                 slot.ended_reason = "generation_record_failed"
@@ -345,7 +458,10 @@ class KernelSupervisor:
                     reason="generation_record_failed",
                 )
                 self._shutdown(failed)
-                raise
+                raise KernelRestartFailed(
+                    f"the restarted {lease.language} kernel could not record "
+                    "its replacement generation"
+                ) from exc
             self._finish_generation(
                 old_generation_id,
                 state="crashed",
@@ -458,6 +574,7 @@ class KernelSupervisor:
         expected: KernelLease | None,
         recovered_from_generation_id: str | None = None,
         bootstrap: dict[str, Any] | None = None,
+        candidate_token: str | None = None,
     ) -> KernelLease:
         """Atomically adopt one already-live, already-validated worker.
 
@@ -479,6 +596,16 @@ class KernelSupervisor:
         if not self._alive(kernel):
             raise RuntimeError(f"{language} recovery candidate is not alive")
         with self._lock:
+            if candidate_token is not None:
+                preparing = self._preparing.get(language)
+                if preparing is None or preparing != (candidate_token, kernel):
+                    raise RuntimeError(
+                        f"{language} kernel candidate was cancelled before publish"
+                    )
+                # Consume the publication right while holding the same lock
+                # Stop uses to revoke it. A stopped candidate can therefore
+                # never be adopted after Stop returns.
+                self._preparing.pop(language, None)
             slot = self._slot(language)
             if kernel is slot.kernel:
                 raise ValueError("recovery candidate is already published")

--- a/openai4s/kernel/transport.py
+++ b/openai4s/kernel/transport.py
@@ -273,11 +273,16 @@ class OutboundTcpTransport:
             raise WorkerConnectionRefused(
                 f"remote worker {self._peer} sent a line over {MAX_LINE_BYTES} bytes"
             )
-        # `replace`, not strict: a mangled byte is the peer's problem to have
-        # produced, and `json.loads` above will refuse the frame anyway --
-        # whereas a UnicodeDecodeError here would surface as a transport
-        # failure and lose which frame it was.
-        return raw.decode("utf-8", "replace")
+        try:
+            return raw.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            # U+FFFD is legal inside a JSON string, so replacement decoding
+            # silently changed source code, paths and host responses while
+            # still producing a valid frame.  Protocol bytes are exact.
+            self._alive = False
+            raise WorkerConnectionRefused(
+                f"remote worker {self._peer} sent invalid UTF-8"
+            ) from exc
 
     def alive(self) -> bool:
         """Latched, and honest about being latched.
@@ -315,6 +320,14 @@ class OutboundTcpTransport:
             except Exception:  # noqa: BLE001
                 pass
         self._alive = False
+        # A makefile reader may be blocked in ``readline`` on another thread.
+        # Closing that BufferedReader first can wait forever for the read to
+        # return; shutting down the socket is what wakes it.  Only then is it
+        # safe to close the wrappers and their shared descriptor.
+        try:
+            self._sock.shutdown(socket.SHUT_RDWR)
+        except OSError:
+            pass
         for handle in (self._reader, self._writer):
             try:
                 handle.close()

--- a/openai4s/kernel/transport.py
+++ b/openai4s/kernel/transport.py
@@ -244,9 +244,15 @@ class OutboundTcpTransport:
         self._remote_pid = remote_pid
         self._alive = True
         self._lock = threading.Lock()
-        # Text wrappers over the socket, line-buffered, so the framing is
-        # byte-for-byte what the pipe path produces.
-        self._reader = sock.makefile("r", encoding="utf-8", newline="\n")
+        # The reader is *binary* and the writer text. Both produce the same
+        # framing as the pipe path; the asymmetry is about `MAX_LINE_BYTES`
+        # meaning bytes. `TextIOWrapper.readline(size)` bounds **characters**,
+        # so a text reader let a peer spend 4 bytes per character and turn a
+        # 16 MiB cap into a 64 MiB allocation -- against a constant whose own
+        # comment calls the unbounded case "a memory exhaustion primitive".
+        # `BufferedReader.readline(size)` bounds bytes, which is what was
+        # meant.
+        self._reader = sock.makefile("rb")
         self._writer = sock.makefile("w", encoding="utf-8", newline="\n", buffering=1)
 
     def write_line(self, line: str) -> None:
@@ -255,11 +261,11 @@ class OutboundTcpTransport:
             self._writer.flush()
 
     def read_line(self) -> str:
-        line = self._reader.readline(MAX_LINE_BYTES)
-        if not line:
+        raw = self._reader.readline(MAX_LINE_BYTES)
+        if not raw:
             self._alive = False
             return ""
-        if len(line) >= MAX_LINE_BYTES and not line.endswith("\n"):
+        if len(raw) >= MAX_LINE_BYTES and not raw.endswith(b"\n"):
             # A peer that never sends a newline would otherwise be an
             # unbounded allocation. Treat it as a dead connection rather
             # than as a frame: a truncated frame is not a frame.
@@ -267,9 +273,22 @@ class OutboundTcpTransport:
             raise WorkerConnectionRefused(
                 f"remote worker {self._peer} sent a line over {MAX_LINE_BYTES} bytes"
             )
-        return line
+        # `replace`, not strict: a mangled byte is the peer's problem to have
+        # produced, and `json.loads` above will refuse the frame anyway --
+        # whereas a UnicodeDecodeError here would surface as a transport
+        # failure and lose which frame it was.
+        return raw.decode("utf-8", "replace")
 
     def alive(self) -> bool:
+        """Latched, and honest about being latched.
+
+        There is no `poll()` for a process on another machine, so this can
+        only report what the last read saw. Two things make the latch usable
+        rather than misleading: `SO_KEEPALIVE` on the accepted socket (see
+        `orchestration/worker_gateway.py`), which turns a vanished node into
+        an EOF the reader will actually reach, and the lease reclaimer, which
+        ends the allocation on its own clock.
+        """
         return self._alive
 
     def interrupt(self) -> bool:

--- a/openai4s/kernel/worker.py
+++ b/openai4s/kernel/worker.py
@@ -122,13 +122,24 @@ def _connect_remote_protocol():
         host, _, port = target.rpartition(":")
         sock = _socket.create_connection((host or "127.0.0.1", int(port)), timeout=60)
         sock.sendall((credential + "\n").encode("utf-8"))
+        # One byte at a time, deliberately. A chunked read consumes whatever
+        # arrived in the same segment as the handshake reply, and the previous
+        # version then threw the remainder away -- so a protocol frame the
+        # daemon wrote immediately afterwards (registration wakes a thread
+        # that builds the Kernel and executes at once, so "immediately" is the
+        # normal case) was lost before the reader wrapper existed to see it,
+        # and the daemon blocked forever on a reply to a cell the worker never
+        # received. The reply is one short line; the syscalls are cheap and
+        # happen once.
         reply = b""
-        while b"\n" not in reply:
-            chunk = sock.recv(4096)
+        while not reply.endswith(b"\n"):
+            chunk = sock.recv(1)
             if not chunk:
                 raise OSError("daemon closed during handshake")
             reply += chunk
-        answer = _json.loads(reply.split(b"\n", 1)[0].decode("utf-8"))
+            if len(reply) > 65536:
+                raise OSError("handshake reply too long")
+        answer = _json.loads(reply.rstrip(b"\n").decode("utf-8"))
         if not answer.get("ok"):
             raise OSError(f"daemon refused this worker: {answer.get('error')}")
         # The generation the Host admitted this connection under. A local

--- a/openai4s/kernel/worker.py
+++ b/openai4s/kernel/worker.py
@@ -90,6 +90,27 @@ _MAX_CACHED_CELLS = 128  # linecache retention, evicted by counter
 #: secret ever appears in a job's environment (INV-9).
 _CONNECT_ENV = "OPENAI4S_WORKER_CONNECT"
 _CREDENTIAL_ENV = "OPENAI4S_WORKER_BOOTSTRAP_PATH"
+_CREDENTIAL_TEMPLATE_ENV = "OPENAI4S_WORKER_BOOTSTRAP_PATH_TEMPLATE"
+_RANK_ENV_NAME_ENV = "OPENAI4S_WORKER_RANK_ENV"
+
+
+def _remote_credential_path() -> str:
+    template = (os.environ.get(_CREDENTIAL_TEMPLATE_ENV) or "").strip()
+    if not template:
+        return (os.environ.get(_CREDENTIAL_ENV) or "").strip()
+    rank_env = (os.environ.get(_RANK_ENV_NAME_ENV) or "").strip()
+    if not rank_env:
+        raise ValueError(
+            f"{_CREDENTIAL_TEMPLATE_ENV} is set but {_RANK_ENV_NAME_ENV} is not"
+        )
+    raw_rank = (os.environ.get(rank_env) or "").strip()
+    try:
+        rank = int(raw_rank)
+    except ValueError as exc:
+        raise ValueError(f"invalid worker rank in {rank_env}: {raw_rank!r}") from exc
+    if rank < 0 or "{rank}" not in template:
+        raise ValueError("worker credential template/rank is invalid")
+    return template.replace("{rank}", str(rank))
 
 
 def _connect_remote_protocol():
@@ -107,16 +128,13 @@ def _connect_remote_protocol():
     import json as _json
     import socket as _socket
 
-    credential_path = (os.environ.get(_CREDENTIAL_ENV) or "").strip()
-    if not credential_path:
-        print(
-            f"{_CONNECT_ENV} is set but {_CREDENTIAL_ENV} is not; refusing to "
-            f"connect without a credential",
-            file=sys.stderr,
-            flush=True,
-        )
-        raise SystemExit(70)
     try:
+        credential_path = _remote_credential_path()
+        if not credential_path:
+            raise ValueError(
+                f"{_CONNECT_ENV} is set but {_CREDENTIAL_ENV} is not; refusing "
+                "to connect without a credential"
+            )
         with open(credential_path, encoding="utf-8") as handle:
             credential = handle.read().strip()
         host, _, port = target.rpartition(":")

--- a/openai4s/orchestration/bootstrap.py
+++ b/openai4s/orchestration/bootstrap.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+import math
 import os
 import secrets
 import threading
@@ -74,6 +75,30 @@ CREDENTIAL_PATH_ENV = "OPENAI4S_WORKER_BOOTSTRAP_PATH"
 
 class BootstrapError(RuntimeError):
     """A credential was absent, malformed, expired, replayed or forged."""
+
+
+def _strict_fsync_dir(directory: Path) -> None:
+    """Durably publish a security fence's directory entry.
+
+    The shared permissions helper is intentionally best-effort for files such
+    as the daemon signing secret, where losing the name invalidates old
+    credentials. A replay fence has the opposite failure mode: losing its new
+    name can *re-admit* a nonce after restart. POSIX cluster hosts must
+    therefore reject the operation when the directory cannot be synced.
+
+    Windows does not expose directory fsync through ``os.open``. Remote worker
+    admission uses a POSIX execution plane; file flush plus atomic replace
+    stays as the portable behavior when this module is imported elsewhere.
+    """
+
+    if os.name != "posix":
+        return
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    fd = os.open(directory, flags)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
 
 
 def load_or_mint_secret(data_dir: Path | str) -> bytes:
@@ -250,6 +275,7 @@ class BootstrapAuthority:
             return
         try:
             data = json.loads(self._state_path.read_text("utf-8"))
+            consumed, epochs = _validated_state(data)
         except Exception as exc:  # noqa: BLE001
             self._fence_error = (
                 f"the worker bootstrap fence at {self._state_path} could not be "
@@ -262,37 +288,28 @@ class BootstrapAuthority:
             )
             return
         now = self._clock()
-        consumed = data.get("consumed")
-        if isinstance(consumed, dict):
-            # nonce -> expiry. Pruned on load, so the file cannot grow
-            # without bound across a long-lived install: a nonce past its
-            # credential's expiry is refused by the expiry check anyway.
-            self._consumed = {
-                str(nonce)
-                for nonce, expires in consumed.items()
-                if _as_float(expires) > now
-            }
-            self._consumed_expiry = {
-                str(nonce): _as_float(expires)
-                for nonce, expires in consumed.items()
-                if _as_float(expires) > now
-            }
-        epochs = data.get("epochs")
-        if isinstance(epochs, dict):
-            self._current_epoch = {
-                str(allocation): int(epoch) for allocation, epoch in epochs.items()
-            }
+        # nonce -> expiry. Pruned on load, so the file cannot grow without
+        # bound across a restart: a nonce past the credential's expiry is
+        # refused by the expiry check anyway.
+        self._consumed_expiry = {
+            nonce: expires for nonce, expires in consumed.items() if expires > now
+        }
+        self._consumed = set(self._consumed_expiry)
+        self._current_epoch = epochs
 
-    def _save_state(self) -> None:
+    def _save_state(
+        self,
+        *,
+        consumed_expiry: dict[str, float],
+        current_epoch: dict[str, int],
+    ) -> dict[str, float]:
         """Rewrite the fence, atomically and 0600.
 
-        Called with the lock held. Best-effort: a write that fails must not
-        fail the registration it was recording, because refusing a worker
-        that presented a valid credential is a worse outcome than a fence
-        that has to be rebuilt.
+        Called with the lock held, using candidate copies rather than live
+        state. A failed durable write refuses the operation and leaves the
+        in-memory fence unchanged: acknowledging a credential whose nonce was
+        not durably burned would make it reusable after a restart.
         """
-        if self._state_path is None:
-            return
         # Prune here, not only in `_load_state`. The claim there -- "pruned on
         # load, so the file cannot grow without bound across a long-lived
         # install" -- was true only of installs that restart: load happens once,
@@ -303,16 +320,17 @@ class BootstrapAuthority:
         now = self._clock()
         live = {
             nonce: expires
-            for nonce, expires in (getattr(self, "_consumed_expiry", {}) or {}).items()
+            for nonce, expires in consumed_expiry.items()
             if expires > now
         }
-        self._consumed_expiry = live
-        self._consumed = set(live)
         payload = {
             "consumed": live,
-            "epochs": self._current_epoch,
+            "epochs": current_epoch,
         }
+        if self._state_path is None:
+            return live
         tmp = self._state_path.with_suffix(".tmp")
+        published = False
         try:
             self._state_path.parent.mkdir(parents=True, exist_ok=True)
             with open(
@@ -333,12 +351,30 @@ class BootstrapAuthority:
                 # both of these since it was written.
                 os.fsync(handle.fileno())
             os.replace(tmp, self._state_path)
-            _fsync_dir(self._state_path.parent)
-        except Exception:  # noqa: BLE001
+            published = True
+            _strict_fsync_dir(self._state_path.parent)
+        except Exception as exc:  # noqa: BLE001
             try:
                 tmp.unlink(missing_ok=True)
             except Exception:  # noqa: BLE001
                 pass
+            message = (
+                f"could not persist the worker bootstrap fence at "
+                f"{self._state_path}: {exc}"
+            )
+            if published:
+                # The candidate is now visible but its directory entry was
+                # not confirmed durable. Memory cannot safely choose the old
+                # fence (a restart may read the new one) or the candidate (a
+                # power loss may reveal the old one). Lock this authority
+                # closed until a restart reloads whichever complete state the
+                # filesystem retained.
+                self._fence_error = (
+                    message + "; fence durability is uncertain, so worker admission "
+                    "is locked until the daemon restarts"
+                )
+            raise BootstrapError(message) from exc
+        return live
 
     def issue(
         self,
@@ -356,13 +392,22 @@ class BootstrapAuthority:
             "nonce": secrets.token_urlsafe(24),
         }
         with self._lock:
+            if self._fence_error is not None:
+                raise BootstrapError(self._fence_error)
             # Issuing for an epoch fences every earlier one: recovery mints a
             # new epoch, and the worker from the old one must not be able to
             # register afterwards.
             known = self._current_epoch.get(allocation_id)
             if known is None or epoch > known:
-                self._current_epoch[allocation_id] = int(epoch)
-                self._save_state()
+                epochs = dict(self._current_epoch)
+                epochs[allocation_id] = int(epoch)
+                live = self._save_state(
+                    consumed_expiry=dict(self._consumed_expiry),
+                    current_epoch=epochs,
+                )
+                self._current_epoch = epochs
+                self._consumed_expiry = live
+                self._consumed = set(live)
         return BootstrapCredential(signature=_sign(self._secret, payload), **payload)
 
     def verify(self, credential: BootstrapCredential) -> None:
@@ -375,6 +420,8 @@ class BootstrapAuthority:
         if credential.expires_at <= self._clock():
             raise BootstrapError("credential has expired")
         with self._lock:
+            if self._fence_error is not None:
+                raise BootstrapError(self._fence_error)
             current = self._current_epoch.get(credential.allocation_id)
             if current is not None and credential.epoch < current:
                 # INV-7: an old epoch's worker is refused, by the same rule
@@ -392,6 +439,8 @@ class BootstrapAuthority:
         if self._fence_error is not None:
             raise BootstrapError(self._fence_error)
         with self._lock:
+            if self._fence_error is not None:
+                raise BootstrapError(self._fence_error)
             if credential.nonce in self._consumed:
                 raise BootstrapError("credential has already been used")
             # Signature and expiry first, so a replay of a forged credential
@@ -407,28 +456,78 @@ class BootstrapAuthority:
                     f"STALE_EPOCH: allocation {credential.allocation_id} is at "
                     f"epoch {current}, credential carries {credential.epoch}"
                 )
-            self._consumed.add(credential.nonce)
-            expiry = getattr(self, "_consumed_expiry", None)
-            if expiry is None:
-                expiry = self._consumed_expiry = {}
+            expiry = dict(self._consumed_expiry)
             expiry[credential.nonce] = float(credential.expires_at)
             # Written before the caller is told the credential was accepted:
             # a crash between "burned" and "recorded as burned" is the one
             # ordering that reopens the replay this fence exists to close.
-            self._save_state()
+            epochs = dict(self._current_epoch)
+            live = self._save_state(
+                consumed_expiry=expiry,
+                current_epoch=epochs,
+            )
+            self._current_epoch = epochs
+            self._consumed_expiry = live
+            self._consumed = set(live)
 
     def fence_epoch(self, allocation_id: str, epoch: int) -> None:
         """Declare the epoch now in force, refusing everything older."""
         with self._lock:
-            self._current_epoch[allocation_id] = int(epoch)
-            self._save_state()
+            if self._fence_error is not None:
+                raise BootstrapError(self._fence_error)
+            epochs = dict(self._current_epoch)
+            epochs[allocation_id] = int(epoch)
+            live = self._save_state(
+                consumed_expiry=dict(self._consumed_expiry),
+                current_epoch=epochs,
+            )
+            self._current_epoch = epochs
+            self._consumed_expiry = live
+            self._consumed = set(live)
 
 
-def _as_float(value: object) -> float:
-    try:
-        return float(value)  # type: ignore[arg-type]
-    except Exception:  # noqa: BLE001
-        return 0.0
+def _validated_state(data: object) -> tuple[dict[str, float], dict[str, int]]:
+    """Decode the durable fence without turning malformed state into empty.
+
+    This file is an authorization record, not a cache. Ignoring a missing or
+    mistyped field would silently un-burn nonces or un-fence epochs, so the
+    writer's exact two-field schema is also the reader's contract.
+    """
+    if not isinstance(data, dict):
+        raise ValueError("the fence root must be an object")
+    if set(data) != {"consumed", "epochs"}:
+        raise ValueError("the fence must contain exactly 'consumed' and 'epochs'")
+    raw_consumed = data["consumed"]
+    raw_epochs = data["epochs"]
+    if not isinstance(raw_consumed, dict):
+        raise ValueError("the fence 'consumed' field must be an object")
+    if not isinstance(raw_epochs, dict):
+        raise ValueError("the fence 'epochs' field must be an object")
+
+    consumed: dict[str, float] = {}
+    for nonce, raw_expiry in raw_consumed.items():
+        if not isinstance(nonce, str) or not nonce:
+            raise ValueError("every consumed nonce must be a non-empty string")
+        if (
+            not isinstance(raw_expiry, (int, float))
+            or isinstance(raw_expiry, bool)
+            or not math.isfinite(float(raw_expiry))
+        ):
+            raise ValueError(f"the expiry for consumed nonce {nonce!r} is invalid")
+        consumed[nonce] = float(raw_expiry)
+
+    epochs: dict[str, int] = {}
+    for allocation_id, raw_epoch in raw_epochs.items():
+        if not isinstance(allocation_id, str) or not allocation_id:
+            raise ValueError("every fenced allocation id must be a non-empty string")
+        if (
+            not isinstance(raw_epoch, int)
+            or isinstance(raw_epoch, bool)
+            or raw_epoch < 0
+        ):
+            raise ValueError(f"the epoch for allocation {allocation_id!r} is invalid")
+        epochs[allocation_id] = raw_epoch
+    return consumed, epochs
 
 
 def write_credential_file(

--- a/openai4s/orchestration/bootstrap.py
+++ b/openai4s/orchestration/bootstrap.py
@@ -56,6 +56,11 @@ from openai4s.security.permissions import (
 #: Filename of the per-daemon signing secret, under the data dir.
 SECRET_FILENAME = "worker-bootstrap-secret"
 
+#: Filename of the durable replay fence, beside the secret. Named here rather
+#: than spelled at the one construction site, because the sandbox has to deny
+#: reads of it too and a second spelling is how the first one gets missed.
+STATE_FILENAME = "worker-bootstrap-state.json"
+
 #: Default credential lifetime. Long enough to cover a start-up that waits
 #: on a shared filesystem and a slow interpreter; short enough that a
 #: credential found in a stale workspace is already useless.
@@ -288,8 +293,23 @@ class BootstrapAuthority:
         """
         if self._state_path is None:
             return
+        # Prune here, not only in `_load_state`. The claim there -- "pruned on
+        # load, so the file cannot grow without bound across a long-lived
+        # install" -- was true only of installs that restart: load happens once,
+        # at construction, and a daemon that stays up for a month accumulated
+        # every nonce it ever burned and rewrote all of them on every worker
+        # registration. An expired nonce is refused by the expiry check anyway,
+        # so dropping it here costs nothing and bounds the file by the TTL.
+        now = self._clock()
+        live = {
+            nonce: expires
+            for nonce, expires in (getattr(self, "_consumed_expiry", {}) or {}).items()
+            if expires > now
+        }
+        self._consumed_expiry = live
+        self._consumed = set(live)
         payload = {
-            "consumed": getattr(self, "_consumed_expiry", {}),
+            "consumed": live,
             "epochs": self._current_epoch,
         }
         tmp = self._state_path.with_suffix(".tmp")
@@ -301,7 +321,19 @@ class BootstrapAuthority:
                 encoding="utf-8",
             ) as handle:
                 json.dump(payload, handle)
+                handle.flush()
+                # `os.replace` is atomic about the *directory entry*, not
+                # about the bytes: without this the rename can reach disk
+                # before the data does, and a power loss leaves the new name
+                # pointing at an empty file. `_load_state` reads an
+                # unparseable fence as tampering and fails admission closed
+                # *permanently*, so the missing fsync turned an ordinary
+                # crash into "no worker may ever register again". The sibling
+                # protocol twenty lines up (`load_or_mint_secret`) has done
+                # both of these since it was written.
+                os.fsync(handle.fileno())
             os.replace(tmp, self._state_path)
+            _fsync_dir(self._state_path.parent)
         except Exception:  # noqa: BLE001
             try:
                 tmp.unlink(missing_ok=True)
@@ -434,6 +466,7 @@ __all__ = [
     "CREDENTIAL_PATH_ENV",
     "DEFAULT_TTL_S",
     "SECRET_FILENAME",
+    "STATE_FILENAME",
     "BootstrapAuthority",
     "BootstrapCredential",
     "BootstrapError",

--- a/openai4s/orchestration/local/backend.py
+++ b/openai4s/orchestration/local/backend.py
@@ -38,6 +38,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from openai4s.execution.process_group import stop_process_group
+from openai4s.kernel.environment import name_can_carry_a_secret
 from openai4s.orchestration.models import (
     Allocation,
     ExternalHandle,
@@ -68,8 +70,11 @@ class _LocalJob:
     stderr_path: Path | None = None
     exit_code: int | None = None
     cancelled: bool = False
-    reaped: bool = False
     diagnostics: dict[str, Any] = field(default_factory=dict)
+    #: The child's process group, read at *spawn*. `os.getpgid(pid)` fails once
+    #: the leader has been reaped -- which `observe()` does on every tick --
+    #: and that is exactly when the surviving group most needs signalling.
+    pgid: int | None = None
 
 
 class LocalBackend:
@@ -167,8 +172,13 @@ class LocalBackend:
                         except OSError:
                             pass
 
+            try:
+                job_pgid: int | None = os.getpgid(process.pid)
+            except OSError:  # pragma: no cover - the child died instantly
+                job_pgid = None
             self._jobs[allocation.id] = _LocalJob(
                 allocation_id=allocation.id,
+                pgid=job_pgid,
                 token=token,
                 process=process,
                 started_at=self._clock(),
@@ -191,7 +201,21 @@ class LocalBackend:
             for key in ("PATH", "HOME", "LANG", "LC_ALL", "TMPDIR")
             if key in os.environ
         }
-        base.update(spec.environment)
+        # The spec's environment is caller-supplied -- `POST /orchestration/jobs`
+        # passes `body["environment"]` straight through, and `WorkloadSpec`
+        # validates only `command`. Taking it verbatim let a submission set
+        # `LD_PRELOAD` or `PYTHONSTARTUP` on a child of the daemon, and put a
+        # credential-shaped value into `/proc/<pid>/environ` where every other
+        # process of the same uid can read it. The scheduler sibling has
+        # refused exactly this since it was written; two backends disagreeing
+        # about the same field is the drift, not the rule.
+        for key, value in spec.environment.items():
+            if name_can_carry_a_secret(str(key)):
+                raise ValueError(
+                    f"refusing to put {key!r} in a job environment "
+                    f"(INV-9: pass a path to a 0600 file instead)"
+                )
+            base[str(key)] = str(value)
         return base
 
     # --- observation ------------------------------------------------------
@@ -220,7 +244,6 @@ class LocalBackend:
                     diagnostics=dict(job.diagnostics),
                 )
             job.exit_code = code
-            job.reaped = True
             diagnostics = dict(job.diagnostics, exit_code=code)
             if job.cancelled:
                 return Observation(
@@ -257,14 +280,15 @@ class LocalBackend:
             job.cancelled = True
             if job.process.poll() is not None:
                 return
-            try:
-                # The whole group: the command may have spawned the real work.
-                os.killpg(os.getpgid(job.process.pid), signal.SIGTERM)
-            except (ProcessLookupError, PermissionError, OSError):
-                try:
-                    job.process.terminate()
-                except OSError:
-                    return
+            # `stop_process_group`, not a bare `killpg(SIGTERM)`: it escalates
+            # to SIGKILL and then *confirms* the group is gone. A TERM that the
+            # work ignores used to return here as success, so the cancel
+            # barrier concluded "released" for a job still holding its CPUs --
+            # the one outcome the barrier exists to prevent. The shared helper
+            # is also where the escalation ladder is tuned, so this path gets
+            # future fixes instead of missing them.
+            stopped, detail = stop_process_group(job.process, job.pgid)
+            job.diagnostics["cancel"] = {"stopped": stopped, "detail": detail}
 
     def find_by_token(self, token: SubmissionToken) -> ExternalHandle | None:
         with self._lock:
@@ -296,10 +320,9 @@ class LocalBackend:
             jobs = list(self._jobs.values())
         for job in jobs:
             if job.process.poll() is None:
-                try:
-                    os.killpg(os.getpgid(job.process.pid), signal.SIGTERM)
-                except OSError:
-                    pass
+                # Same stopper as `cancel`: shutdown is the other place a
+                # group that ignores TERM turns into orphaned compute.
+                stop_process_group(job.process, job.pgid)
 
     # --- helpers ----------------------------------------------------------
 

--- a/openai4s/orchestration/local/backend.py
+++ b/openai4s/orchestration/local/backend.py
@@ -38,7 +38,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from openai4s.execution.process_group import stop_process_group
+from openai4s.execution.process_group import group_alive, stop_process_group
 from openai4s.kernel.environment import name_can_carry_a_secret
 from openai4s.orchestration.models import (
     Allocation,
@@ -100,11 +100,34 @@ class LocalBackend:
     # --- submission -------------------------------------------------------
 
     def _live_count(self) -> int:
-        return sum(
-            1
-            for job in self._jobs.values()
-            if job.exit_code is None and job.process.poll() is None
-        )
+        live = 0
+        for job in self._jobs.values():
+            code, whole_group_alive = self._poll_job(job)
+            if code is None or whole_group_alive:
+                live += 1
+        return live
+
+    @staticmethod
+    def _poll_job(job: _LocalJob) -> tuple[int | None, bool]:
+        """Return leader status/group liveness and freeze a terminal job.
+
+        A saved pgid is needed only for the short leader-exited/child-alive
+        window. Keeping it after the group is confirmed empty lets OS pgid
+        reuse resurrect a completed allocation or makes a later cancel/close
+        signal an unrelated process group. Once terminal, cache the exit code
+        and discard the pgid permanently.
+        """
+
+        if job.exit_code is not None:
+            return job.exit_code, False
+        code = job.process.poll()
+        if code is None:
+            return None, True
+        whole_group_alive = group_alive(job.pgid)
+        if not whole_group_alive:
+            job.exit_code = code
+            job.pgid = None
+        return code, whole_group_alive
 
     def submit(
         self,
@@ -172,10 +195,13 @@ class LocalBackend:
                         except OSError:
                             pass
 
-            try:
-                job_pgid: int | None = os.getpgid(process.pid)
-            except OSError:  # pragma: no cover - the child died instantly
-                job_pgid = None
+            # ``start_new_session=True`` makes the child a POSIX session
+            # leader, so its process group id is its pid by definition.  Do
+            # not ask the kernel for it after spawn: a wrapper may already
+            # have exited while a descendant remains in that group, and
+            # ``getpgid`` then loses the only handle capable of stopping the
+            # surviving work.
+            job_pgid: int | None = process.pid if os.name == "posix" else None
             self._jobs[allocation.id] = _LocalJob(
                 allocation_id=allocation.id,
                 pgid=job_pgid,
@@ -236,14 +262,22 @@ class LocalBackend:
                     )
                 return Observation(phase=Phase.SUBMITTING)
 
-            code = job.process.poll()
-            if code is None:
+            code, whole_group_alive = self._poll_job(job)
+            if code is None or whole_group_alive:
+                diagnostics = dict(job.diagnostics)
+                if code is not None:
+                    # The process we spawned was only the group leader. A
+                    # wrapper may exit after starting the real work, and that
+                    # work is still the allocation until the whole group is
+                    # empty. Publishing COMPLETED here made the reconciler
+                    # release capacity while descendants kept consuming it.
+                    diagnostics["leader_exit_code"] = code
                 return Observation(
                     phase=Phase.ACTIVE,
                     handle=self._handle(job.allocation_id),
-                    diagnostics=dict(job.diagnostics),
+                    diagnostics=diagnostics,
                 )
-            job.exit_code = code
+            assert code is not None
             diagnostics = dict(job.diagnostics, exit_code=code)
             if job.cancelled:
                 return Observation(
@@ -277,9 +311,10 @@ class LocalBackend:
             job = self._jobs.get(allocation.id)
             if job is None:
                 return
-            job.cancelled = True
-            if job.process.poll() is not None:
+            code, whole_group_alive = self._poll_job(job)
+            if code is not None and not whole_group_alive:
                 return
+            job.cancelled = True
             # `stop_process_group`, not a bare `killpg(SIGTERM)`: it escalates
             # to SIGKILL and then *confirms* the group is gone. A TERM that the
             # work ignores used to return here as success, so the cancel
@@ -289,6 +324,11 @@ class LocalBackend:
             # future fixes instead of missing them.
             stopped, detail = stop_process_group(job.process, job.pgid)
             job.diagnostics["cancel"] = {"stopped": stopped, "detail": detail}
+            if stopped:
+                code = job.process.poll()
+                if code is not None:
+                    job.exit_code = code
+                    job.pgid = None
 
     def find_by_token(self, token: SubmissionToken) -> ExternalHandle | None:
         with self._lock:
@@ -319,10 +359,21 @@ class LocalBackend:
         with self._lock:
             jobs = list(self._jobs.values())
         for job in jobs:
-            if job.process.poll() is None:
-                # Same stopper as `cancel`: shutdown is the other place a
-                # group that ignores TERM turns into orphaned compute.
-                stop_process_group(job.process, job.pgid)
+            with self._lock:
+                code, whole_group_alive = self._poll_job(job)
+            if code is not None and not whole_group_alive:
+                continue
+            # Same stopper as `cancel`: shutdown is the other place a group
+            # that ignores TERM turns into orphaned compute. The helper also
+            # handles a reaped leader with surviving descendants, which a
+            # `poll()` guard would skip.
+            stopped, _detail = stop_process_group(job.process, job.pgid)
+            if stopped:
+                with self._lock:
+                    code = job.process.poll()
+                    if code is not None:
+                        job.exit_code = code
+                        job.pgid = None
 
     # --- helpers ----------------------------------------------------------
 

--- a/openai4s/orchestration/models.py
+++ b/openai4s/orchestration/models.py
@@ -339,6 +339,15 @@ class Workload:
     phase: Phase = Phase.PENDING
     execution_epoch: int = 0
     reason: Reason | None = None
+    #: Which registered backend runs it -- a *name*, never a backend object,
+    #: so this stays a description of the ask rather than a reference to a
+    #: scheduler (INV-2). Declared rather than attached: persistence used to
+    #: `setattr` it after construction, and the reconciler and the routes both
+    #: read it back with `getattr` and two different fallbacks, so the one
+    #: field that decides *where work runs* was invisible to the type checker
+    #: and had no single default. Empty means "the caller did not say", which
+    #: is what makes `workload.backend or <default>` a meaningful sentence.
+    backend: str = ""
 
     @staticmethod
     def new_id() -> str:

--- a/openai4s/orchestration/reclaimer.py
+++ b/openai4s/orchestration/reclaimer.py
@@ -138,10 +138,11 @@ class LeaseReclaimer:
             expiry = lease.expiry(now)
             if expiry is None:
                 continue
-            report.expired += 1
             reason = _REASON_FOR[expiry]
             try:
-                stopped = self._workloads.request_stop(lease.workload_id, reason=reason)
+                expired, stopped = self._leases.expire_if_unchanged(
+                    lease, now_ms=now, reason=reason
+                )
             except Exception as exc:  # noqa: BLE001
                 report.errors.append(f"{lease.workload_id}: {exc}")
                 self.last_error = f"{lease.workload_id}: {type(exc).__name__}: {exc}"
@@ -154,11 +155,11 @@ class LeaseReclaimer:
                 # happened, so the next sweep must try again rather than
                 # inherit a lease it believes was dealt with.
                 continue
-            # Released whether or not the stop landed. `request_stop`
-            # returning False means the workload is already terminal — the
-            # resource is gone and the lease has nothing left to govern, so
-            # keeping the row live would re-examine a dead session forever.
-            self._leases.release(lease.workload_id)
+            if not expired:
+                # A touch/reopen won the CAS after this sweep's snapshot. It
+                # is current user intent and this stale pass has no work.
+                continue
+            report.expired += 1
             if stopped:
                 report.stopped += 1
             self._emit(

--- a/openai4s/orchestration/reclaimer.py
+++ b/openai4s/orchestration/reclaimer.py
@@ -102,9 +102,13 @@ class LeaseReclaimer:
 
     def stop(self, *, timeout_s: float = 5.0) -> None:
         self._stop.set()
-        thread, self._thread = self._thread, None
+        thread = self._thread
         if thread is not None:
             thread.join(timeout=timeout_s)
+        # See `Reconciler.stop`: forgetting a thread the join did not reap
+        # lets `start()` clear the stop flag under it and run two sweepers.
+        if thread is None or not thread.is_alive():
+            self._thread = None
 
     def _run(self) -> None:
         while not self._stop.is_set():
@@ -177,7 +181,7 @@ class LeaseReclaimer:
 
 def _store_is_gone(exc: BaseException) -> bool:
     text = str(exc).lower()
-    return "closed database" in text or "cannot operate on a closed database" in text
+    return "closed database" in text
 
 
 __all__ = ["DEFAULT_SWEEP_S", "LeaseReclaimer", "SweepReport"]

--- a/openai4s/orchestration/reconciler.py
+++ b/openai4s/orchestration/reconciler.py
@@ -88,6 +88,10 @@ class WorkloadStore(Protocol):
 
     def save_workload(self, workload: Workload) -> None: ...
 
+    def save_allocation_and_workload(
+        self, allocation: Allocation, workload: Workload
+    ) -> None: ...
+
     def open_recovery_epoch(
         self, allocation: Allocation, workload: Workload
     ) -> None: ...
@@ -303,9 +307,8 @@ class Reconciler:
             allocation.phase = Phase.PENDING
             allocation.reason = None
             allocation.diagnostics = dict(result.diagnostics)
-            self._store.save_allocation(allocation)
             workload.phase = Phase.PENDING
-            self._store.save_workload(workload)
+            self._store.save_allocation_and_workload(allocation, workload)
             report.submitted += 1
             self._emit(
                 "allocation_submitted",
@@ -320,8 +323,7 @@ class Reconciler:
             allocation.phase = Phase.FAILED
             allocation.reason = result.reason
             allocation.diagnostics = dict(result.diagnostics, detail=result.detail)
-            self._store.save_allocation(allocation)
-            self._fail(workload, result.reason, report)
+            self._fail(workload, result.reason, report, allocation=allocation)
             return
         # Unknown: record it and stop. The next tick reconciles by token —
         # retrying here is exactly the double-submission INV-8 exists to
@@ -348,9 +350,8 @@ class Reconciler:
             allocation.handle = handle
             allocation.phase = Phase.PENDING
             allocation.reason = None
-            self._store.save_allocation(allocation)
             workload.phase = Phase.PENDING
-            self._store.save_workload(workload)
+            self._store.save_allocation_and_workload(allocation, workload)
             report.adopted += 1
             self._emit(
                 "allocation_adopted",
@@ -377,9 +378,8 @@ class Reconciler:
             # successful resubmission emitted no event at all even though
             # `report.submitted` counted it.
             allocation.diagnostics = dict(result.diagnostics)
-            self._store.save_allocation(allocation)
             workload.phase = Phase.PENDING
-            self._store.save_workload(workload)
+            self._store.save_allocation_and_workload(allocation, workload)
             report.submitted += 1
             self._emit(
                 "allocation_submitted",
@@ -393,8 +393,7 @@ class Reconciler:
             allocation.phase = Phase.FAILED
             allocation.reason = result.reason
             allocation.diagnostics = dict(result.diagnostics, detail=result.detail)
-            self._store.save_allocation(allocation)
-            self._fail(workload, result.reason, report)
+            self._fail(workload, result.reason, report, allocation=allocation)
         # still Unknown -> leave it; the next tick asks again.
 
     def _advance(
@@ -428,14 +427,12 @@ class Reconciler:
         if observed.handle is not None:
             allocation.handle = observed.handle
         allocation.diagnostics = dict(observed.diagnostics)
-        self._store.save_allocation(allocation)
-
         if observed.phase.is_terminal:
             if self._recover_session(workload, allocation, observed, report):
                 return
             workload.phase = observed.phase
             workload.reason = observed.reason
-            self._store.save_workload(workload)
+            self._store.save_allocation_and_workload(allocation, workload)
             report.advanced += 1
             if observed.phase is not Phase.COMPLETED:
                 report.failed += 1
@@ -451,12 +448,14 @@ class Reconciler:
 
         if changed:
             workload.phase = observed.phase
-            self._store.save_workload(workload)
+            self._store.save_allocation_and_workload(allocation, workload)
             report.advanced += 1
             self._emit(
                 "workload_phase",
                 {"workload_id": workload.id, "phase": observed.phase.value},
             )
+        else:
+            self._store.save_allocation(allocation)
 
     def _recover_session(
         self,
@@ -631,10 +630,9 @@ class Reconciler:
             if allocation.handle is None:
                 allocation.phase = Phase.CANCELLED
                 allocation.reason = reason
-                self._store.save_allocation(allocation)
                 workload.phase = Phase.CANCELLED
                 workload.reason = reason
-                self._store.save_workload(workload)
+                self._store.save_allocation_and_workload(allocation, workload)
                 report.cancelled += 1
                 self._emit(
                     "workload_terminal",
@@ -677,12 +675,11 @@ class Reconciler:
         allocation.phase = observed.phase
         allocation.reason = observed.reason or reason
         allocation.diagnostics = dict(observed.diagnostics)
-        self._store.save_allocation(allocation)
         workload.phase = (
             Phase.CANCELLED if observed.phase is Phase.CANCELLED else observed.phase
         )
         workload.reason = reason
-        self._store.save_workload(workload)
+        self._store.save_allocation_and_workload(allocation, workload)
         report.cancelled += 1
         self._emit(
             "workload_terminal",
@@ -695,10 +692,20 @@ class Reconciler:
 
     # --- helpers ----------------------------------------------------------
 
-    def _fail(self, workload: Workload, reason: Reason, report: TickReport) -> None:
+    def _fail(
+        self,
+        workload: Workload,
+        reason: Reason,
+        report: TickReport,
+        *,
+        allocation: Allocation | None = None,
+    ) -> None:
         workload.phase = Phase.FAILED
         workload.reason = reason
-        self._store.save_workload(workload)
+        if allocation is None:
+            self._store.save_workload(workload)
+        else:
+            self._store.save_allocation_and_workload(allocation, workload)
         report.failed += 1
         self._emit(
             "workload_terminal",

--- a/openai4s/orchestration/reconciler.py
+++ b/openai4s/orchestration/reconciler.py
@@ -175,9 +175,18 @@ class Reconciler:
 
     def stop(self, *, timeout_s: float = 5.0) -> None:
         self._stop.set()
-        thread, self._thread = self._thread, None
+        thread = self._thread
         if thread is not None:
             thread.join(timeout=timeout_s)
+        # Only forget the thread once it is actually gone. Clearing the
+        # reference on a join *timeout* made `running()` answer False for a
+        # thread that was still ticking, and `start()` then both revived it
+        # (`_stop.clear()`) and spawned a second one beside it -- two
+        # reconcilers submitting for the same workloads. A tick can outlast
+        # five seconds honestly -- a backend query has its own, longer,
+        # timeout -- so the join timing out is an ordinary event.
+        if thread is None or not thread.is_alive():
+            self._thread = None
 
     def _run(self) -> None:
         while not self._stop.is_set():
@@ -222,7 +231,7 @@ class Reconciler:
         return report
 
     def _backend_for(self, workload: Workload) -> AllocationBackend:
-        name = getattr(workload, "backend", None) or self._default_backend
+        name = workload.backend or self._default_backend
         try:
             return self._backends[name]
         except KeyError:
@@ -359,13 +368,31 @@ class Reconciler:
             allocation.handle = result.handle
             allocation.phase = Phase.PENDING
             allocation.reason = None
+            # Both of these were missing here and present in `_submit_new`.
+            # The row this path loads was written by the *previous* attempt
+            # with `BACKEND_SUBMISSION_UNKNOWN` and its failure detail, and
+            # `save_allocation` re-serialises whatever `diagnostics` holds --
+            # so every allocation that recovered through INV-8 carried the
+            # dead attempt's error text for the rest of its life, and the
+            # successful resubmission emitted no event at all even though
+            # `report.submitted` counted it.
+            allocation.diagnostics = dict(result.diagnostics)
             self._store.save_allocation(allocation)
             workload.phase = Phase.PENDING
             self._store.save_workload(workload)
             report.submitted += 1
+            self._emit(
+                "allocation_submitted",
+                {
+                    "workload_id": workload.id,
+                    "allocation_id": allocation.id,
+                    "existing": isinstance(result, Existing),
+                },
+            )
         elif isinstance(result, Rejected):
             allocation.phase = Phase.FAILED
             allocation.reason = result.reason
+            allocation.diagnostics = dict(result.diagnostics, detail=result.detail)
             self._store.save_allocation(allocation)
             self._fail(workload, result.reason, report)
         # still Unknown -> leave it; the next tick asks again.
@@ -387,7 +414,15 @@ class Reconciler:
             )
             return
 
-        changed = observed.phase is not allocation.phase
+        # Against the *workload*, not the allocation this method is about to
+        # overwrite. Comparing with `allocation.phase` made the comparison
+        # answer a question that had already been answered: `save_allocation`
+        # commits first, so a `save_workload` that fails after it leaves the
+        # next tick seeing observed == allocation, `changed` False, and the
+        # workload row stale for the rest of the run. "Safe to run twice" is
+        # the property this module claims, and it needs the predicate to be
+        # about the state that is still wrong.
+        changed = observed.phase is not workload.phase
         allocation.phase = observed.phase
         allocation.reason = observed.reason
         if observed.handle is not None:
@@ -422,8 +457,6 @@ class Reconciler:
                 "workload_phase",
                 {"workload_id": workload.id, "phase": observed.phase.value},
             )
-
-    # --- recovery ---------------------------------------------------------
 
     def _recover_session(
         self,
@@ -532,6 +565,19 @@ class Reconciler:
             workload.reason = reason
             self._store.save_workload(workload)
             report.cancelled += 1
+            # And say so. Every other terminal transition in this file emits
+            # `workload_terminal`, and it is one of the two kinds the daemon
+            # acts on -- so cancelling before an allocation ever existed was
+            # the one ending that happened invisibly: nothing in the log,
+            # nothing on the operator page.
+            self._emit(
+                "workload_terminal",
+                {
+                    "workload_id": workload.id,
+                    "phase": Phase.CANCELLED.value,
+                    "reason": reason.value if reason else None,
+                },
+            )
             return
 
         # 2-3. cancel active tasks and drain. The task plane is the kernel's
@@ -647,32 +693,6 @@ class Reconciler:
             },
         )
 
-    # --- recovery ---------------------------------------------------------
-
-    def recover(self, workload: Workload, *, reason: Reason) -> Allocation | None:
-        """Start a new epoch after a lost allocation (INV-6/INV-7).
-
-        History is not rewritten: the old allocation keeps its terminal
-        phase, the workload's epoch increments, and the next tick submits
-        under a *new* token. An old epoch's callbacks are refused by whoever
-        holds the epoch fence, which is why this returns the new allocation
-        rather than mutating the old one.
-        """
-        current = self._store.active_allocation(workload.id)
-        if current is not None:
-            current.phase = Phase.LOST
-            current.reason = reason
-            self._store.save_allocation(current)
-        workload.execution_epoch += 1
-        workload.phase = Phase.PENDING
-        workload.reason = reason
-        self._store.save_workload(workload)
-        self._emit(
-            "workload_recovered",
-            {"workload_id": workload.id, "epoch": workload.execution_epoch},
-        )
-        return None
-
     # --- helpers ----------------------------------------------------------
 
     def _fail(self, workload: Workload, reason: Reason, report: TickReport) -> None:
@@ -706,15 +726,9 @@ def _store_is_gone(exc: BaseException) -> bool:
     return "closed database" in str(exc).lower()
 
 
-def new_token() -> SubmissionToken:
-    """Re-exported so a store implementation need not import models directly."""
-    return SubmissionToken.mint()
-
-
 __all__ = [
     "DEFAULT_INTERVAL_S",
     "Reconciler",
     "TickReport",
     "WorkloadStore",
-    "new_token",
 ]

--- a/openai4s/orchestration/session.py
+++ b/openai4s/orchestration/session.py
@@ -34,6 +34,8 @@ from __future__ import annotations
 
 import os
 import sys
+import threading
+from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable
@@ -45,6 +47,7 @@ from openai4s.orchestration.bootstrap import (
 )
 from openai4s.orchestration.models import (
     Allocation,
+    DesiredState,
     Phase,
     RecoveryStrategy,
     ResourceProfile,
@@ -56,6 +59,7 @@ from openai4s.orchestration.models import (
 from openai4s.orchestration.reconciler import (
     DEFAULT_MAX_RECOVERIES as _DEFAULT_MAX_RECOVERIES,
 )
+from openai4s.security.permissions import harden_dir
 
 #: Where the worker is told to dial. Read by `kernel/worker.py`.
 CONNECT_ENV = "OPENAI4S_WORKER_CONNECT"
@@ -64,6 +68,9 @@ CONNECT_ENV = "OPENAI4S_WORKER_CONNECT"
 #: The resource plane's own launcher expands it, because which variable
 #: holds a node's rank is that plane's vocabulary and not this layer's.
 CREDENTIAL_PATH_TEMPLATE_ENV = "OPENAI4S_WORKER_BOOTSTRAP_PATH_TEMPLATE"
+#: The value names the resource-plane environment variable containing this
+#: worker's integer rank. The core expands no scheduler vocabulary itself.
+RANK_ENV_NAME_ENV = "OPENAI4S_WORKER_RANK_ENV"
 
 #: How long a credential is good for. Long enough to survive a queue wait
 #: that the site's scheduler decides, short enough that one recovered from
@@ -169,6 +176,7 @@ class SessionRuntime:
     registrations: list[Any] = field(default_factory=list)
     kernel: Any = None
     kernel_ready: bool = False
+    ever_ready: bool = False
     state_lost_epochs: list[int] = field(default_factory=list)
 
     def public(self) -> dict[str, Any]:
@@ -307,6 +315,39 @@ def _default_advertise_host() -> str:
         return "127.0.0.1"
 
 
+def _registration_alive(registration: Any) -> bool:
+    """Whether a parked worker's shared transport is still usable.
+
+    Lightweight test doubles predate the transport protocol and have no
+    ``alive`` method; production registrations always do. Unknown doubles stay
+    compatible, while an exception from a real liveness probe is a denial.
+    """
+
+    transport = getattr(registration, "transport", None)
+    alive = getattr(transport, "alive", None)
+    if not callable(alive):
+        return True
+    try:
+        return bool(alive())
+    except Exception:  # noqa: BLE001 — undecidable is not a live worker
+        return False
+
+
+def _close_registrations(registrations: list[Any]) -> None:
+    """Close worker transports whose ownership cannot be published."""
+
+    seen: set[int] = set()
+    for registration in registrations:
+        transport = getattr(registration, "transport", None)
+        if transport is None or id(transport) in seen:
+            continue
+        seen.add(id(transport))
+        try:
+            transport.close(graceful=False)
+        except Exception:  # noqa: BLE001 — stale handoff cleanup is best-effort
+            pass
+
+
 class ComputeSessionManager:
     """Ties a chat session to a workload, a lease, and a remote kernel.
 
@@ -331,11 +372,27 @@ class ComputeSessionManager:
         self._gateway = gateway
         self._authority = authority
         self._workspace_root = Path(workspace_root)
+        # Bubblewrap can only mask paths that exist when the sandbox is
+        # assembled. Create the credential-bearing parent before any local
+        # kernel can start, so a later first cluster request cannot make a new
+        # readable directory appear through the sandbox's read-only root bind.
+        self._workspace_root.mkdir(parents=True, exist_ok=True)
+        harden_dir(self._workspace_root)
         self._kernel_factory = kernel_factory
         self._idle_ttl_s = idle_ttl_s
         self._max_lifetime_s = max_lifetime_s
         self._on_event = on_event or (lambda kind, payload: None)
         self._runtimes: dict[str, SessionRuntime] = {}
+        # One session request spans several repository calls and an in-memory
+        # runtime publication.  ThreadingHTTPServer may execute two POSTs for
+        # the same session concurrently; without a manager boundary both saw
+        # no binding, created a workload, then one overwrote the other's
+        # binding and left an orphan job eligible for submission.
+        self._lock = threading.RLock()
+        set_expectation = getattr(gateway, "set_registration_expectation", None)
+        expected = getattr(store.workloads, "session_registration_expected", None)
+        if callable(set_expectation) and callable(expected):
+            set_expectation(expected)
 
     # --- workspaces -------------------------------------------------------
 
@@ -386,38 +443,55 @@ class ComputeSessionManager:
         if not strategy.supported:
             raise UnsupportedRecoveryStrategy(strategy)
 
-        existing = self._store.leases.workload_for_session(session_id)
-        if existing:
-            found = self._store.workloads.get_workload(existing)
-            if found is not None and not found.phase.is_terminal:
-                return found
+        with self._lock:
+            existing = self._store.leases.workload_for_session(session_id)
+            if existing:
+                found = self._store.workloads.get_workload(existing)
+                if found is not None and not found.phase.is_terminal:
+                    return found
 
-        workspace = self.ensure_workspace(session_id)
-        spec = WorkloadSpec(
-            kind=WorkloadKind.SESSION,
-            profile=profile,
-            workdir=str(workspace),
-            environment=dict(environment or {}),
-        )
-        workload = self._store.workloads.create_workload(
-            spec=spec,
-            owner_user_id=owner_user_id,
-            project_id=project_id,
-            backend=backend,
-        )
-        # The workspace is keyed by workload from here on; the session-keyed
-        # one above only existed to have somewhere to stand before an id
-        # existed.
-        self.ensure_workspace(workload.id)
-        self._store.leases.bind_session(session_id, workload.id)
-        self._store.leases.open_lease(
-            workload.id,
-            idle_ttl_s=self._idle_ttl_s,
-            max_lifetime_s=self._max_lifetime_s,
-        )
-        self._runtimes[session_id] = SessionRuntime(
-            session_id=session_id, workload_id=workload.id
-        )
+            workspace = self.ensure_workspace(session_id)
+            spec = WorkloadSpec(
+                kind=WorkloadKind.SESSION,
+                profile=profile,
+                workdir=str(workspace),
+                environment=dict(environment or {}),
+            )
+            create_session = getattr(
+                self._store.workloads, "create_session_workload", None
+            )
+            if callable(create_session):
+                workload = create_session(
+                    session_id=session_id,
+                    spec=spec,
+                    owner_user_id=owner_user_id,
+                    project_id=project_id,
+                    backend=backend,
+                    idle_ttl_s=self._idle_ttl_s,
+                    max_lifetime_s=self._max_lifetime_s,
+                )
+            else:
+                # Compatibility for protocol-level test stores. Production
+                # repositories implement the atomic operation above.
+                workload = self._store.workloads.create_workload(
+                    spec=spec,
+                    owner_user_id=owner_user_id,
+                    project_id=project_id,
+                    backend=backend,
+                )
+                self._store.leases.bind_session(session_id, workload.id)
+                self._store.leases.open_lease(
+                    workload.id,
+                    idle_ttl_s=self._idle_ttl_s,
+                    max_lifetime_s=self._max_lifetime_s,
+                )
+            # The workspace is keyed by workload from here on; the
+            # session-keyed one above only existed to have somewhere to stand
+            # before an id existed.
+            self.ensure_workspace(workload.id)
+            self._runtimes[session_id] = SessionRuntime(
+                session_id=session_id, workload_id=workload.id
+            )
         self._emit(
             "session_workload_requested",
             {"session_id": session_id, "workload_id": workload.id},
@@ -427,27 +501,40 @@ class ComputeSessionManager:
     def readiness(self, session_id: str) -> SessionReadiness:
         """INV-5, evaluated against durable state — never against a cached
         'we were ready a minute ago'."""
-        workload_id = self._store.leases.workload_for_session(session_id)
-        if not workload_id:
-            return SessionReadiness()
-        allocation = self._store.workloads.active_allocation(workload_id)
-        granted = allocation is not None and allocation.phase in (
-            Phase.GRANTED,
-            Phase.ACTIVE,
-        )
-        runtime = self._runtimes.get(session_id)
-        workload = self._store.workloads.get_workload(workload_id)
-        expected = 1
-        if workload is not None:
-            expected = max(1, int(workload.spec.profile.nodes))
-        return SessionReadiness(
-            allocation_granted=granted,
-            worker_registered=bool(runtime and runtime.registration is not None),
-            workspace_ready=self.workspace_for(workload_id).is_dir(),
-            kernel_ready=bool(runtime and runtime.kernel_ready),
-            workers_expected=expected,
-            workers_registered=len(runtime.registrations) if runtime else 0,
-        )
+        with self._lock:
+            workload_id = self._store.leases.workload_for_session(session_id)
+            if not workload_id:
+                return SessionReadiness()
+            allocation = self._store.workloads.active_allocation(workload_id)
+            granted = allocation is not None and allocation.phase in (
+                Phase.GRANTED,
+                Phase.ACTIVE,
+            )
+            runtime = self._runtimes.get(session_id)
+            workload = self._store.workloads.get_workload(workload_id)
+            expected = 1
+            if workload is not None:
+                expected = max(1, int(workload.spec.profile.nodes))
+            live_registrations = (
+                [r for r in runtime.registrations if _registration_alive(r)]
+                if runtime
+                else []
+            )
+            registration_live = bool(
+                runtime
+                and runtime.registration is not None
+                and _registration_alive(runtime.registration)
+            )
+            return SessionReadiness(
+                allocation_granted=granted,
+                worker_registered=registration_live,
+                workspace_ready=self.workspace_for(workload_id).is_dir(),
+                kernel_ready=bool(
+                    runtime and runtime.kernel_ready and registration_live
+                ),
+                workers_expected=expected,
+                workers_registered=len(live_registrations),
+            )
 
     def attach_worker(self, session_id: str, *, timeout_s: float = 60.0) -> bool:
         """Wait for this attempt's worker to dial in, then build its Kernel.
@@ -470,46 +557,72 @@ class ComputeSessionManager:
             expected=expected,
             timeout_s=timeout_s,
         )
-        runtime = self._runtimes.setdefault(
-            session_id,
-            SessionRuntime(session_id=session_id, workload_id=workload_id),
-        )
-        # Record the partial set even when it is short. A caller that threw
-        # away three of four registrations would leave those workers
-        # connected, waiting, and unreleasable — and the UI would have no
-        # way to say "3 of 4" rather than "not ready".
-        #
-        # Merged, not assigned, and keyed by rank. `attach_worker` is called
-        # again on every cell while the gang is incomplete, so an assignment
-        # made each retry start from whatever that call happened to see:
-        # with a 5s timeout and ranks arriving 5s apart, attempt one took
-        # rank 0, attempt two saw only rank 1 and overwrote it, and the gang
-        # could never complete. Rank is the identity because a re-dial of
-        # the same rank replaces its predecessor rather than counting twice.
-        if runtime.epoch != workload.execution_epoch:
-            # A new epoch is a new attempt: the previous epoch's workers are
-            # fenced out by the credential anyway, and carrying them here
-            # would let a dead attempt's count satisfy this one's gang.
-            runtime.registrations = []
-        by_rank = {int(getattr(r, "rank", 0)): r for r in runtime.registrations}
-        by_rank.update({int(getattr(r, "rank", 0)): r for r in arrivals})
-        runtime.registrations = [by_rank[k] for k in sorted(by_rank)]
-        arrivals = runtime.registrations
-        runtime.epoch = workload.execution_epoch
-        if len(arrivals) < expected:
-            return False
-        # Rank 0, not "whichever arrived first". One interpreter runs the
-        # cell and the rest are its peers, and which one that is has to be
-        # the same node the user's code thinks it is -- a distributed job
-        # whose driver is chosen by network timing is a job whose results
-        # depend on network timing.
-        registration = next(
-            (r for r in arrivals if int(getattr(r, "rank", 0)) == 0), arrivals[0]
-        )
-        runtime.registration = registration
-        if self._kernel_factory is not None:
-            runtime.kernel = self._kernel_factory(registration)
-            runtime.kernel_ready = True
+        with self._lock:
+            # Release/recovery may have won while the gateway wait was outside
+            # our lock.  Never publish those late arrivals into a different
+            # binding or epoch.
+            current_id = self._store.leases.workload_for_session(session_id)
+            current_workload = (
+                self._store.workloads.get_workload(current_id) if current_id else None
+            )
+            if (
+                current_id != workload_id
+                or current_workload is None
+                or current_workload.execution_epoch != workload.execution_epoch
+            ):
+                # A complete gang was popped out of the gateway before this
+                # identity recheck. No gateway reaper or manager runtime owns
+                # those sockets now, so a release/recovery winner must close
+                # them here rather than leak one transport per rank.
+                _close_registrations(list(arrivals))
+                return False
+            runtime = self._runtimes.setdefault(
+                session_id,
+                SessionRuntime(session_id=session_id, workload_id=workload_id),
+            )
+            # Record the partial set even when it is short. A caller that threw
+            # away three of four registrations would leave those workers
+            # connected, waiting, and unreleasable — and the UI would have no
+            # way to say "3 of 4" rather than "not ready".
+            #
+            # Merged, not assigned, and keyed by rank. `attach_worker` is called
+            # again on every cell while the gang is incomplete, so an assignment
+            # made each retry start from whatever that call happened to see:
+            # with a 5s timeout and ranks arriving 5s apart, attempt one took
+            # rank 0, attempt two saw only rank 1 and overwrote it, and the gang
+            # could never complete. Rank is the identity because a re-dial of
+            # the same rank replaces its predecessor rather than counting twice.
+            if runtime.epoch != workload.execution_epoch:
+                # A new epoch is a new attempt: the previous epoch's workers are
+                # fenced out by the credential anyway, and carrying them here
+                # would let a dead attempt's count satisfy this one's gang.
+                runtime.registrations = []
+            live_existing = [r for r in runtime.registrations if _registration_alive(r)]
+            live_arrivals = [r for r in arrivals if _registration_alive(r)]
+            if runtime.registration is not None and not _registration_alive(
+                runtime.registration
+            ):
+                runtime.registration = None
+            by_rank = {int(getattr(r, "rank", 0)): r for r in live_existing}
+            by_rank.update({int(getattr(r, "rank", 0)): r for r in live_arrivals})
+            runtime.registrations = [by_rank[k] for k in sorted(by_rank)]
+            arrivals = runtime.registrations
+            runtime.epoch = workload.execution_epoch
+            if len(arrivals) < expected:
+                return False
+            # Rank 0, not "whichever arrived first". One interpreter runs the
+            # cell and the rest are its peers, and which one that is has to be
+            # the same node the user's code thinks it is -- a distributed job
+            # whose driver is chosen by network timing is a job whose results
+            # depend on network timing.
+            registration = next(
+                (r for r in arrivals if int(getattr(r, "rank", 0)) == 0),
+                arrivals[0],
+            )
+            runtime.registration = registration
+            if self._kernel_factory is not None:
+                runtime.kernel = self._kernel_factory(registration)
+                runtime.kernel_ready = True
         self._emit(
             "session_worker_attached",
             {
@@ -519,6 +632,49 @@ class ComputeSessionManager:
             },
         )
         return True
+
+    def discard_unbound_registration(self, session_id: str) -> None:
+        """Forget a worker whose Kernel candidate never committed.
+
+        Candidate shutdown closes its transport. Keeping that Registration in
+        the runtime would make the next Cell reuse a dead socket and report a
+        worker as ready even though the supervisor correctly rejected it.
+        A bound kernel is already committed ownership and is deliberately not
+        changed here.
+        """
+
+        with self._lock:
+            runtime = self._runtimes.get(session_id)
+            if runtime is None or runtime.kernel is not None:
+                return
+            runtime.registration = None
+            runtime.registrations = []
+            runtime.kernel_ready = False
+
+    def discard_dead_registration(self, session_id: str) -> None:
+        """Forget a latched-dead worker and any Kernel built over it."""
+
+        kernel = None
+        with self._lock:
+            runtime = self._runtimes.get(session_id)
+            if (
+                runtime is None
+                or runtime.registration is None
+                or _registration_alive(runtime.registration)
+            ):
+                return
+            kernel = runtime.kernel
+            runtime.registration = None
+            runtime.registrations = [
+                r for r in runtime.registrations if _registration_alive(r)
+            ]
+            runtime.kernel = None
+            runtime.kernel_ready = False
+        if kernel is not None:
+            try:
+                kernel.shutdown()
+            except Exception:  # noqa: BLE001
+                pass
 
     def note_state_lost(self, workload_id: str, *, epoch: int) -> None:
         """Recovery happened. Say so — INV-11 forbids quietly continuing.
@@ -533,14 +689,22 @@ class ComputeSessionManager:
         session_id = self._store.leases.session_for_workload(workload_id)
         if not session_id:
             return
-        runtime = self._runtimes.get(session_id)
-        if runtime is not None:
-            runtime.registration = None
-            runtime.registrations = []
-            runtime.kernel = None
-            runtime.kernel_ready = False
-            if epoch not in runtime.state_lost_epochs:
-                runtime.state_lost_epochs.append(epoch)
+        kernel = None
+        with self._lock:
+            runtime = self._runtimes.get(session_id)
+            if runtime is not None:
+                kernel = runtime.kernel
+                runtime.registration = None
+                runtime.registrations = []
+                runtime.kernel = None
+                runtime.kernel_ready = False
+                if epoch not in runtime.state_lost_epochs:
+                    runtime.state_lost_epochs.append(epoch)
+        if kernel is not None:
+            try:
+                kernel.shutdown()
+            except Exception:  # noqa: BLE001
+                pass
         self._emit(
             "session_kernel_state_lost",
             {"session_id": session_id, "workload_id": workload_id, "epoch": epoch},
@@ -548,38 +712,82 @@ class ComputeSessionManager:
 
     def touch(self, session_id: str) -> bool:
         """A user did something. The *only* thing that renews a lease."""
-        workload_id = self._store.leases.workload_for_session(session_id)
-        if not workload_id:
-            return False
-        return self._store.leases.touch(workload_id)
+        with self._lock:
+            workload_id = self._store.leases.workload_for_session(session_id)
+            if not workload_id:
+                return False
+            return self._store.leases.touch(workload_id)
 
-    def release(self, session_id: str, *, reason: Any) -> bool:
-        workload_id = self._store.leases.workload_for_session(session_id)
-        if not workload_id:
-            return False
-        stopped = self._store.workloads.request_stop(workload_id, reason=reason)
-        self._store.leases.release(workload_id)
-        # Drop the binding too. `request_stop` writes intent, not phase, so
-        # the workload stays non-terminal while the cancel barrier tears it
-        # down -- and `request_session` short-circuits on any non-terminal
-        # workload it finds bound to the session. Leaving the row meant the
-        # next request handed the user back the resource that was being
-        # released, with a lease already marked released and therefore
-        # impossible to renew.
-        self._store.leases.unbind_session(session_id)
-        runtime = self._runtimes.pop(session_id, None)
-        if runtime is not None and runtime.kernel is not None:
+    def release(
+        self,
+        session_id: str,
+        *,
+        reason: Any,
+        expected_workload_id: str | None = None,
+    ) -> bool:
+        with self._lock:
+            release_atomic = getattr(
+                self._store.workloads, "release_session_workload", None
+            )
+            if callable(release_atomic):
+                workload_id = release_atomic(
+                    session_id=session_id,
+                    reason=reason,
+                    expected_workload_id=expected_workload_id,
+                )
+                if not workload_id:
+                    return False
+            else:
+                # Compatibility for small protocol fakes.  Production Store
+                # always takes the transaction above.
+                workload_id = self._store.leases.workload_for_session(session_id)
+                if not workload_id:
+                    return False
+                if (
+                    expected_workload_id is not None
+                    and workload_id != expected_workload_id
+                ):
+                    return False
+                self._store.workloads.request_stop(workload_id, reason=reason)
+                self._store.leases.release(workload_id)
+                self._store.leases.unbind_session(session_id)
+            runtime = self._runtimes.pop(session_id, None)
+        kernel = runtime.kernel if runtime is not None else None
+        if kernel is not None:
             try:
-                runtime.kernel.shutdown()
+                kernel.shutdown()
+            except Exception:  # noqa: BLE001
+                pass
+        seen_transports: set[int] = set()
+        for registration in runtime.registrations if runtime is not None else ():
+            transport = getattr(registration, "transport", None)
+            if transport is None or id(transport) in seen_transports:
+                continue
+            seen_transports.add(id(transport))
+            if kernel is not None and getattr(kernel, "_transport", None) is transport:
+                continue
+            try:
+                transport.close(graceful=False)
             except Exception:  # noqa: BLE001
                 pass
         self._emit(
             "session_released",
             {"session_id": session_id, "workload_id": workload_id},
         )
-        return stopped
+        # This return value answers whether the expected binding was consumed,
+        # not whether request_stop happened to change a row. A terminal or
+        # already-stopping workload still needs its runtime/supervisor cleanup.
+        return True
 
-    def bind_kernel(self, session_id: str, kernel: Any) -> bool:
+    def bind_kernel(
+        self,
+        session_id: str,
+        kernel: Any,
+        *,
+        expected_workload_id: str | None = None,
+        expected_epoch: int | None = None,
+        expected_transport: Any = None,
+    ) -> bool:
         """Record the Kernel a caller built over this session's worker.
 
         The manager deliberately does not construct it. A session's kernel is
@@ -590,15 +798,93 @@ class ComputeSessionManager:
         answer the fourth condition (INV-5) from something that exists rather
         than from something that was arranged.
         """
-        runtime = self._runtimes.get(session_id)
-        if runtime is None:
-            return False
-        runtime.kernel = kernel
-        runtime.kernel_ready = kernel is not None
-        return True
+        with self._lock:
+            workload_id = self._store.leases.workload_for_session(session_id)
+            runtime = self._runtimes.get(session_id)
+            if runtime is None or not workload_id:
+                return False
+            if expected_workload_id is not None and workload_id != expected_workload_id:
+                return False
+            if runtime.workload_id != workload_id:
+                return False
+            workload = self._store.workloads.get_workload(workload_id)
+            if workload is None:
+                return False
+            lease = self._store.leases.get(workload_id)
+            if (
+                workload.desired_state is not DesiredState.RUNNING
+                or workload.phase.is_terminal
+                or lease is None
+                or lease.released_at is not None
+            ):
+                return False
+            if expected_epoch is not None and (
+                runtime.epoch != expected_epoch
+                or workload.execution_epoch != expected_epoch
+            ):
+                return False
+            registration = runtime.registration
+            if registration is None or not _registration_alive(registration):
+                return False
+            if expected_transport is not None and (
+                getattr(registration, "transport", None) is not expected_transport
+            ):
+                return False
+            runtime.kernel = kernel
+            runtime.kernel_ready = kernel is not None
+            runtime.ever_ready = kernel is not None
+            return True
+
+    @contextmanager
+    def kernel_binding_guard(
+        self,
+        session_id: str,
+        *,
+        expected_workload_id: str,
+        expected_epoch: int,
+        expected_transport: Any,
+    ):
+        """Freeze the durable/runtime identity while a candidate is published.
+
+        The supervisor and compute manager are separate ownership domains. A
+        recovery, release or lease expiry between their commits must not leave
+        one pointing at a worker the other rejected.  Holding both manager and
+        Store locks makes the caller's supervisor publish + ``bind_kernel`` a
+        single identity decision; no protocol read occurs in this section.
+        """
+
+        store_lock = getattr(self._store, "_lock", None)
+        with self._lock:
+            with store_lock if store_lock is not None else nullcontext():
+                workload_id = self._store.leases.workload_for_session(session_id)
+                runtime = self._runtimes.get(session_id)
+                workload = (
+                    self._store.workloads.get_workload(workload_id)
+                    if workload_id
+                    else None
+                )
+                lease = self._store.leases.get(workload_id) if workload_id else None
+                registration = runtime.registration if runtime is not None else None
+                current = bool(
+                    workload_id == expected_workload_id
+                    and runtime is not None
+                    and runtime.workload_id == expected_workload_id
+                    and runtime.epoch == expected_epoch
+                    and workload is not None
+                    and workload.execution_epoch == expected_epoch
+                    and workload.desired_state is DesiredState.RUNNING
+                    and not workload.phase.is_terminal
+                    and lease is not None
+                    and lease.released_at is None
+                    and registration is not None
+                    and _registration_alive(registration)
+                    and getattr(registration, "transport", None) is expected_transport
+                )
+                yield current
 
     def runtime(self, session_id: str) -> SessionRuntime | None:
-        return self._runtimes.get(session_id)
+        with self._lock:
+            return self._runtimes.get(session_id)
 
     def _emit(self, kind: str, payload: dict) -> None:
         try:
@@ -610,6 +896,7 @@ class ComputeSessionManager:
 __all__ = [
     "CONNECT_ENV",
     "CREDENTIAL_PATH_TEMPLATE_ENV",
+    "RANK_ENV_NAME_ENV",
     "CREDENTIAL_TTL_S",
     "DEFAULT_IDLE_TTL_S",
     "DEFAULT_MAX_LIFETIME_S",

--- a/openai4s/orchestration/slurm/backend.py
+++ b/openai4s/orchestration/slurm/backend.py
@@ -173,8 +173,21 @@ class SlurmBackend:
         # Existing rather than a second job.
         try:
             already = self._broker.find_by_comment(allocation.submission_token.value)
-        except SlurmCommandError:
-            already = None
+        except SlurmCommandError as exc:
+            # An unanswerable lookup is `Unknown`, not "nothing carries it".
+            # Swallowing the error to None and carrying on inverted the whole
+            # invariant: `find_by_comment` raises on a timeout or an
+            # unreachable controller precisely because absence of an answer is
+            # not an answer of absence -- and the next statement submitted a
+            # second job for a token that may well already have one. The
+            # reconciler's `_reconcile_unknown` is what is allowed to decide a
+            # fresh submission is safe, and only after the backend has
+            # actually answered.
+            return Unknown(
+                token=allocation.submission_token,
+                detail=str(exc),
+                diagnostics={"command": list(exc.command), "phase": "find_by_token"},
+            )
         if already:
             return Existing(handle=self._handle(already))
 
@@ -291,11 +304,11 @@ class SlurmBackend:
         phase, reason = _STATE_MAP.get(status.state, (Phase.ACTIVE, None))
         if phase is Phase.PENDING and status.reason in _UNSCHEDULABLE_REASONS:
             phase, reason = Phase.FAILED, Reason.UNSCHEDULABLE
-        if phase is Phase.FAILED and reason is None and status.exit_code:
-            # An exit code is the detail an operator wants, but it does not
-            # change the reason: a nonzero exit is a failure of the work,
-            # which has no more specific cause than "it failed".
-            pass
+        # No branch on `status.exit_code` here: an exit code is the detail an
+        # operator wants and it is already carried in `diagnostics`, but it
+        # does not change the *reason* -- a nonzero exit is a failure of the
+        # work, which has no more specific cause than "it failed". The
+        # condition used to be spelled out and then do nothing.
         return Observation(
             phase=phase,
             reason=reason,

--- a/openai4s/orchestration/slurm/backend.py
+++ b/openai4s/orchestration/slurm/backend.py
@@ -37,6 +37,7 @@ from openai4s.orchestration.models import (
     Reason,
     ResourceProfile,
     SubmissionToken,
+    WorkloadKind,
     WorkloadSpec,
 )
 from openai4s.orchestration.ports import (
@@ -60,6 +61,12 @@ _STATE_MAP: dict[str, tuple[Phase, Reason | None]] = {
     "PENDING": (Phase.PENDING, None),
     "CONFIGURING": (Phase.PENDING, None),
     "REQUEUED": (Phase.PENDING, None),
+    "REQUEUE_HOLD": (Phase.PENDING, None),
+    "REQUEUE_FED": (Phase.PENDING, None),
+    "RESV_DEL_HOLD": (Phase.PENDING, None),
+    "EXPEDITING": (Phase.PENDING, None),
+    "POWER_UP_NODE": (Phase.PENDING, None),
+    "SPECIAL_EXIT": (Phase.PENDING, None),
     "RESIZING": (Phase.ACTIVE, None),
     "RUNNING": (Phase.ACTIVE, None),
     "SUSPENDED": (Phase.ACTIVE, None),
@@ -67,6 +74,8 @@ _STATE_MAP: dict[str, tuple[Phase, Reason | None]] = {
     "COMPLETED": (Phase.COMPLETED, None),
     "CANCELLED": (Phase.CANCELLED, Reason.USER_CANCELLED),
     "FAILED": (Phase.FAILED, None),
+    "LAUNCH_FAILED": (Phase.FAILED, Reason.BOOTSTRAP_FAILED),
+    "RECONFIG_FAIL": (Phase.FAILED, None),
     "TIMEOUT": (Phase.FAILED, Reason.TIME_LIMIT_EXCEEDED),
     "OUT_OF_MEMORY": (Phase.FAILED, Reason.OUT_OF_MEMORY),
     "NODE_FAIL": (Phase.LOST, Reason.NODE_FAILED),
@@ -74,7 +83,6 @@ _STATE_MAP: dict[str, tuple[Phase, Reason | None]] = {
     "BOOT_FAIL": (Phase.FAILED, Reason.BOOTSTRAP_FAILED),
     "DEADLINE": (Phase.FAILED, Reason.TIME_LIMIT_EXCEEDED),
     "REVOKED": (Phase.CANCELLED, Reason.ADMIN_CANCELLED),
-    "SPECIAL_EXIT": (Phase.FAILED, None),
 }
 
 #: Queue reasons that mean "this will never schedule". Everything else is
@@ -86,9 +94,7 @@ _UNSCHEDULABLE_REASONS = frozenset(
         "PartitionNodeLimit",
         "PartitionTimeLimit",
         "QOSMaxWallDurationPerJobLimit",
-        "QOSGrpCpuLimit",
         "BadConstraints",
-        "NodeDown",
         "InvalidQOS",
         "InvalidAccount",
     }
@@ -133,15 +139,39 @@ class SlurmBackend:
         profile: ResourceProfile,
     ) -> SubmitSpec:
         site = self._cluster_profile(profile)
-        prefix = self._cluster.job_name_prefix or "openai4s"
         script_lines = ["#!/bin/sh", "set -eu"]
         if spec.workdir:
             script_lines.append(f"cd {_sh_quote(spec.workdir)}")
-        script_lines.append(" ".join(_sh_quote(part) for part in spec.command))
+        command = tuple(spec.command)
+        environment = dict(spec.environment)
+        if spec.kind is WorkloadKind.SESSION and int(profile.nodes) > 1:
+            # A batch script itself runs once, on its first node. Gang
+            # readiness needs one worker per node, and srun is the scheduler's
+            # in-allocation launcher that also supplies a distinct SLURM_PROCID
+            # to each task. The worker resolves its credential template from
+            # that variable; no credential value enters the job environment.
+            from openai4s.orchestration.session import RANK_ENV_NAME_ENV
+
+            environment[RANK_ENV_NAME_ENV] = "SLURM_PROCID"
+            command = (
+                "srun",
+                f"--nodes={int(profile.nodes)}",
+                f"--ntasks={int(profile.nodes)}",
+                "--ntasks-per-node=1",
+                f"--cpus-per-task={int(profile.cpus)}",
+                "--kill-on-bad-exit=1",
+                "--",
+                *command,
+            )
+        script_lines.append(" ".join(_sh_quote(part) for part in command))
         return SubmitSpec(
             # The workload id, not the user's text: a job name reaches the
-            # scheduler's own logs and every operator's squeue output.
-            job_name=f"{prefix}-{allocation.workload_id}",
+            # scheduler's own logs and every operator's squeue output. Keep the
+            # idempotency token in JobName too: Comment is persisted by sacct
+            # only when a site enables AccountingStoreFlags=job_comment, while
+            # JobName is an ordinary accounting field. Prefix/workload slices
+            # keep the full token within Slurm's common 128-byte name limit.
+            job_name=self._job_name_for_token(allocation.submission_token),
             comment=allocation.submission_token.value,
             script="\n".join(script_lines) + "\n",
             cpus=profile.cpus,
@@ -158,7 +188,7 @@ class SlurmBackend:
             stderr_path=(
                 f"{self._log_dir}/{allocation.id}.err" if self._log_dir else None
             ),
-            environment=dict(spec.environment),
+            environment=environment,
         )
 
     def submit(
@@ -172,7 +202,10 @@ class SlurmBackend:
         # already out there. A retry after an Unknown lands here and gets
         # Existing rather than a second job.
         try:
-            already = self._broker.find_by_comment(allocation.submission_token.value)
+            already = self._broker.find_by_comment(
+                allocation.submission_token.value,
+                job_name=self._job_name_for_token(allocation.submission_token),
+            )
         except SlurmCommandError as exc:
             # An unanswerable lookup is `Unknown`, not "nothing carries it".
             # Swallowing the error to None and carrying on inverted the whole
@@ -329,8 +362,21 @@ class SlurmBackend:
         self._broker.cancel(allocation.handle.external_id)
 
     def find_by_token(self, token: SubmissionToken) -> ExternalHandle | None:
-        found = self._broker.find_by_comment(token.value)
+        found = self._broker.find_by_comment(
+            token.value, job_name=self._job_name_for_token(token)
+        )
         return self._handle(found) if found else None
+
+    def _job_name_for_token(self, token: SubmissionToken) -> str:
+        """A durable, scheduler-indexable idempotency key.
+
+        Accounting persists JobName at ordinary sites while Comment requires
+        an optional Slurm setting.  The name is derived only from the token so
+        reconciliation can reconstruct the exact server-side filter after a
+        daemon restart without loading every historical accounting row.
+        """
+        prefix = self._cluster.job_name_prefix or "openai4s"
+        return f"{prefix[:64]}-{token.value}"
 
     def log_paths(self, allocation_id: str) -> tuple[Path | None, Path | None]:
         """Where this allocation's output went, for the log-tail route.

--- a/openai4s/orchestration/slurm/broker.py
+++ b/openai4s/orchestration/slurm/broker.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import re
 import shutil
 import subprocess
+import threading
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -69,6 +70,14 @@ _credential_hint = name_can_carry_a_secret
 #: slowly; a cluster that is gone does not answer at all, and the daemon's
 #: reconciler must not block on either.
 DEFAULT_TIMEOUT_S = 30.0
+_CONTROL_TIMEOUT = object()
+
+# A scientific step may run for the allocation's whole wall time.  The
+# scheduler owns that deadline; the 30 second timeout above is only for
+# control-plane queries.  Drain output continuously while retaining a
+# bounded prefix so a chatty task cannot exhaust the daemon's memory.
+MAX_STEP_OUTPUT_BYTES = 8 * 1024 * 1024
+MAX_STEP_STDERR_BYTES = 64 * 1024
 
 
 class SlurmCommandError(RuntimeError):
@@ -254,21 +263,32 @@ class SlurmBroker:
         # scheduler scripts the plan asks for are driven through PATH, and
         # this exists for the unit-level checks of argv construction.
         self._runner = runner or subprocess.run
+        self._uses_default_runner = runner is None
 
     # --- plumbing ---------------------------------------------------------
 
     def available(self) -> bool:
         """Is there a scheduler on PATH at all?"""
-        return all(shutil.which(tool) for tool in ("sbatch", "squeue", "scancel"))
+        return all(
+            shutil.which(tool)
+            for tool in ("sbatch", "squeue", "sacct", "scancel", "srun")
+        )
 
-    def _run(self, command: list[str], *, stdin: str | None = None) -> str:
+    def _run(
+        self,
+        command: list[str],
+        *,
+        stdin: str | None = None,
+        timeout_s: float | None | object = _CONTROL_TIMEOUT,
+    ) -> str:
+        timeout = self._timeout_s if timeout_s is _CONTROL_TIMEOUT else timeout_s
         try:
             completed = self._runner(
                 command,
                 input=stdin,
                 capture_output=True,
                 text=True,
-                timeout=self._timeout_s,
+                timeout=timeout,
                 shell=False,
                 check=False,
             )
@@ -282,7 +302,7 @@ class SlurmBroker:
             # The caller must distinguish this from a refusal: a submission
             # that timed out may still have landed (INV-8).
             raise SlurmCommandError(
-                f"{command[0]} timed out after {self._timeout_s}s",
+                f"{command[0]} timed out after {timeout}s",
                 command=tuple(command),
                 timed_out=True,
             ) from exc
@@ -294,6 +314,79 @@ class SlurmBroker:
                 stderr=(completed.stderr or "").strip()[:2000],
             )
         return completed.stdout or ""
+
+    @staticmethod
+    def _drain_capped(stream: Any, *, limit: int, chunks: list[bytes]) -> None:
+        """Drain a pipe completely while retaining at most ``limit`` bytes."""
+        kept = 0
+        while True:
+            block = stream.read(65536)
+            if not block:
+                return
+            if kept < limit:
+                prefix = block[: limit - kept]
+                chunks.append(prefix)
+                kept += len(prefix)
+
+    def _run_step_capped(self, command: list[str]) -> str:
+        """Run a long-lived step without the control-command timeout.
+
+        ``Popen.communicate`` and ``subprocess.run(capture_output=True)`` retain
+        the complete output.  A distributed task can print for hours, so two
+        drainers discard everything beyond the documented diagnostic caps.
+        """
+        try:
+            process = subprocess.Popen(
+                command,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                shell=False,
+            )
+        except FileNotFoundError as exc:
+            raise SlurmCommandError(
+                f"{command[0]} not found on PATH",
+                command=tuple(command),
+                unreachable=True,
+            ) from exc
+        assert process.stdout is not None and process.stderr is not None
+        stdout_chunks: list[bytes] = []
+        stderr_chunks: list[bytes] = []
+        readers = [
+            threading.Thread(
+                target=self._drain_capped,
+                kwargs={
+                    "stream": process.stdout,
+                    "limit": MAX_STEP_OUTPUT_BYTES,
+                    "chunks": stdout_chunks,
+                },
+                daemon=True,
+            ),
+            threading.Thread(
+                target=self._drain_capped,
+                kwargs={
+                    "stream": process.stderr,
+                    "limit": MAX_STEP_STDERR_BYTES,
+                    "chunks": stderr_chunks,
+                },
+                daemon=True,
+            ),
+        ]
+        for reader in readers:
+            reader.start()
+        returncode = process.wait()
+        for reader in readers:
+            reader.join()
+        stdout = b"".join(stdout_chunks).decode("utf-8", "replace")
+        stderr = b"".join(stderr_chunks).decode("utf-8", "replace")
+        if returncode != 0:
+            raise SlurmCommandError(
+                f"{command[0]} failed with exit {returncode}",
+                command=tuple(command),
+                returncode=returncode,
+                stderr=stderr.strip()[:2000],
+            )
+        return stdout
 
     # --- submission -------------------------------------------------------
 
@@ -373,13 +466,20 @@ class SlurmBroker:
             pairs = ",".join(f"{k}={v}" for k, v in sorted(spec.environment.items()))
             _assert_no_export_keyword(pairs)
             argv.append(f"--export={pairs}")
+        else:
+            argv.append("--export=NONE")
         argv.append("--")
         argv.extend(spec.command)
         return argv
 
     def run_step(self, job_id: str, spec: "StepSpec") -> str:
         """Run a step and return what it wrote. Blocking, like `srun` is."""
-        return self._run(self.build_step_argv(job_id, spec))
+        command = self.build_step_argv(job_id, spec)
+        if self._uses_default_runner:
+            return self._run_step_capped(command)
+        # Preserve the injected runner seam in unit tests, but do not apply
+        # the control-plane timeout to a scientific task.
+        return self._run(command, timeout_s=None)
 
     # --- observation ------------------------------------------------------
 
@@ -398,15 +498,28 @@ class SlurmBroker:
             f"--job={job_id}",
             "--format=" + "|".join(f"%{code}" for code in ("i", "T", "r", "k")),
         ]
+        # A non-zero exit is not evidence that the job is absent: permission,
+        # configuration and controller failures use the same channel. Propagate
+        # it so the backend can preserve the last known phase. Schedulers that
+        # represent an unknown id with an empty successful result still return
+        # None below.
         try:
             stdout = self._run(argv)
         except SlurmCommandError as exc:
-            # squeue exits non-zero for an unknown job on some builds.
-            if exc.timed_out or exc.unreachable:
-                # Absence of an answer is not an answer of absence.
-                raise
-            return None
+            # Some Slurm versions answer a completed/expired id with this
+            # specific non-zero result instead of a successful empty set. It is
+            # the one error that means "not in slurmctld" and therefore permits
+            # the caller's required sacct fallback; permission/controller/config
+            # failures remain unknown and propagate.
+            if self._is_unknown_job_error(exc):
+                return None
+            raise
         return self._parse_row(stdout, self._SQUEUE_FIELDS)
+
+    @staticmethod
+    def _is_unknown_job_error(exc: SlurmCommandError) -> bool:
+        stderr = str(exc.stderr or "").lower()
+        return "invalid job id specified" in stderr
 
     def accounting_status(self, job_id: str) -> JobStatus | None:
         """The accounting record, which outlives the queue entry."""
@@ -417,16 +530,10 @@ class SlurmBroker:
             f"--jobs={job_id}",
             "--format=" + ",".join(self._SACCT_FIELDS),
         ]
-        try:
-            stdout = self._run(argv)
-        except SlurmCommandError as exc:
-            if exc.timed_out or exc.unreachable:
-                # Absence of an answer is not an answer of absence.
-                raise
-            return None
+        stdout = self._run(argv)
         return self._parse_row(stdout, self._SACCT_FIELDS, separator="|")
 
-    def find_by_comment(self, comment: str) -> str | None:
+    def find_by_comment(self, comment: str, *, job_name: str) -> str | None:
         """The INV-8 reconciliation: does anything carry this token?
 
         Asks the queue first (a submission that just landed is there) and
@@ -437,41 +544,49 @@ class SlurmBroker:
         """
         if not _SAFE_TOKEN_RE.fullmatch(comment):
             raise ValueError(f"invalid comment {comment!r}")
+        if not _SAFE_TOKEN_RE.fullmatch(job_name):
+            raise ValueError(f"invalid job name {job_name!r}")
         argv = [
             "squeue",
             "--noheader",
             "--all",
-            "--format=%i|%k",
+            f"--name={job_name}",
+            "--format=%i|%k|%j",
         ]
-        try:
-            stdout = self._run(argv)
-        except SlurmCommandError as exc:
-            if exc.timed_out or exc.unreachable:
-                # Absence of an answer is not an answer of absence.
-                raise
-            stdout = ""
+        # This is an all-jobs query, so it cannot fail because one requested
+        # job id was absent. Any command failure means the lookup is unknown,
+        # never that the token is absent.
+        stdout = self._run(argv)
         for line in (stdout or "").splitlines():
             parts = [p.strip() for p in line.split("|")]
-            if len(parts) >= 2 and parts[1] == comment and parts[0]:
+            if (
+                len(parts) >= 2
+                and parts[0]
+                and (parts[1] == comment or (len(parts) >= 3 and parts[2] == job_name))
+            ):
                 return parts[0].split(".")[0]
 
         argv = [
             "sacct",
             "--noheader",
             "--parsable2",
-            "--allusers",
-            "--format=JobIDRaw,Comment",
+            f"--name={job_name}",
+            # With no filter sacct defaults to midnight today. A submission
+            # whose response was lost just before midnight then vanished from
+            # the lookup after restart and INV-8 submitted it twice. Search all
+            # records the site's accounting retention still has; this query is
+            # already scoped to the daemon's own Unix identity.
+            "--starttime=1970-01-01",
+            "--format=JobIDRaw,Comment,JobName",
         ]
-        try:
-            stdout = self._run(argv)
-        except SlurmCommandError as exc:
-            if exc.timed_out or exc.unreachable:
-                # Absence of an answer is not an answer of absence.
-                raise
-            return None
+        stdout = self._run(argv)
         for line in (stdout or "").splitlines():
             parts = [p.strip() for p in line.split("|")]
-            if len(parts) >= 2 and parts[1] == comment and parts[0]:
+            if (
+                len(parts) >= 2
+                and parts[0]
+                and (parts[1] == comment or (len(parts) >= 3 and parts[2] == job_name))
+            ):
                 return parts[0].split(".")[0]
         return None
 
@@ -479,13 +594,10 @@ class SlurmBroker:
         """Ask the scheduler to kill it. Idempotent by contract: cancelling
         something already gone is success, because the cancel barrier can run
         twice and a second failure there would strand a workload."""
-        try:
-            self._run(["scancel", str(job_id)])
-        except SlurmCommandError as exc:
-            if exc.timed_out or exc.unreachable:
-                # Absence of an answer is not an answer of absence.
-                raise
-            return
+        # `--quiet` makes an already-completed job a successful no-op while a
+        # generic non-zero exit still means permission/controller failure. That
+        # preserves idempotency without interpreting every error as absence.
+        self._run(["scancel", "--quiet", str(job_id)])
 
     # --- parsing ----------------------------------------------------------
 

--- a/openai4s/orchestration/slurm/broker.py
+++ b/openai4s/orchestration/slurm/broker.py
@@ -31,6 +31,8 @@ import subprocess
 from dataclasses import dataclass, field
 from typing import Any
 
+from openai4s.kernel.environment import name_can_carry_a_secret
+
 #: What a job name or comment may contain. Slurm accepts more, but these are
 #: values WE mint and later match on, and a comma or a newline in a
 #: `--format`-parsed field is a parser bug waiting for an unusual input.
@@ -51,9 +53,17 @@ _ENV_VALUE_RE = re.compile(r"\A[^,\r\n\x00]{0,4096}\Z")
 #: variables. Checked after assembly as well, so a future field that skips
 #: the dataclass cannot reintroduce the same thing.
 _EXPORT_KEYWORDS = frozenset({"all", "none", "nil"})
-_CREDENTIAL_HINT_RE = re.compile(
-    r"(SECRET|TOKEN|PASSWORD|PASSWD|API_?KEY|CREDENTIAL|PRIVATE)", re.IGNORECASE
-)
+#: "Can this variable name carry a secret, or inject code?" -- answered by the
+#: kernel's own list rather than by a second, narrower rule. The regex that
+#: used to live here matched SECRET/TOKEN/PASSWORD/PASSWD/API_?KEY/CREDENTIAL/
+#: PRIVATE and therefore missed ACCESS_KEY, OAUTH, BEARER and COOKIE -- so
+#: `AWS_ACCESS_KEY_ID` rode `--export` into the scheduler's job record, which
+#: `scontrol show job` reads back to anyone on the cluster. It also had no
+#: equivalent of the loader-injection block (`LD_*`, `DYLD_*`, `BASH_ENV`,
+#: `PYTHONSTARTUP`, `R_PROFILE`, ...), which is the other half of what a job
+#: environment can do. One list, so a marker added for the kernel protects
+#: the scheduler path too.
+_credential_hint = name_can_carry_a_secret
 
 #: Default timeout for a scheduler command. A cluster under load answers
 #: slowly; a cluster that is gone does not answer at all, and the daemon's
@@ -152,7 +162,7 @@ class StepSpec:
         for key, value in self.environment.items():
             if not _ENV_NAME_RE.fullmatch(key):
                 raise ValueError(f"invalid environment variable name {key!r}")
-            if _CREDENTIAL_HINT_RE.search(key):
+            if _credential_hint(key):
                 raise ValueError(
                     f"refusing to put {key!r} in a step environment "
                     f"(INV-9: pass a path to a 0600 file instead)"
@@ -199,7 +209,7 @@ class SubmitSpec:
         for key, value in self.environment.items():
             if not _ENV_NAME_RE.fullmatch(key):
                 raise ValueError(f"invalid environment variable name {key!r}")
-            if _CREDENTIAL_HINT_RE.search(key):
+            if _credential_hint(key):
                 raise ValueError(
                     f"refusing to put {key!r} in a submission environment "
                     f"(INV-9): a credential belongs in an 0600 file whose "

--- a/openai4s/orchestration/slurm/profiles.py
+++ b/openai4s/orchestration/slurm/profiles.py
@@ -198,6 +198,69 @@ def _parse_scalar(raw: str, *, where: str) -> Any:
     )
 
 
+def _split_table_path(header: str) -> list[str]:
+    """`profiles."gpu.big"` -> `["profiles", "gpu.big"]`.
+
+    Splitting on `.` and unquoting afterwards is the obvious order and the
+    wrong one: a quoted key containing a dot became two nested tables, so
+    `[profiles."gpu.big"]` silently defined a profile named `gpu` -- with no
+    partition, no QoS, and every resource at its default -- where `tomllib`
+    defines one named `gpu.big` with the operator's real values. Both readers
+    are production paths (3.10 is the `requires-python` floor), and the
+    divergence surfaced as a 4-GPU job landing on the default queue asking for
+    one CPU, with `configured: true` and no error anywhere.
+
+    A dot inside quotes is part of the key; only a bare dot separates.
+    """
+    parts: list[str] = []
+    current: list[str] = []
+    quote = ""
+    for char in header:
+        if quote:
+            if char == quote:
+                quote = ""
+            else:
+                current.append(char)
+        elif char in ("'", '"'):
+            quote = char
+        elif char == ".":
+            parts.append("".join(current).strip())
+            current = []
+        else:
+            current.append(char)
+    if quote:
+        raise ValueError("unterminated quoted key")
+    parts.append("".join(current).strip())
+    return parts
+
+
+def _strip_trailing_comment(value_text: str) -> str:
+    """Drop a `# comment` that follows a value, quotes respected.
+
+    Skipping the strip entirely for a quoted value was the simple reading and
+    the wrong one: `partition = "gpu"   # the GPU queue` then reached
+    `_parse_scalar` as `"gpu"   # the GPU queue`, whose last character is not
+    the closing quote, so it raised "unterminated string". `tomllib` accepts
+    that line, which means a `cluster.toml` that works on 3.11+ made the whole
+    cluster backend unavailable on 3.10 -- the `requires-python` floor this
+    fallback exists for -- and the failure surfaced only as one stderr line
+    at boot and `configured: false` afterwards.
+
+    So walk the value instead: a `#` inside quotes is data, a `#` outside them
+    starts a comment.
+    """
+    quote = ""
+    for index, char in enumerate(value_text):
+        if quote:
+            if char == quote:
+                quote = ""
+        elif char in ("'", '"'):
+            quote = char
+        elif char == "#":
+            return value_text[:index].strip()
+    return value_text.strip()
+
+
 def _parse_toml_subset(text: str, *, source: str) -> dict[str, Any]:
     """The 3.10 fallback. See the module docstring for the supported subset."""
     data: dict[str, Any] = {}
@@ -216,7 +279,12 @@ def _parse_toml_subset(text: str, *, source: str) -> dict[str, Any]:
                 raise ClusterConfigError(
                     f"{where}: array-of-tables is not supported by this reader"
                 )
-            path = [part.strip().strip('"') for part in line[1:-1].split(".")]
+            try:
+                path = _split_table_path(line[1:-1])
+            except ValueError as exc:
+                raise ClusterConfigError(
+                    f"{where}: malformed table header {line!r} ({exc})"
+                ) from None
             if not all(path):
                 raise ClusterConfigError(f"{where}: malformed table header {line!r}")
             current = data
@@ -236,8 +304,7 @@ def _parse_toml_subset(text: str, *, source: str) -> dict[str, Any]:
         if not key:
             raise ClusterConfigError(f"{where}: empty key")
         value_text = value_text.strip()
-        if not value_text.startswith(("'", '"')):
-            value_text = value_text.split("#", 1)[0].strip()
+        value_text = _strip_trailing_comment(value_text)
         current[key] = _parse_scalar(value_text, where=where)
     return data
 

--- a/openai4s/orchestration/slurm/profiles.py
+++ b/openai4s/orchestration/slurm/profiles.py
@@ -86,6 +86,22 @@ class ClusterConfigError(ValueError):
     """cluster.toml exists but cannot be used, with the reason and the path."""
 
 
+_TOP_LEVEL_KEYS = frozenset({"cluster", "profiles"})
+_CLUSTER_KEYS = frozenset({"name", "job_name_prefix"})
+_PROFILE_KEYS = frozenset(
+    {
+        "partition",
+        "qos",
+        "cpus",
+        "memory_mb",
+        "gpus",
+        "walltime_s",
+        "nodes",
+        "description",
+    }
+)
+
+
 @dataclass(frozen=True)
 class ClusterProfile:
     """One named profile: what a user asks for, plus how to ask the scheduler.
@@ -166,6 +182,24 @@ def _optional_str(table: dict, key: str, *, where: str) -> str | None:
     return value.strip()
 
 
+def _reject_unknown_keys(table: dict, allowed: frozenset[str], *, where: str) -> None:
+    unknown = sorted(str(key) for key in table if key not in allowed)
+    if unknown:
+        raise ClusterConfigError(
+            f"{where}: unknown key(s): {', '.join(unknown)}; "
+            "refusing to guess at scheduler configuration"
+        )
+
+
+def _plain_str(
+    table: dict, key: str, default: str, *, where: str, allow_empty: bool = True
+) -> str:
+    value = table.get(key, default)
+    if not isinstance(value, str) or (not allow_empty and not value.strip()):
+        raise ClusterConfigError(f"{where}.{key} must be a string")
+    return value.strip()
+
+
 def _parse_scalar(raw: str, *, where: str) -> Any:
     """One TOML value, from the subset this file uses.
 
@@ -184,6 +218,13 @@ def _parse_scalar(raw: str, *, where: str) -> Any:
         inner = value[1:-1]
         if quote in inner:
             raise ClusterConfigError(f"{where}: unsupported quoting in {value!r}")
+        if quote == '"' and "\\" in inner:
+            # The tiny 3.10 reader does not implement TOML basic-string
+            # escapes.  Returning the backslash literally diverged from
+            # tomllib and could silently select a different queue/path.
+            raise ClusterConfigError(
+                f"{where}: escape sequences in basic strings are unsupported"
+            )
         return inner
     if value in ("true", "false"):
         return value == "true"
@@ -273,6 +314,10 @@ def _parse_toml_subset(text: str, *, source: str) -> dict[str, Any]:
         # A '#' inside a quoted value is not a comment; only strip one that
         # starts a bare token. Cheap to get wrong, so it is explicit.
         if line.startswith("["):
+            # TOML permits a comment after a table header too. Apply the same
+            # quote-aware rule as values so `[profiles."gpu#big"] # note`
+            # keeps the hash inside the key and drops only the real comment.
+            line = _strip_trailing_comment(line)
             if not line.endswith("]"):
                 raise ClusterConfigError(f"{where}: malformed table header {line!r}")
             if line.startswith("[["):
@@ -321,9 +366,14 @@ def parse_cluster_config(text: str, *, source: str = "cluster.toml") -> ClusterC
         except Exception as exc:  # tomllib.TOMLDecodeError, but be liberal
             raise ClusterConfigError(f"{source} is not valid TOML: {exc}") from exc
 
+    if not isinstance(data, dict):
+        raise ClusterConfigError(f"{source}: expected a TOML document")
+    _reject_unknown_keys(data, _TOP_LEVEL_KEYS, where=source)
+
     cluster = data.get("cluster") or {}
     if not isinstance(cluster, dict):
         raise ClusterConfigError(f"{source}: [cluster] must be a table")
+    _reject_unknown_keys(cluster, _CLUSTER_KEYS, where=f"{source}: cluster")
     profiles_table = data.get("profiles") or {}
     if not isinstance(profiles_table, dict):
         raise ClusterConfigError(f"{source}: [profiles] must be a table")
@@ -333,6 +383,7 @@ def parse_cluster_config(text: str, *, source: str = "cluster.toml") -> ClusterC
         where = f"{source}: profiles.{name}"
         if not isinstance(raw, dict):
             raise ClusterConfigError(f"{where} must be a table")
+        _reject_unknown_keys(raw, _PROFILE_KEYS, where=where)
         try:
             resources = ResourceProfile(
                 name=str(name),
@@ -351,12 +402,18 @@ def parse_cluster_config(text: str, *, source: str = "cluster.toml") -> ClusterC
             resources=resources,
             partition=_optional_str(raw, "partition", where=where),
             qos=_optional_str(raw, "qos", where=where),
-            description=str(raw.get("description") or ""),
+            description=_plain_str(raw, "description", "", where=where),
         )
 
     return ClusterConfig(
-        name=str(cluster.get("name") or ""),
-        job_name_prefix=str(cluster.get("job_name_prefix") or "openai4s"),
+        name=_plain_str(cluster, "name", "", where=f"{source}: cluster"),
+        job_name_prefix=_plain_str(
+            cluster,
+            "job_name_prefix",
+            "openai4s",
+            where=f"{source}: cluster",
+            allow_empty=False,
+        ),
         profiles=profiles,
     )
 

--- a/openai4s/orchestration/worker_gateway.py
+++ b/openai4s/orchestration/worker_gateway.py
@@ -159,10 +159,13 @@ class WorkerGateway:
         self._bind = bind
         self._on_register = on_register
         self._interrupt_hook_for = interrupt_hook_for
+        self._registration_is_expected: Callable[[str, int], bool] | None = None
         self._server: socket.socket | None = None
         self._thread: threading.Thread | None = None
         self._stop = threading.Event()
         self._lock = threading.Lock()
+        self._generation = 0
+        self._handshakes: dict[threading.Thread, socket.socket] = {}
         self._waiters: dict[tuple[str, int], threading.Event] = {}
         # A *list* per attempt, not one registration. A multi-node job
         # places one worker per rank and all of them present a credential
@@ -188,6 +191,13 @@ class WorkerGateway:
     def address(self) -> tuple[str, int] | None:
         return self._server.getsockname() if self._server is not None else None
 
+    def set_registration_expectation(
+        self, predicate: Callable[[str, int], bool] | None
+    ) -> None:
+        """Install the durable ownership check used by orphan housekeeping."""
+        with self._lock:
+            self._registration_is_expected = predicate
+
     def start(self) -> None:
         if self._thread is not None and self._thread.is_alive():
             return
@@ -198,12 +208,15 @@ class WorkerGateway:
         server.settimeout(0.5)  # so stop() is prompt rather than eventual
         self._server = server
         self._stop.clear()
+        with self._lock:
+            self._generation += 1
         self._thread = threading.Thread(
             target=self._serve, name="openai4s-worker-gateway", daemon=True
         )
         self._thread.start()
 
     def stop(self, *, timeout_s: float = 5.0) -> None:
+        deadline = time.monotonic() + max(0.0, timeout_s)
         self._stop.set()
         server, self._server = self._server, None
         if server is not None:
@@ -213,7 +226,20 @@ class WorkerGateway:
                 pass
         thread, self._thread = self._thread, None
         if thread is not None:
-            thread.join(timeout=timeout_s)
+            thread.join(timeout=max(0.0, deadline - time.monotonic()))
+        # Accepted sockets are not owned by the listener any more. Close every
+        # in-flight handshake to wake recv/send, then join those threads before
+        # clearing parked registrations. Otherwise a verified peer can publish
+        # into `_arrived` *after* stop() has emptied it.
+        with self._lock:
+            handshakes = list(self._handshakes.items())
+        for _handshake, conn in handshakes:
+            try:
+                conn.close()
+            except OSError:
+                pass
+        for handshake, _conn in handshakes:
+            handshake.join(timeout=max(0.0, deadline - time.monotonic()))
         # Close what nobody collected. `stop()` used to close only the
         # listening socket, so every parked registration's accepted socket
         # and its two makefile wrappers survived the gateway that owned them
@@ -236,6 +262,13 @@ class WorkerGateway:
             try:
                 conn, addr = server.accept()
             except socket.timeout:  # noqa: UP041 — stdlib alias
+                # The accept timeout is also the gateway's housekeeping tick.
+                # Reaping only from `await_workers` or another arrival leaves
+                # the final straggler parked forever when the daemon becomes
+                # otherwise idle -- exactly the case an orphan timeout is
+                # supposed to bound.
+                with self._lock:
+                    self._reap_locked()
                 continue
             except OSError:
                 return
@@ -256,14 +289,28 @@ class WorkerGateway:
                 except OSError:
                     pass
                 continue
-            threading.Thread(
+            with self._lock:
+                generation = self._generation
+            handshake = threading.Thread(
                 target=self._handshake_bounded,
-                args=(conn, addr),
+                args=(conn, addr, generation),
                 name="openai4s-worker-handshake",
                 daemon=True,
-            ).start()
+            )
+            with self._lock:
+                if self._stop.is_set() or generation != self._generation:
+                    self._handshake_slots.release()
+                    try:
+                        conn.close()
+                    except OSError:
+                        pass
+                    continue
+                self._handshakes[handshake] = conn
+            handshake.start()
 
-    def _handshake_bounded(self, conn: socket.socket, addr: Any) -> None:
+    def _handshake_bounded(
+        self, conn: socket.socket, addr: Any, generation: int
+    ) -> None:
         """`_handshake` with the pre-auth slot released the moment it ends.
 
         Released here rather than inside `_handshake` so that every exit
@@ -272,13 +319,17 @@ class WorkerGateway:
         a smaller unbounded one, one connection at a time.
         """
         try:
-            self._handshake(conn, addr)
+            self._handshake(conn, addr, gateway_generation=generation)
         finally:
+            with self._lock:
+                self._handshakes.pop(threading.current_thread(), None)
             self._handshake_slots.release()
 
     # --- admission --------------------------------------------------------
 
-    def _handshake(self, conn: socket.socket, addr: Any) -> None:
+    def _handshake(
+        self, conn: socket.socket, addr: Any, *, gateway_generation: int | None = None
+    ) -> None:
         peer = f"{addr[0]}:{addr[1]}" if isinstance(addr, tuple) else str(addr)
         conn.settimeout(HANDSHAKE_TIMEOUT_S)
         try:
@@ -326,10 +377,12 @@ class WorkerGateway:
         # a recovery each get their own: reusing one across attempts would
         # let a worker from the epoch before a recovery keep authorizing
         # against the generation the new one is using.
-        generation = f"kernel:{uuid.uuid4()}"
+        worker_generation = f"kernel:{uuid.uuid4()}"
         try:
             conn.sendall(
-                (json.dumps({"ok": True, "generation": generation}) + "\n").encode()
+                (
+                    json.dumps({"ok": True, "generation": worker_generation}) + "\n"
+                ).encode()
             )
         except OSError:
             try:
@@ -362,9 +415,10 @@ class WorkerGateway:
             rank=credential.rank,
             transport=transport,
             peer=peer,
-            generation=generation,
+            generation=worker_generation,
         )
         key = (credential.allocation_id, credential.epoch)
+        admitted = False
         with self._lock:
             # Reap here as well as in `await_workers`. The leak `_reap_locked`
             # was written for is a straggler nobody ever awaits -- a fenced-off
@@ -372,10 +426,22 @@ class WorkerGateway:
             # the only caller was the wait, so on a daemon where nothing waits
             # again the fd triple it drops was never dropped. Arrival is the
             # other moment the dict changes, so it is the other moment to sweep.
-            self._reap_locked()
-            self.accepted += 1
-            self._arrived.setdefault(key, []).append(registration)
-            waiter = self._waiters.get(key)
+            if not self._stop.is_set() and (
+                gateway_generation is None or gateway_generation == self._generation
+            ):
+                self._reap_locked()
+                self.accepted += 1
+                self._arrived.setdefault(key, []).append(registration)
+                waiter = self._waiters.get(key)
+                admitted = True
+            else:
+                waiter = None
+        if not admitted:
+            try:
+                transport.close(graceful=False)
+            except Exception:  # noqa: BLE001 — shutdown race must not publish
+                pass
+            return
         if waiter is not None:
             waiter.set()
         if self._on_register is not None:
@@ -411,7 +477,7 @@ class WorkerGateway:
                 break
             if total > MAX_HANDSHAKE_BYTES:
                 raise BootstrapError("handshake line too long")
-        return b"".join(chunks).split(b"\n", 1)[0].decode("utf-8", "replace")
+        return b"".join(chunks).split(b"\n", 1)[0].decode("utf-8")
 
     def _reap_locked(self) -> int:
         """Close and drop arrivals nobody is going to await. Caller holds the lock.
@@ -435,6 +501,21 @@ class WorkerGateway:
         cutoff = time.monotonic() - ORPHAN_REGISTRATION_TTL_S
         dropped = 0
         for key in [k for k in self._arrived if k not in self._waiters]:
+            expected = self._registration_is_expected
+            if expected is not None:
+                try:
+                    if expected(key[0], key[1]):
+                        # A live session may legitimately sit between worker
+                        # registration and its first Cell longer than the
+                        # orphan TTL. Its lease, not user think-time here,
+                        # owns that resource.
+                        continue
+                except Exception:  # noqa: BLE001 — uncertainty must not kill it
+                    # Storage can be briefly busy or closing.  Reaping a valid
+                    # scheduler worker is irreversible; keeping it until the
+                    # next housekeeping tick is bounded by the same TTL and
+                    # becomes decidable again once storage recovers.
+                    continue
             keep: list[Registration] = []
             for registration in self._arrived.get(key) or ():
                 # `getattr`, because `_arrived` is also written directly by
@@ -518,6 +599,13 @@ class WorkerGateway:
             remaining = deadline - time.monotonic()
             if remaining <= 0 or not waiter.wait(timeout=remaining):
                 with self._lock:
+                    # Sweep while this key still has its waiter: a partial gang
+                    # belongs to the caller below and must be restamped, while
+                    # an unrelated registration that arrived after the sweep at
+                    # the top of the loop is now old and unclaimed. Without this
+                    # second sweep, the ack-before-parking race could miss that
+                    # orphan until some future gateway activity (or forever).
+                    self._reap_locked()
                     self._waiters.pop(key, None)
                     # Hand back a *copy* of the partial set and keep it.
                     #

--- a/openai4s/orchestration/worker_gateway.py
+++ b/openai4s/orchestration/worker_gateway.py
@@ -27,6 +27,7 @@ and is not optional.
 
 from __future__ import annotations
 
+import dataclasses
 import json
 import os
 import socket
@@ -114,6 +115,32 @@ def parse_listen(spec: str | None) -> tuple[str, int] | None:
     # A compute node cannot reach the daemon's loopback, so the default bind
     # is every interface. The credential check is what makes that safe.
     return (host or "0.0.0.0", port)
+
+
+def _enable_keepalive(conn: socket.socket) -> None:
+    """Turn on TCP keepalive, as aggressively as this platform allows.
+
+    Best-effort by design: the per-idle/interval/count options are named
+    differently on Linux and macOS and are absent elsewhere, and a socket
+    without them is still better off with plain `SO_KEEPALIVE` than with
+    nothing. Every setting is individually guarded so an unsupported one
+    cannot cost us the ones that did apply.
+    """
+    for level, option, value in (
+        (socket.SOL_SOCKET, getattr(socket, "SO_KEEPALIVE", None), 1),
+        # Linux: idle seconds before the first probe, then interval and count.
+        (socket.IPPROTO_TCP, getattr(socket, "TCP_KEEPIDLE", None), 60),
+        (socket.IPPROTO_TCP, getattr(socket, "TCP_KEEPINTVL", None), 20),
+        (socket.IPPROTO_TCP, getattr(socket, "TCP_KEEPCNT", None), 6),
+        # macOS spells the idle timer differently.
+        (socket.IPPROTO_TCP, getattr(socket, "TCP_KEEPALIVE", None), 60),
+    ):
+        if option is None:
+            continue
+        try:
+            conn.setsockopt(level, option, value)
+        except OSError:  # pragma: no cover - platform dependent
+            pass
 
 
 class WorkerGateway:
@@ -314,6 +341,13 @@ class WorkerGateway:
         # take hours, and a socket timeout there would look like a dead
         # worker every time somebody ran a real computation.
         conn.settimeout(None)
+        # Blocking forever is right for a cell that runs for hours; being
+        # unable to notice a peer that stopped existing is not. Without
+        # keepalive a remote node that dies without closing TCP (a fence, a
+        # power loss, a severed network) leaves the daemon's reader parked in
+        # `recv` with `alive()` still answering True, holding the kernel's
+        # protocol transaction lock for the life of the process.
+        _enable_keepalive(conn)
 
         hook = None
         if self._interrupt_hook_for is not None:
@@ -332,6 +366,13 @@ class WorkerGateway:
         )
         key = (credential.allocation_id, credential.epoch)
         with self._lock:
+            # Reap here as well as in `await_workers`. The leak `_reap_locked`
+            # was written for is a straggler nobody ever awaits -- a fenced-off
+            # epoch, a session released while its job was still queued -- and
+            # the only caller was the wait, so on a daemon where nothing waits
+            # again the fd triple it drops was never dropped. Arrival is the
+            # other moment the dict changes, so it is the other moment to sweep.
+            self._reap_locked()
             self.accepted += 1
             self._arrived.setdefault(key, []).append(registration)
             waiter = self._waiters.get(key)
@@ -494,7 +535,26 @@ class WorkerGateway:
                     # what "3 of 4, waiting for the rest" has to mean. The
                     # reaper below is what stops a set nobody ever awaits
                     # from living forever.
-                    return list(self._arrived.get(key) or ())
+                    #
+                    # But the reaper's rule is "old and unclaimed", and the
+                    # waiter is gone by the time it looks -- so a partial gang
+                    # held across the TTL had rank 0's transport closed
+                    # underneath a session that was still counting it, and the
+                    # last rank's arrival then built a Kernel over a closed
+                    # socket. Restamp what we hand out: for a partial set the
+                    # clock that matters is "how long since anybody asked",
+                    # not "how long since it arrived", and that restores the
+                    # reaper's own premise that a registration still in this
+                    # dict is one nobody has taken. A caller that stops asking
+                    # still ages out on the same TTL.
+                    now = time.monotonic()
+                    claimed = [
+                        dataclasses.replace(registration, arrived_at=now)
+                        for registration in (self._arrived.get(key) or ())
+                    ]
+                    if claimed:
+                        self._arrived[key] = claimed
+                    return list(claimed)
 
 
 def gateway_from_environment(

--- a/openai4s/security/sandbox.py
+++ b/openai4s/security/sandbox.py
@@ -165,6 +165,24 @@ def _default_secret_read_denials(
     # Shares carry relay credentials, and the per-share tokens are what make a
     # read-only snapshot reachable from outside this machine.
     entries.append(("subpath", str(data_dir / "shares")))
+    # The worker-bootstrap signing secret and its replay fence -- siblings of
+    # the DB, exactly like `access-token` above, and missed for the same
+    # reason. `BootstrapAuthority.verify` is pure HMAC plus expiry, epoch and
+    # nonce: it never asks whether the allocation exists, so anyone holding
+    # these 32 bytes can mint a credential for an arbitrary
+    # (allocation_id, epoch, rank) and have `WorkerGateway` hand them an
+    # `OutboundTcpTransport` -- which carries, per its own module docstring,
+    # "arbitrary Host RPC" inside another tenant's session. The fence is
+    # denied alongside it because a cell that can *write* it un-burns every
+    # consumed nonce and drops every epoch a recovery fenced off.
+    # Imported rather than spelled, so a rename cannot reopen the read.
+    from openai4s.orchestration.bootstrap import SECRET_FILENAME, STATE_FILENAME
+
+    entries.append(("literal", str(data_dir / SECRET_FILENAME)))
+    entries.append(("literal", str(data_dir / STATE_FILENAME)))
+    # The per-allocation credential files themselves, written into each
+    # workload's runtime directory. Same credential, one indirection away.
+    entries.append(("subpath", str(data_dir / "cluster-workspaces")))
     # The git-ignored daemon .env, discovered the same way config._load_dotenv
     # walks for it.
     try:

--- a/openai4s/server/cell_run.py
+++ b/openai4s/server/cell_run.py
@@ -14,6 +14,7 @@ from typing import Any, Callable, Protocol
 
 from openai4s.agent.actions import is_completion_only_cell
 from openai4s.execution import CaptureResult, CellExecutionResult, CellRequest
+from openai4s.execution.watchdog import KernelNotResetTimeout
 from openai4s.kernel import KernelLease, KernelSupervisor
 
 NOTEBOOK_DIVIDER = "----- output -----"
@@ -102,6 +103,15 @@ CELL_TIMEOUT_MESSAGE = (
     "the cell exceeded its time limit and was stopped; the kernel was reset, so "
     "variables from earlier cells were cleared"
 )
+#: The same event where the reset did not happen -- a worker this daemon did
+#: not spawn cannot be respawned by it. Saying "variables were cleared" there
+#: is not a harmless simplification: it tells the user the work stopped, and
+#: on a cluster session the allocation may still be running the cell.
+CELL_TIMEOUT_NO_RESET_MESSAGE = (
+    "the cell exceeded its time limit and was stopped here, but its kernel "
+    "could not be reset from this daemon; if the session runs on a cluster the "
+    "work may still be running on its allocation"
+)
 
 
 def _worker_failure_text(exc: BaseException, public: dict) -> str:
@@ -116,6 +126,8 @@ def _worker_failure_text(exc: BaseException, public: dict) -> str:
 
     if isinstance(exc, GatewayError):
         base = str(public.get("error") or KERNEL_FAILURE_MESSAGE)
+    elif isinstance(exc, KernelNotResetTimeout):
+        base = CELL_TIMEOUT_NO_RESET_MESSAGE
     elif isinstance(exc, TimeoutError):
         base = CELL_TIMEOUT_MESSAGE
     else:

--- a/openai4s/server/cell_run.py
+++ b/openai4s/server/cell_run.py
@@ -14,7 +14,10 @@ from typing import Any, Callable, Protocol
 
 from openai4s.agent.actions import is_completion_only_cell
 from openai4s.execution import CaptureResult, CellExecutionResult, CellRequest
-from openai4s.execution.watchdog import KernelNotResetTimeout
+from openai4s.execution.watchdog import (
+    KernelNotResetTimeout,
+    KernelResetUnavailableTimeout,
+)
 from openai4s.kernel import KernelLease, KernelSupervisor
 
 NOTEBOOK_DIVIDER = "----- output -----"
@@ -103,6 +106,14 @@ CELL_TIMEOUT_MESSAGE = (
     "the cell exceeded its time limit and was stopped; the kernel was reset, so "
     "variables from earlier cells were cleared"
 )
+#: A local reset did destroy the old namespace, but the replacement failed its
+#: bootstrap and was detached. It must not reuse the no-reset cluster warning:
+#: there is no old allocation that may still be running this cell.
+CELL_TIMEOUT_RESET_UNAVAILABLE_MESSAGE = (
+    "the cell exceeded its time limit and was stopped; the old kernel was reset "
+    "and variables from earlier cells were cleared, but its replacement could "
+    "not be initialized; retry to start a fresh kernel"
+)
 #: The same event where the reset did not happen -- a worker this daemon did
 #: not spawn cannot be respawned by it. Saying "variables were cleared" there
 #: is not a harmless simplification: it tells the user the work stopped, and
@@ -128,6 +139,8 @@ def _worker_failure_text(exc: BaseException, public: dict) -> str:
         base = str(public.get("error") or KERNEL_FAILURE_MESSAGE)
     elif isinstance(exc, KernelNotResetTimeout):
         base = CELL_TIMEOUT_NO_RESET_MESSAGE
+    elif isinstance(exc, KernelResetUnavailableTimeout):
+        base = CELL_TIMEOUT_RESET_UNAVAILABLE_MESSAGE
     elif isinstance(exc, TimeoutError):
         base = CELL_TIMEOUT_MESSAGE
     else:

--- a/openai4s/server/compute_session_routes.py
+++ b/openai4s/server/compute_session_routes.py
@@ -22,6 +22,8 @@ name from cluster.toml, and what the response carries is `allocation_id`.
 
 from __future__ import annotations
 
+import sys
+from pathlib import Path
 from typing import Any
 
 from openai4s.orchestration.models import (
@@ -163,11 +165,26 @@ def handle(
         if not _may_use(self, session_id, store):
             self._json({"error": "session not found"}, 404)
             return True
+        identity = _identity(self)
+        if not team_policy.may_control_session(store, identity, session_id):
+            self._json(
+                {
+                    "ok": False,
+                    "code": "owner_only",
+                    "error": "only the session owner or an admin may release it",
+                },
+                403,
+            )
+            return True
         if manager is None:
             self._json({"ok": False, "code": "not_configured"}, 409)
             return True
-        identity = _identity(self)
-        released = manager.release(session_id, reason=Reason.USER_CANCELLED)
+        release = getattr(runner, "release_session_compute", None)
+        released = (
+            release(session_id, reason=Reason.USER_CANCELLED)
+            if callable(release)
+            else manager.release(session_id, reason=Reason.USER_CANCELLED)
+        )
         try:
             store.team.audit(
                 actor=identity.username if identity else "local",
@@ -185,6 +202,26 @@ def handle(
         session_id = m.group(1)
         if not _may_use(self, session_id, store):
             self._json({"error": "session not found"}, 404)
+            return True
+        identity = _identity(self)
+        if identity is not None and not identity.is_admin:
+            # A cluster session is the interactive sibling of an
+            # orchestration job: the scheduler is invoked with the daemon's
+            # Unix identity and site credential, not an authenticated account
+            # belonging to this browser member. Refuse before configuration,
+            # profile lookup, or any durable write so this route cannot bypass
+            # the admin-only boundary on ``POST /orchestration/jobs``.
+            self._json(
+                {
+                    "ok": False,
+                    "code": "admin_only",
+                    "error": (
+                        "cluster session placement uses daemon-managed identity "
+                        "or credentials and is admin only"
+                    ),
+                },
+                403,
+            )
             return True
         if manager is None:
             self._json(
@@ -257,7 +294,6 @@ def handle(
             return True
         profile: ResourceProfile = site.resources
 
-        identity = _identity(self)
         # From the *session*, not from the identity. `TeamIdentity` is a
         # frozen dataclass of (user_id, username, role, kind) with no
         # `project_id` and no `__getattr__`, so the `getattr(identity,
@@ -266,16 +302,62 @@ def handle(
         # and `GET /orchestration/jobs?project_id=…` matched none of them.
         frame = store.get_frame(session_id) or {}
         project_id = frame.get("project_id") or None
+        # Remote environment placement is not yet part of the workload
+        # contract: AttemptPreparer launches the worker with the daemon's
+        # interpreter. Refuse a locally selected different interpreter instead
+        # of labelling/provenancing that remote worker as an env it never ran.
+        from openai4s.kernel import environments as envmod
+
+        selected_name = str(
+            frame.get("runtime_env") or envmod.default_env_name() or "base"
+        )
+        selected_env = envmod.get_environment(selected_name)
+        selected_python = getattr(selected_env, "interpreter", None)
+        if selected_python is not None and (
+            Path(selected_python).resolve() != Path(sys.executable).resolve()
+        ):
+            self._json(
+                {
+                    "ok": False,
+                    "code": "remote_env_unsupported",
+                    "error": (
+                        f"environment {selected_name!r} uses a different Python; "
+                        "cluster sessions currently require the base daemon "
+                        "interpreter"
+                    ),
+                },
+                409,
+            )
+            return True
         # The manager refuses it too, and that is not redundant: the route
         # is one caller of a manager the CLI and tests also reach.
-        workload = manager.request_session(
-            session_id=session_id,
-            owner_user_id=identity.user_id if identity else "local",
-            project_id=project_id,
-            profile=profile,
-            backend=getattr(runner, "cluster_backend_name", "cluster"),
-            recovery=strategy,
-        )
+        request_compute = getattr(runner, "request_session_compute", None)
+        if callable(request_compute):
+            workload = request_compute(
+                session_id,
+                owner_user_id=identity.user_id if identity else "local",
+                project_id=project_id or "default",
+                profile=profile,
+                backend=getattr(runner, "cluster_backend_name", "cluster"),
+                recovery=strategy,
+            )
+        else:
+            workload = manager.request_session(
+                session_id=session_id,
+                owner_user_id=identity.user_id if identity else "local",
+                project_id=project_id,
+                profile=profile,
+                backend=getattr(runner, "cluster_backend_name", "cluster"),
+                recovery=strategy,
+            )
+        # Freeze the response before starting a previously idle reconciler.
+        # Otherwise a fresh request nondeterministically returned either the
+        # durable workload alone or that workload plus its first allocation,
+        # depending only on whether the background thread won this race. A
+        # repeated request may still report the allocation once it exists;
+        # clients therefore see both legitimate eventual states, but a single
+        # request is no longer scheduled-thread timing dressed up as API data.
+        response = _status_json(manager, store, session_id)
         ensure = getattr(runner, "ensure_reconciler", None)
         if callable(ensure):
             ensure()
@@ -288,7 +370,7 @@ def handle(
             )
         except Exception:  # noqa: BLE001
             pass
-        self._json(_status_json(manager, store, session_id), 201)
+        self._json(response, 201)
         return True
 
     return False

--- a/openai4s/server/compute_session_routes.py
+++ b/openai4s/server/compute_session_routes.py
@@ -31,7 +31,7 @@ from openai4s.orchestration.models import (
     UnsupportedRecoveryStrategy,
 )
 
-from . import contract
+from . import contract, team_policy
 
 _STATUS = contract.RouteSpec(
     "session.compute", "GET", r"/sessions/([^/]+)/compute", mutates=False
@@ -64,16 +64,17 @@ def _identity(self):
 def _may_use(self, session_id: str, store: Any) -> bool:
     """The same rule the rest of the session surface uses, called rather
     than reimplemented — a second copy of a visibility rule is a second
-    place for it to be wrong."""
-    identity = _identity(self)
-    if identity is None:  # team mode off: single user, everything is theirs
-        return True
-    try:
-        return bool(
-            store.team.session_visible_to(session_id, self._team_identity_dict())
-        )
-    except Exception:  # noqa: BLE001 — undecidable visibility fails closed
-        return False
+    place for it to be wrong.
+
+    That is what the docstring claimed while the body called
+    `session_visible_to` directly, through a *different* identity adapter
+    (`_team_identity_dict`, which drops `username`) than the one
+    `team_policy` uses. Two copies of one rule, one of them already
+    drifted. `may_use_session` is the canonical predicate — four gateway
+    call sites reach it — and it already fails closed on an undecidable
+    answer, so this is now the same code and not merely the same intent.
+    """
+    return team_policy.may_use_session(store, _identity(self), session_id)
 
 
 def _status_json(manager: Any, store: Any, session_id: str) -> dict:

--- a/openai4s/server/file_area.py
+++ b/openai4s/server/file_area.py
@@ -117,15 +117,6 @@ class FileArea:
             return parts[1]
         return None
 
-    def _contained(self, candidate: Path) -> bool:
-        for root in self.roots:
-            try:
-                if candidate == root or root in candidate.parents:
-                    return True
-            except OSError:
-                continue
-        return False
-
     def resolve(self, raw: str, *, reader: str | None = None) -> Path:
         """The real path behind a client-supplied one, or a refusal.
 

--- a/openai4s/server/file_routes.py
+++ b/openai4s/server/file_routes.py
@@ -23,7 +23,7 @@ import tempfile
 from typing import Any
 from urllib.parse import quote
 
-from . import contract
+from . import contract, team_policy
 from .file_area import MAX_UPLOAD_BYTES, FileAreaError
 
 _LIST = contract.RouteSpec("files.list", "GET", r"/files", mutates=False)
@@ -111,6 +111,26 @@ def handle(
                 409,
             )
             return True
+        if target.exists():
+            # Overwriting is the destructive verb, so it is the one that needs
+            # an owner. `_scoped_upload_dir` confines a *member* to their own
+            # subtree, which is containment and not ownership -- and an admin
+            # is not scoped at all, so `POST /files/upload?dir=<shared>&
+            # overwrite=1` replaced a member's shared-area file with nothing
+            # consulted. `team_policy.may_overwrite_file` was written for
+            # exactly this question and had no caller; this is the caller.
+            root = file_area.root_of(target)
+            existing_owner = (
+                file_area.personal_area_owner(root, target)
+                if root is not None
+                else None
+            )
+            if not team_policy.may_overwrite_file(identity, existing_owner):
+                self._json(
+                    {"error": "path not found", "code": "path_not_found"},
+                    404,
+                )
+                return True
         length = self._content_length()
         if length <= 0:
             self._json({"error": "empty upload", "code": "empty_upload"}, 400)

--- a/openai4s/server/gateway.py
+++ b/openai4s/server/gateway.py
@@ -36,7 +36,7 @@ import traceback
 import uuid
 import zipfile
 from collections.abc import Mapping
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -621,11 +621,6 @@ class WSConnection:
     # outbound queue strictly larger than that snapshot plus its begin/end
     # envelope, with a little room for the execution/approval projections that
     # immediately follow subscription.
-    #: How long `may_receive` trusts a previous answer. Short enough that a
-    #: revocation lands promptly, long enough that a chatty turn does not run
-    #: one ownership query per stdout chunk per viewer.
-    _VIS_TTL_S = 5.0
-
     _QUEUE_CAP = (
         _WS_RESUME_BUFFER_CAP + _WS_REPLAY_ENVELOPE_EVENTS + _WS_REPLAY_QUEUE_HEADROOM
     )
@@ -640,7 +635,8 @@ class WSConnection:
         #: single-user default) means every subscription stays valid, which is
         #: the behaviour a daemon with no team mode has always had.
         self.visibility_check: Any = None
-        self._vis_cache: dict[str, tuple[float, bool]] = {}
+        self._visibility_denied: set[str] = set()
+        self._last_delivered_seq: dict[str, int] = {}
         self._q: "queue.Queue" = queue.Queue(maxsize=self._QUEUE_CAP)
         self._q_budget_lock = threading.Lock()
         self._queued_bytes = 0
@@ -692,7 +688,7 @@ class WSConnection:
         self._drop()
 
     def may_receive(self, root_frame_id: str) -> bool:
-        """Is this subscription still authorized, right now?
+        """Compatibility answer when no fresh check result was returned.
 
         Subscribing was checked once, at `view_session`, and nothing rechecked
         it afterwards -- so making a session private, removing a member from
@@ -701,44 +697,60 @@ class WSConnection:
         cell code, stdout and pending approval prompts for as long as the tab
         stayed open.
 
-        Cached for a few seconds because this runs per event per subscriber
-        and the answer is a database read; revocation therefore takes effect
-        within `_VIS_TTL_S` rather than instantly, which is the same order as
-        the user noticing. A check that raises is a denial: an ownership row
-        we cannot read is not an open door.
+        `refresh_visibility` now returns the answer used for one event. Keeping
+        this method lets older connection doubles describe their single-user
+        behavior, but a real team connection cannot answer positively here:
+        there is deliberately no stored positive authorization to consult.
         """
         if self.visibility_check is None:
             return True
-        cached = self._vis_cache.get(root_frame_id)
-        if cached is None:
-            # Never asked. Refuse rather than assume: `refresh_visibility`
-            # runs before every fan-out, so the only way to be here is a
-            # connection that appeared between the refresh and the send.
-            return False
-        return cached[1]
+        # A positive answer is never retained. WSHub uses the bool returned by
+        # `refresh_visibility` for exactly one fan-out; this compatibility
+        # method therefore has no positive fact it may safely return.
+        return False
 
-    def refresh_visibility(self, root_frame_id: str) -> None:
-        """Re-ask, at most once per `_VIS_TTL_S`. Never under the hub lock.
+    def refresh_visibility(self, root_frame_id: str) -> bool:
+        """Re-ask every positive authorization. Never under the hub lock.
 
         The check reads the database, and `broadcast` holds the hub lock over
         its sequencing and enqueue — so doing the read there would take the
         store lock while holding the hub lock, inverting the order every
-        producer that broadcasts *from* a store operation already uses. It is
-        a cheap dict lookup on the hot path and a query only when the cached
-        answer has aged out.
+        producer that broadcasts *from* a store operation already uses.
+
+        Neither answer is cached.  A positive cache delays revocation; a
+        negative cache drops events after access is restored and creates a
+        sequence hole the client can otherwise mistake for a complete stream.
         """
         check = self.visibility_check
         if check is None:
-            return
-        now = time.monotonic()
-        cached = self._vis_cache.get(root_frame_id)
-        if cached is not None and cached[0] > now:
-            return
+            return True
         try:
             allowed = bool(check(root_frame_id))
         except Exception:  # noqa: BLE001 — undecidable is refused
             allowed = False
-        self._vis_cache[root_frame_id] = (now + self._VIS_TTL_S, allowed)
+        return allowed
+
+    def commit_visibility(self, root_frame_id: str, *, allowed: bool) -> int | None:
+        """Commit one checked answer in the hub's ordered fan-out section.
+
+        Authorization happens outside the hub lock to preserve lock order.  Its
+        denied/restored state must be recorded only when that same fan-out gets
+        its sequence position; otherwise two concurrent producers can commit
+        their visibility answers in the opposite order and leave an unmarked
+        hole in the stream.
+        """
+
+        if not allowed:
+            self._visibility_denied.add(root_frame_id)
+            return None
+        if root_frame_id not in self._visibility_denied:
+            return None
+        self._visibility_denied.discard(root_frame_id)
+        return int(self._last_delivered_seq.get(root_frame_id, 0))
+
+    def note_delivered(self, root_frame_id: str, sequence: int) -> None:
+        if sequence > self._last_delivered_seq.get(root_frame_id, 0):
+            self._last_delivered_seq[root_frame_id] = int(sequence)
 
     def _drain(self) -> None:
         while True:
@@ -1434,14 +1446,6 @@ class WSHub:
         buf["event_bytes"] = sum(buf["event_sizes"])
 
     def broadcast(self, root_frame_id: str | None, obj: dict) -> None:
-        if root_frame_id:
-            # Before the lock, deliberately: see `WSConnection.refresh_visibility`.
-            with self._lock:
-                subscribers = [
-                    c for c in tuple(self._conns) if c.alive and root_frame_id in c.subs
-                ]
-            for c in subscribers:
-                c.refresh_visibility(root_frame_id)
         if root_frame_id is None:
             # No caller passes None today, and a None fan-out would reach
             # every connection regardless of subscription — in team mode that
@@ -1449,8 +1453,39 @@ class WSHub:
             # asserted: a future caller's bug should lose one event, not the
             # daemon.
             return
-        with self._lock:
-            if root_frame_id:
+        while True:
+            # Before the lock, deliberately: see
+            # `WSConnection.refresh_visibility`. Snapshot only subscribers to
+            # this frame, then verify that no new one appeared while the store
+            # checks ran. A newcomer has already received a replay ending
+            # before this event, so silently skipping it would create a
+            # one-event hole.
+            with self._lock:
+                subscribers = {
+                    c for c in tuple(self._conns) if c.alive and root_frame_id in c.subs
+                }
+            authorization: dict[Any, bool] = {}
+            for c in subscribers:
+                refreshed = c.refresh_visibility(root_frame_id)
+                # Older in-tree doubles model the single-user no-op by
+                # returning None and expose `may_receive` separately. Real
+                # connections return the answer directly so a successful
+                # authorization is never stored past this fan-out.
+                authorization[c] = (
+                    bool(c.may_receive(root_frame_id))
+                    if refreshed is None
+                    else bool(refreshed)
+                )
+
+            with self._lock:
+                current = {
+                    c for c in tuple(self._conns) if c.alive and root_frame_id in c.subs
+                }
+                if not current.issubset(subscribers):
+                    # Refresh the enlarged snapshot outside the lock. No event
+                    # has been stamped or recorded yet, so retrying is safe.
+                    continue
+
                 # Stamped under the hub lock, so the number a client sees is the
                 # same order the buffer recorded and the same order every other
                 # subscriber receives. Assigning it outside the lock would let
@@ -1462,18 +1497,42 @@ class WSHub:
                     # number: it is not part of this frame's stream, so it must
                     # not advance a cursor either.
                     return
+                # If this connection was denied one or more earlier fan-outs
+                # and is authorized again now, replay that exact gap before
+                # stamping the new live event. Otherwise the client advances
+                # its cursor past unseen events and a later reconnect can never
+                # recover them.
+                for c in current:
+                    allowed = authorization.get(c, False)
+                    commit_visibility = getattr(c, "commit_visibility", None)
+                    since = (
+                        commit_visibility(root_frame_id, allowed=allowed)
+                        if callable(commit_visibility)
+                        else None
+                    )
+                    if allowed and since is not None:
+                        buf = self._live.get(root_frame_id)
+                        events = list(buf.get("events") or []) if buf else []
+                        self._enqueue_replay_locked(
+                            root_frame_id,
+                            c,
+                            events,
+                            int(since),
+                            require_complete=True,
+                        )
                 obj["seq"] = self._next_seq_locked(root_frame_id)
                 self._record(root_frame_id, obj)
-            # ``send_json`` only performs JSON encoding + a non-blocking queue
-            # put.  Keeping enqueue under the hub lock makes its order atomic
-            # with subscribe/replay without coupling producers to socket I/O.
-            for c in tuple(self._conns):
-                if (
-                    c.alive
-                    and (root_frame_id is None or root_frame_id in c.subs)
-                    and (root_frame_id is None or c.may_receive(root_frame_id))
-                ):
-                    c.send_json(obj)
+                # ``send_json`` only performs JSON encoding + a non-blocking
+                # queue put. Keeping enqueue under the hub lock makes its order
+                # atomic with subscribe/replay without coupling producers to
+                # socket I/O.
+                for c in current:
+                    if authorization.get(c, False):
+                        c.send_json(obj)
+                        note = getattr(c, "note_delivered", None)
+                        if callable(note):
+                            note(root_frame_id, int(obj["seq"]))
+                return
 
     def is_running(self, root_frame_id: str) -> bool:
         with self._lock:
@@ -1503,6 +1562,7 @@ class WSHub:
         since_seq: int = 0,
         *,
         forced_gap: bool = False,
+        require_complete: bool = False,
     ) -> None:
         """Replay buffered events, optionally only those after ``since_seq``.
 
@@ -1515,6 +1575,17 @@ class WSHub:
         selected = [e for e in events if int(e.get("seq") or 0) > since_seq]
         first = int(selected[0].get("seq") or 0) if selected else since_seq
         last = int(selected[-1].get("seq") or 0) if selected else since_seq
+        current = int(self._seq.get(root_frame_id, 0))
+        sequences = [int(event.get("seq") or 0) for event in selected]
+        expected = int(since_seq) + 1
+        replay_is_contiguous = bool(sequences)
+        for sequence in sequences:
+            if sequence != expected:
+                replay_is_contiguous = False
+                break
+            expected += 1
+        if sequences and sequences[-1] != current:
+            replay_is_contiguous = False
         conn.send_json(
             {
                 "type": "replay_begin",
@@ -1527,7 +1598,26 @@ class WSHub:
                 # The buffer is capped, so the oldest event it still holds may
                 # be newer than the cursor+1 the client asked for.
                 "gap": bool(
-                    forced_gap or (since_seq and selected and first > since_seq + 1)
+                    forced_gap
+                    # A resume is complete only when its buffered sequences
+                    # cover every number from cursor+1 through the hub's
+                    # current counter. Checking only the first item missed an
+                    # idle (unbuffered) delta in the middle or at the tail.
+                    or (
+                        (bool(since_seq) or require_complete)
+                        and selected
+                        and not replay_is_contiguous
+                    )
+                    # Idle status/metadata deltas deliberately do not create a
+                    # phantom live-turn buffer, but they still advance the
+                    # stream sequence.  An empty replay cannot cover such a
+                    # delta; declare the hole so the client refetches durable
+                    # state instead of accepting the next live sequence.
+                    or (
+                        (bool(since_seq) or require_complete)
+                        and not selected
+                        and current > since_seq
+                    )
                 ),
             }
         )
@@ -1536,6 +1626,9 @@ class WSHub:
         conn.send_json(
             {"type": "replay_end", "root_frame_id": root_frame_id, "to_seq": last}
         )
+        note = getattr(conn, "note_delivered", None)
+        if callable(note):
+            note(root_frame_id, last)
 
     def emitter(self, root_frame_id: str):
         def emit(event: dict) -> None:
@@ -1565,10 +1658,11 @@ class SessionState:
         self.branch_id = branch_id or root_frame_id
         self.workspace = workspace
         #: The workspace this session has when it runs on this machine. A
-        #: cluster placement repoints `workspace` at the workload's directory
-        #: (see `SessionRunner._sync_placement_workspace`); releasing it must
-        #: put the session back where its local files are, so the value it
-        #: came from is kept rather than recomputed.
+        #: successfully attached cluster worker repoints `workspace` at the
+        #: workload's directory (see
+        #: `SessionRunner._sync_placement_workspace`); a local fallback must
+        #: keep using this directory, so the value is kept rather than
+        #: recomputed from a pending workload binding.
         self.local_workspace = workspace
         #: `(profile_id, revision)` this turn was ACCEPTED under, when it came
         #: through the queue. `_pinned_llm_config` prefers it over the frame's
@@ -1663,10 +1757,24 @@ class SessionState:
         return bool(self.kernels.status("python")["manual_stop"])
 
     @contextmanager
-    def execution_barrier(self):
+    def execution_barrier(self, *, deadline: float | None = None):
         """Serialize a turn while giving an already-requested Stop priority."""
+
+        def remaining() -> float | None:
+            if deadline is None:
+                return None
+            return max(0.0, deadline - time.monotonic())
+
         while True:
-            self.turn_lock.acquire()
+            wait_s = remaining()
+            if wait_s is None:
+                acquired = self.turn_lock.acquire()
+            elif wait_s <= 0:
+                acquired = False
+            else:
+                acquired = self.turn_lock.acquire(timeout=wait_s)
+            if not acquired:
+                raise TimeoutError("timed out waiting for session execution barrier")
             # Admission and cancellation reset are one critical section. If a
             # Stop arrives after this clear, its newly-set signal survives; if
             # it arrived before, stop_requested makes this entrant yield.
@@ -1674,7 +1782,11 @@ class SessionState:
             if not self.stop_requested.is_set():
                 break
             self.turn_lock.release()
-            self.stop_finished.wait()
+            stop_wait_s = remaining()
+            if stop_wait_s is not None and stop_wait_s <= 0:
+                raise TimeoutError("timed out waiting for session Stop barrier")
+            if not self.stop_finished.wait(timeout=stop_wait_s):
+                raise TimeoutError("timed out waiting for session Stop barrier")
         try:
             yield
         finally:
@@ -2186,6 +2298,11 @@ def _submit_nudge_for(llm_cfg) -> str:
 
 
 class SessionRunner:
+    _ORCHESTRATION_CLEANUP_WORKERS = 4
+    _ORCHESTRATION_CLEANUP_ADMISSION_TIMEOUT_S = 0.1
+    _ORCHESTRATION_CLEANUP_RETRY_MIN_S = 0.05
+    _ORCHESTRATION_CLEANUP_RETRY_MAX_S = 2.0
+
     def __init__(
         self,
         cfg: Config,
@@ -2218,6 +2335,18 @@ class SessionRunner:
         self._turn_scope = threading.local()
         self._lock = threading.Lock()
         self._closed = False
+        # Reconciler/lease callbacks run on the orchestration control threads.
+        # A terminal session cleanup has to enter the session FIFO and may sit
+        # behind a long Cell, so doing it in the callback stalls reconciliation
+        # for every workload.  Keep a small daemon pool instead: tasks are
+        # deduplicated by session with an ABA-fenced workload identity, retried
+        # until that exact binding is gone, and never keep process exit alive.
+        # The workers are started lazily on the first terminal session event;
+        # installs without cluster sessions still start no extra threads.
+        self._orchestration_cleanup_condition = threading.Condition()
+        self._orchestration_cleanup_tasks: dict[str, dict[str, Any]] = {}
+        self._orchestration_cleanup_threads: list[threading.Thread] = []
+        self._orchestration_cleanup_stopping = False
         self._deleting_projects: set[str] = set()
         # One per daemon, so the startup opt-in and the on-demand route cannot
         # both be seeding the example at the same time.
@@ -2819,8 +2948,15 @@ class SessionRunner:
                             st
                         ):
                             return False
+                        from openai4s.orchestration.models import Reason
+
+                        compute_released = self._release_bound_compute_in_execution(
+                            st, reason=Reason.SESSION_IDLE_TIMEOUT
+                        )
                         stopped = st.kernels.stop("python", manual=False, reason=reason)
                         stopped += st.kernels.stop("r", manual=False, reason=reason)
+                        if compute_released:
+                            stopped += 1
                         if stopped:
                             # The provider history is the largest thing a cold
                             # session holds — measured at ~1.1 MB for a 200-turn
@@ -2887,6 +3023,11 @@ class SessionRunner:
                     st.delegation_runner = None
                 self._interrupt_background(st)
                 with st.turn_lock:
+                    from openai4s.orchestration.models import Reason
+
+                    self._release_bound_compute_in_execution(
+                        st, reason=Reason.USER_CANCELLED
+                    )
                     st.kernels.stop("python", manual=False, reason=reason)
                     st.kernels.stop("r", manual=False, reason=reason)
             finally:
@@ -3054,14 +3195,11 @@ class SessionRunner:
                 self.orchestration_backends["cluster"] = SlurmBackend(
                     cluster=cluster, log_dir=str(log_dir)
                 )
-                # And it becomes the default. `default_backend` was set to
-                # "local" once at construction and never moved, so on a
-                # daemon with a cluster configured every unqualified member
-                # submission resolved to the one backend `_may_submit_to`
-                # refuses them -- "submit to a cluster backend instead", on
-                # the daemon whose whole point is the cluster. The local
-                # backend stays registered and stays reachable by name for
-                # the operator.
+                # And it becomes the default. Both built-in backends are
+                # operator-only in team mode because OpenAI4S has no mapping
+                # from a browser member to a scheduler account; an admin still
+                # gets the configured cluster by omitting the backend name.
+                # The local backend remains reachable by name.
                 self.default_backend = "cluster"
         except ClusterConfigError as exc:
             print(
@@ -3176,6 +3314,7 @@ class SessionRunner:
                 self.reconciler.start()
         except Exception:  # noqa: BLE001 — never block boot on this
             pass
+        self._restore_orchestration_cleanups()
 
     def ensure_reconciler(self) -> None:
         """Start the orchestration loop if it is not already running.
@@ -3206,8 +3345,184 @@ class SessionRunner:
         to carry them would put one user's job events on another user's
         stream.
         """
+        if kind in ("lease_expired", "workload_terminal"):
+            workload_id = str(payload.get("workload_id") or "")
+            session_id = (
+                self.store.leases.session_for_workload(workload_id)
+                if workload_id
+                else None
+            )
+            if session_id:
+                from openai4s.orchestration.models import Reason
+
+                try:
+                    reason = Reason(str(payload.get("reason") or ""))
+                except ValueError:
+                    reason = Reason.WORKER_LOST
+                # Reclamation/terminal observation owns more than the durable
+                # lease row: clear the manager runtime, stop the exact
+                # supervisor worker and restore Host/file tools to the local
+                # workspace before another Cell can reuse retired compute.
+                # Admission may wait behind a long Cell, so it must not run on
+                # the reconciler/reclaimer callback thread.
+                self._schedule_orchestration_cleanup(
+                    str(session_id), workload_id, reason
+                )
         if kind in ("reconcile_error", "workload_terminal"):
             print(f"[openai4s] orchestration {kind}: {payload}", file=sys.stderr)
+
+    def _schedule_orchestration_cleanup(
+        self, session_id: str, workload_id: str, reason: Any
+    ) -> bool:
+        """Queue one exact terminal-placement cleanup without blocking emitters."""
+
+        if not session_id or not workload_id:
+            return False
+        with self._orchestration_cleanup_condition:
+            if self._orchestration_cleanup_stopping:
+                return False
+            # A delayed W1 event must not replace a task for a currently bound
+            # W2. Keep this check inside the task mutation lock: checking first
+            # let W2 bind+schedule between the check and this critical section,
+            # after which the stale W1 event overwrote W2's task.
+            if self.store.leases.workload_for_session(session_id) != workload_id:
+                return False
+            existing = self._orchestration_cleanup_tasks.get(session_id)
+            if existing is not None:
+                # W2 may replace a running W1 task. The worker snapshots W1 and
+                # verifies this target again before removing the task, so W1
+                # completion cannot consume W2's queued cleanup.
+                existing["workload_id"] = workload_id
+                existing["reason"] = reason
+                existing["attempts"] = 0
+                existing["due_at"] = time.monotonic()
+                self._orchestration_cleanup_condition.notify_all()
+                return True
+            self._orchestration_cleanup_tasks[session_id] = {
+                "session_id": session_id,
+                "workload_id": workload_id,
+                "reason": reason,
+                "attempts": 0,
+                "due_at": time.monotonic(),
+                "running": False,
+            }
+            if not self._orchestration_cleanup_threads:
+                for index in range(self._ORCHESTRATION_CLEANUP_WORKERS):
+                    thread = threading.Thread(
+                        target=self._orchestration_cleanup_worker,
+                        name=f"openai4s-orchestration-cleanup-{index}",
+                        daemon=True,
+                    )
+                    self._orchestration_cleanup_threads.append(thread)
+                    thread.start()
+            self._orchestration_cleanup_condition.notify_all()
+        return True
+
+    def _orchestration_cleanup_worker(self) -> None:
+        """Drain cleanup tasks; failures remain queued with capped backoff."""
+
+        while True:
+            with self._orchestration_cleanup_condition:
+                task = None
+                while task is None:
+                    if self._orchestration_cleanup_stopping:
+                        return
+                    now = time.monotonic()
+                    wait_s = None
+                    for candidate in self._orchestration_cleanup_tasks.values():
+                        if candidate["running"]:
+                            continue
+                        delay = float(candidate["due_at"]) - now
+                        if delay <= 0:
+                            candidate["running"] = True
+                            task = candidate
+                            break
+                        wait_s = delay if wait_s is None else min(wait_s, delay)
+                    if task is None:
+                        self._orchestration_cleanup_condition.wait(timeout=wait_s)
+
+            session_id = str(task["session_id"])
+            workload_id = str(task["workload_id"])
+            reason = task["reason"]
+            succeeded = False
+            try:
+                # Never broad-cancel before checking the expected binding. A
+                # delayed W1 event can run after this session is rebound to W2;
+                # the ordinary lifecycle FIFO plus manager's atomic fence lets
+                # W1 become a no-op without touching W2's active Cell.
+                succeeded = bool(
+                    self.release_session_compute(
+                        session_id,
+                        reason=reason,
+                        expected_workload_id=workload_id,
+                        admission_timeout_s=(
+                            self._ORCHESTRATION_CLEANUP_ADMISSION_TIMEOUT_S
+                        ),
+                    )
+                )
+                if not succeeded:
+                    # False is success when an earlier attempt consumed the
+                    # binding or a newer workload won the ABA race. Retry only
+                    # while this exact workload is still current.
+                    succeeded = (
+                        self.store.leases.workload_for_session(session_id)
+                        != workload_id
+                    )
+            except Exception as exc:  # noqa: BLE001 — retry transient admission
+                if not self._orchestration_cleanup_stopping:
+                    task["last_error"] = f"{type(exc).__name__}: {exc}"
+
+            with self._orchestration_cleanup_condition:
+                current = self._orchestration_cleanup_tasks.get(session_id)
+                if current is not task:
+                    continue
+                if str(task["workload_id"]) != workload_id:
+                    task["running"] = False
+                    task["due_at"] = time.monotonic()
+                    self._orchestration_cleanup_condition.notify_all()
+                    continue
+                if self._orchestration_cleanup_stopping or succeeded:
+                    self._orchestration_cleanup_tasks.pop(session_id, None)
+                else:
+                    task["running"] = False
+                    task["attempts"] = int(task["attempts"]) + 1
+                    delay = min(
+                        self._ORCHESTRATION_CLEANUP_RETRY_MAX_S,
+                        self._ORCHESTRATION_CLEANUP_RETRY_MIN_S
+                        * (2 ** min(int(task["attempts"]) - 1, 8)),
+                    )
+                    task["due_at"] = time.monotonic() + delay
+                self._orchestration_cleanup_condition.notify_all()
+
+    def _restore_orchestration_cleanups(self) -> None:
+        """Resume cleanup intents whose sole event preceded daemon restart."""
+
+        if getattr(self, "compute_sessions", None) is None:
+            return
+        try:
+            candidates = self.store.workloads.session_cleanup_candidates()
+        except Exception as exc:  # noqa: BLE001 — recovery must not block boot
+            print(
+                f"[openai4s] orchestration cleanup recovery unavailable: {exc}",
+                file=sys.stderr,
+            )
+            return
+        from openai4s.orchestration.models import Reason
+
+        for session_id, workload_id, recorded_reason in candidates:
+            self._schedule_orchestration_cleanup(
+                session_id,
+                workload_id,
+                recorded_reason or Reason.WORKER_LOST,
+            )
+
+    def _stop_orchestration_cleanup(self) -> None:
+        """Refuse new cleanup work and wake daemon workers without joining."""
+
+        with self._orchestration_cleanup_condition:
+            self._orchestration_cleanup_stopping = True
+            self._orchestration_cleanup_tasks.clear()
+            self._orchestration_cleanup_condition.notify_all()
 
     def close(self) -> None:
         """Stop the sweeper, turns, background workers, and all session slots."""
@@ -3216,6 +3531,10 @@ class SessionRunner:
             if self._closed:
                 return
             self._closed = True
+        # Signal these workers before waiting for orchestration components.
+        # They are daemon threads by design: a cleanup already blocked in a
+        # third-party/kernel close must never turn daemon shutdown into a hang.
+        self._stop_orchestration_cleanup()
         reconciler = getattr(self, "reconciler", None)
         if reconciler is not None:
             reconciler.stop()
@@ -3319,6 +3638,11 @@ class SessionRunner:
         ) as execution:
             result = mutate()
             if invalidate_kernel and result.get("ok"):
+                from openai4s.orchestration.models import Reason
+
+                self._release_bound_compute_in_execution(
+                    st, reason=Reason.USER_CANCELLED
+                )
                 st.kernels.stop(
                     "python", manual=False, reason="branch_revert_requires_recovery"
                 )
@@ -3444,6 +3768,9 @@ class SessionRunner:
             if old.delegation_runner is not None:
                 old.delegation_runner.close(cancel=True)
                 old.delegation_runner = None
+            from openai4s.orchestration.models import Reason
+
+            self._release_bound_compute_in_execution(old, reason=Reason.USER_CANCELLED)
             old.kernels.stop("python", manual=False, reason="branch_activated")
             old.kernels.stop("r", manual=False, reason="branch_activated")
 
@@ -3607,6 +3934,11 @@ class SessionRunner:
             owner_id=owner_id,
             reason=f"kernel recovery: {action_id}",
         ) as execution:
+            if self.store.leases.workload_for_session(root_frame_id):
+                raise RecoveryActionError(
+                    "local kernel recovery is unavailable while a cluster "
+                    "compute session is bound; release the allocation first"
+                )
             runtime = self._recovery_runtime(st, emit)
             fresh = runtime.fresh_manifests() if action_id == "restart_fresh" else ()
             # Re-check enabled/confirmation after FIFO admission, before
@@ -3937,6 +4269,7 @@ class SessionRunner:
         language: str | None = None,
         reason: str,
         metadata: Mapping[str, Any] | None = None,
+        admission_deadline: float | None = None,
     ):
         """Submit after any already-reserved Stop, without holding a long lock.
 
@@ -3947,9 +4280,27 @@ class SessionRunner:
         item it wants cancelled has to be frozen here, at submit.
         """
 
+        def remaining() -> float | None:
+            if admission_deadline is None:
+                return None
+            return max(0.0, admission_deadline - time.monotonic())
+
         while True:
-            st.stop_finished.wait()
-            with st.admission_lock:
+            wait_s = remaining()
+            if wait_s is not None and wait_s <= 0:
+                raise TimeoutError("timed out waiting for session admission")
+            if not st.stop_finished.wait(timeout=wait_s):
+                raise TimeoutError("timed out waiting for session Stop to finish")
+            lock_wait_s = remaining()
+            if lock_wait_s is None:
+                acquired = st.admission_lock.acquire()
+            elif lock_wait_s <= 0:
+                acquired = False
+            else:
+                acquired = st.admission_lock.acquire(timeout=lock_wait_s)
+            if not acquired:
+                raise TimeoutError("timed out waiting for session admission lock")
+            try:
                 if st.stop_requested.is_set():
                     continue
                 try:
@@ -3973,6 +4324,8 @@ class SessionRunner:
                     # cannot accept anything until the user waits or cancels --
                     # which is exactly what the message already tells them.
                     raise GatewayError(429, str(error), "queue_full") from error
+            finally:
+                st.admission_lock.release()
 
     @contextmanager
     def _session_execution(
@@ -3985,6 +4338,7 @@ class SessionRunner:
         language: str | None = None,
         reason: str,
         ticket=None,
+        admission_timeout_s: float | None = None,
     ):
         """Combine FIFO ownership with the compatible turn-lock barrier.
 
@@ -3993,6 +4347,11 @@ class SessionRunner:
         cycle during the incremental migration.
         """
 
+        admission_deadline = (
+            None
+            if admission_timeout_s is None
+            else time.monotonic() + max(0.0, admission_timeout_s)
+        )
         current = self.executions.current(st.root_frame_id)
         owns_admission = current is None
         ticket = current or ticket
@@ -4004,6 +4363,7 @@ class SessionRunner:
                 execution_id=execution_id,
                 language=language,
                 reason=reason,
+                admission_deadline=admission_deadline,
             )
 
         @contextmanager
@@ -4014,7 +4374,7 @@ class SessionRunner:
             if st.root_frame_id in held:
                 yield
                 return
-            with st.execution_barrier():
+            with st.execution_barrier(deadline=admission_deadline):
                 # An exact cancel may arrive after admission but before a
                 # legacy holder releases turn_lock.  execution_barrier clears
                 # the old Event on entry, so restore the ticket-owned signal.
@@ -4027,7 +4387,16 @@ class SessionRunner:
                     held.pop()
 
         if owns_admission:
-            with self.executions.admitted(ticket, cancel_event=st.cancel):
+            remaining_admission_s = (
+                None
+                if admission_deadline is None
+                else max(0.0, admission_deadline - time.monotonic())
+            )
+            with self.executions.admitted(
+                ticket,
+                cancel_event=st.cancel,
+                timeout=remaining_admission_s,
+            ):
                 with turn_barrier():
                     yield ticket
             return
@@ -4219,8 +4588,8 @@ class SessionRunner:
         except Exception:  # noqa: BLE001 — no binding, no placement
             return None
 
-    def _sync_placement_workspace(self, st: SessionState) -> None:
-        """Point the session's workspace at the directory its cells run in.
+    def _sync_placement_workspace(self, st: SessionState, placed: Path | None) -> None:
+        """Point host-side state at the execution plane that was selected.
 
         The remote kernel was built with the workload's directory as its cwd
         while everything on this side of the socket -- the Host dispatcher's
@@ -4231,22 +4600,24 @@ class SessionRunner:
         The inverse failed too, `host.write_file` landing where the cell could
         not see it.
 
-        Resolved here because `_ensure_runtime` is the one call every path
-        into a session passes through -- the turn, a Cell, the R kernel, the
-        Notebook -- so the answer cannot be current for one of them and stale
-        for the next. Symmetric on purpose: releasing the placement puts the
-        session back on its local workspace rather than leaving it pointed at
-        a workload that no longer exists.
+        The caller supplies the *selected* placement rather than deriving one
+        from the durable workload binding. A binding can exist for minutes
+        before its worker arrives; treating it as an execution decision starts
+        the local fallback inside ``cluster-workspaces`` and also drops the
+        sandbox deny that protects the whole credential tree. Symmetric on
+        purpose: selecting local puts the dispatcher and artifact capture back
+        on the session's local workspace.
         """
-        placed = self._placement_workspace(st)
         target = placed if placed is not None else st.local_workspace
         if Path(st.workspace) != Path(target):
             st.workspace = target
+        dispatcher = st.dispatcher
+        rebind = getattr(dispatcher, "set_workspace", None) if dispatcher else None
+        if callable(rebind):
+            rebind(target)
 
     def _ensure_runtime(self, st: SessionState):
         """Build the session control plane without acquiring a language worker."""
-
-        self._sync_placement_workspace(st)
 
         def factory():
             disp = build_dispatcher(
@@ -4302,6 +4673,169 @@ class SessionRunner:
         self._wire_delegation(st)
         return dispatcher
 
+    def _release_bound_compute_in_execution(
+        self,
+        st: SessionState,
+        *,
+        reason,
+        expected_workload_id: str | None = None,
+    ) -> bool:
+        """Release the cluster half while the caller owns the session barrier.
+
+        Branch, idle and deletion lifecycles already hold the coordinator and
+        therefore cannot call ``release_session_compute`` (which would enqueue a
+        nested lifecycle ticket).  They still must retire the durable binding,
+        lease and manager runtime before stopping the resident supervisor.
+        """
+
+        manager = getattr(self, "compute_sessions", None)
+        if manager is None:
+            return False
+        workload_id = self.store.leases.workload_for_session(st.root_frame_id)
+        if not workload_id or (
+            expected_workload_id is not None and workload_id != expected_workload_id
+        ):
+            return False
+        released = bool(
+            manager.release(
+                st.root_frame_id,
+                reason=reason,
+                expected_workload_id=expected_workload_id,
+            )
+        )
+        if released:
+            self._sync_placement_workspace(st, None)
+        return released
+
+    def release_session_compute(
+        self,
+        root_frame_id: str,
+        *,
+        reason,
+        expected_workload_id: str | None = None,
+        admission_timeout_s: float | None = None,
+    ) -> bool:
+        """Release a placement and atomically restore its resident local plane.
+
+        The manager owns the durable lease/runtime; ``SessionState`` owns the
+        supervisor, dispatcher and artifact workspace. Releasing only the
+        first half left tools-only turns writing into the retired cluster
+        directory until another Python Cell happened to spawn. Serialize with
+        Cell/lifecycle writers, then move every resident projection together.
+        """
+        manager = getattr(self, "compute_sessions", None)
+        if manager is None or not root_frame_id:
+            return False
+        bound_workload_id = self.store.leases.workload_for_session(root_frame_id)
+        if not bound_workload_id or (
+            expected_workload_id is not None
+            and bound_workload_id != expected_workload_id
+        ):
+            # `/compute/release` is idempotent, but it is not a generic kernel
+            # reset.  A pure-local session (or a repeated release) must retain
+            # its Python namespace.
+            return False
+        st = self._existing_state(root_frame_id)
+        if st is None:
+            return bool(
+                manager.release(
+                    root_frame_id,
+                    reason=reason,
+                    expected_workload_id=expected_workload_id,
+                )
+            )
+        with self._session_execution(
+            st,
+            owner="lifecycle",
+            owner_id=f"compute-release-{uuid.uuid4().hex[:12]}",
+            language="python",
+            reason="release cluster session",
+            admission_timeout_s=admission_timeout_s,
+        ):
+            released = self._release_bound_compute_in_execution(
+                st,
+                reason=reason,
+                expected_workload_id=expected_workload_id,
+            )
+            if not released:
+                # An ABA replacement won while the lifecycle ticket waited.
+                # It owns the resident session now; do not stop its kernel or
+                # redirect its workspace for an event about the old workload.
+                return False
+            st.kernels.stop("python", manual=False, reason="cluster_session_released")
+            return released
+
+    def request_session_compute(
+        self,
+        root_frame_id: str,
+        *,
+        owner_user_id: str,
+        project_id: str,
+        profile,
+        backend: str,
+        recovery,
+    ):
+        """Create/bind compute under the session lifecycle coordinator."""
+
+        manager = getattr(self, "compute_sessions", None)
+        if manager is None:
+            raise RuntimeError("cluster sessions are not configured")
+        st = self._state(root_frame_id, project_id)
+        with self._session_execution(
+            st,
+            owner="lifecycle",
+            owner_id=f"compute-request-{uuid.uuid4().hex[:12]}",
+            language="python",
+            reason="request cluster session",
+        ):
+            # Repeat this decision *inside* the lifecycle barrier.  The route
+            # performs an early check for a useful 409, but set_env/host.env.use
+            # is another lifecycle writer and could otherwise win between that
+            # check and the durable workload bind. Remote workers currently use
+            # the daemon interpreter, so accepting a different selected env
+            # would publish false runtime/provenance metadata.
+            from openai4s.kernel import environments as envmod
+
+            selected_name = self._selected_env_name(st)
+            selected_env = envmod.get_environment(selected_name)
+            selected_python = getattr(selected_env, "interpreter", None)
+            if selected_python is not None and (
+                Path(selected_python).resolve() != Path(sys.executable).resolve()
+            ):
+                raise GatewayError(
+                    409,
+                    f"environment {selected_name!r} uses a different Python; "
+                    "cluster sessions currently require the base daemon interpreter",
+                    "remote_env_unsupported",
+                )
+            active_delegations = 0
+            if st.delegation_runner is not None:
+                try:
+                    stats = st.delegation_runner.delegation_stats()
+                    # ``children()`` is direct-only.  A finished child may
+                    # have launched a still-running grandchild, so placement
+                    # must ask the shared delegation tree for whole-session
+                    # activity or it creates local and cluster execution
+                    # planes at the same time.
+                    active_delegations = int(stats.get("active_session") or 0)
+                except Exception:  # noqa: BLE001 — undecidable means occupied
+                    active_delegations = 1
+            if self._background_active(st) or active_delegations:
+                raise GatewayError(
+                    409,
+                    "finish or stop local background/delegated work before "
+                    "placing this session on a cluster",
+                    "async_work_active",
+                )
+            return manager.request_session(
+                session_id=root_frame_id,
+                owner_user_id=owner_user_id,
+                project_id=project_id,
+                profile=profile,
+                backend=backend,
+                recovery=recovery,
+            )
+
     def _release_session_compute(self, root_frame_id: str) -> None:
         """Give a deleted session's cluster resource back.
 
@@ -4316,7 +4850,7 @@ class SessionRunner:
             return
         from openai4s.orchestration.models import Reason
 
-        manager.release(root_frame_id, reason=Reason.USER_CANCELLED)
+        self.release_session_compute(root_frame_id, reason=Reason.USER_CANCELLED)
 
     def _touch_compute_lease(self, st: "SessionState") -> None:
         """Renew this session's cluster lease, if it has one."""
@@ -4359,6 +4893,33 @@ class SessionRunner:
             return None
 
         runtime = manager.runtime(session_id)
+        durably_remote = False
+        try:
+            latest_generation = self.store.latest_kernel_generation(
+                session_id,
+                "python",
+                branch_id=st.branch_id,
+            )
+            durable_key = (
+                (latest_generation.get("environment") or {}).get("key")
+                if latest_generation
+                else None
+            )
+            durably_remote = bool(
+                isinstance(durable_key, (list, tuple))
+                and len(durable_key) >= 3
+                and durable_key[0] == "cluster"
+                and str(durable_key[1]) == str(workload_id)
+            )
+        except Exception as exc:  # noqa: BLE001 — execution plane is undecidable
+            raise RuntimeError(
+                "cannot verify the bound session's prior execution plane; "
+                "refusing a daemon-local fallback"
+            ) from exc
+        previously_remote = (
+            bool(runtime and (runtime.ever_ready or runtime.state_lost_epochs))
+            or durably_remote
+        )
         if runtime is None or runtime.registration is None:
             try:
                 attached = manager.attach_worker(
@@ -4370,16 +4931,47 @@ class SessionRunner:
                     file=sys.stderr,
                     flush=True,
                 )
-                return None
+                raise RuntimeError(
+                    "the cluster worker could not be attached; refusing to run "
+                    "this bound session on the daemon"
+                ) from exc
             if not attached:
-                return None
+                detail = (
+                    "connection was lost and the session must recover"
+                    if previously_remote
+                    else "has not registered yet"
+                )
+                raise RuntimeError(
+                    f"the cluster worker {detail}; refusing to run this bound "
+                    "session on the daemon"
+                )
             runtime = manager.runtime(session_id)
         if runtime is None or runtime.registration is None:
-            return None
+            raise RuntimeError(
+                "the cluster worker is not registered; refusing to run this "
+                "bound session on the daemon"
+            )
 
         transport = getattr(runtime.registration, "transport", None)
         if transport is None:
-            return None
+            raise RuntimeError(
+                "the cluster worker has no live transport; refusing a daemon-local "
+                "fallback"
+            )
+        alive = getattr(transport, "alive", None)
+        if callable(alive):
+            try:
+                transport_live = bool(alive())
+            except Exception:  # noqa: BLE001
+                transport_live = False
+            if not transport_live:
+                discard = getattr(manager, "discard_dead_registration", None)
+                if callable(discard):
+                    discard(session_id)
+                raise RuntimeError(
+                    "the cluster worker connection was lost; refusing to run "
+                    "this bound session on the daemon"
+                )
 
         # The generation this worker was admitted under. Minted by the Host
         # in the handshake and echoed to the worker there, so both ends agree
@@ -4400,7 +4992,6 @@ class SessionRunner:
             )
             if admitted_generation:
                 kernel.adopt_authorization_generation(admitted_generation)
-            manager.bind_kernel(session_id, kernel)
             return kernel
 
         # The epoch is in the key so a recovery — a new epoch, a new worker —
@@ -4424,8 +5015,12 @@ class SessionRunner:
             str(env.root) if getattr(env, "is_conda", False) else None,
         )
 
+        # A workload binding is only a request for another execution plane.
+        # Until `_remote_kernel_factory` returns a live attached worker this is
+        # a local spawn, and its cwd must remain outside the credential-bearing
+        # cluster workspace tree even when a previous attempt was remote.
         kernel_options = {
-            "cwd": str(st.workspace),
+            "cwd": str(st.local_workspace),
             "mode": "repl",
             "python": env.interpreter,
             "env_root": str(env.root) if env.is_conda else None,
@@ -4452,13 +5047,144 @@ class SessionRunner:
                 return Kernel(dispatcher=disp, **kernel_options)
 
         previous_lease = st.kernels.lease("python")
+        current_matches = bool(
+            previous_lease is not None
+            and previous_lease.key == env_key
+            and st.kernels.alive("python")
+        )
+        manager = (
+            getattr(self, "compute_sessions", None) if remote is not None else None
+        )
+        workload_id = str(remote_key[1]) if remote is not None else ""
+        epoch = int(remote_key[2]) if remote is not None else 0
+        expected_transport = None
+        if remote is not None and manager is not None:
+            runtime = manager.runtime(st.root_frame_id)
+            expected_transport = getattr(
+                getattr(runtime, "registration", None), "transport", None
+            )
+
+        candidate = None
+        lease = previous_lease
+        bootstrap: dict = {}
         try:
-            lease = st.kernels.ensure("python", env_key, factory)
+            if not current_matches:
+                candidate = factory()
+                if not candidate.is_alive():
+                    raise RuntimeError("python kernel factory returned a dead worker")
+            candidate_scope = (
+                st.kernels.preparing_candidate("python", candidate)
+                if candidate is not None
+                else nullcontext()
+            )
+            with candidate_scope as candidate_token:
+                if candidate is not None:
+                    placed_candidate = (
+                        Path(candidate.cwd)
+                        if remote is not None
+                        else st.local_workspace
+                    )
+                    bootstrap = (
+                        self._run_bootstrap(st, candidate, workspace=placed_candidate)
+                        or {}
+                    )
+                    if bootstrap.get("status") == "failed":
+                        raise RuntimeError(
+                            "kernel bootstrap failed: "
+                            + str(bootstrap.get("error") or "unknown bootstrap error")
+                        )
+
+                guard = nullcontext(True)
+                if remote is not None:
+                    if manager is None or expected_transport is None:
+                        raise RuntimeError("cluster session runtime disappeared")
+                    guard = manager.kernel_binding_guard(
+                        st.root_frame_id,
+                        expected_workload_id=workload_id,
+                        expected_epoch=epoch,
+                        expected_transport=expected_transport,
+                    )
+                # Cross-owner commits use one lock order everywhere:
+                # supervisor -> manager -> Store. Interrupt/activity already
+                # use supervisor -> Store; reversing the first two here made a
+                # permanent ABBA deadlock possible.
+                with st.kernels.publication_guard():
+                    with guard as binding_current:
+                        if not binding_current:
+                            raise RuntimeError(
+                                "cluster session changed epoch, expired, or was "
+                                "released during worker attach"
+                            )
+                        if candidate is not None:
+                            lease = st.kernels.publish_candidate(
+                                "python",
+                                env_key,
+                                candidate,
+                                factory=factory,
+                                generation_id=str(uuid.uuid4()),
+                                expected=previous_lease,
+                                bootstrap=bootstrap,
+                                candidate_token=candidate_token,
+                            )
+                            # Ownership transferred to the supervisor. It will
+                            # close this worker on any later failure.
+                            candidate = None
+                        assert lease is not None
+                        if remote is not None and not manager.bind_kernel(
+                            st.root_frame_id,
+                            lease.kernel,
+                            expected_workload_id=workload_id,
+                            expected_epoch=epoch,
+                            expected_transport=expected_transport,
+                        ):
+                            st.kernels.shutdown_if_current(
+                                lease,
+                                reason="remote_runtime_disappeared",
+                                terminal_state="crashed",
+                            )
+                            raise RuntimeError(
+                                "cluster session changed epoch, expired, or was "
+                                "released during worker attach"
+                            )
         except BaseException:
+            from openai4s.orchestration.models import Reason
+
+            if candidate is not None:
+                try:
+                    candidate.shutdown()
+                except Exception:  # noqa: BLE001
+                    pass
+            if remote is not None:
+                release = (
+                    getattr(manager, "release", None) if manager is not None else None
+                )
+                released = bool(
+                    release(
+                        st.root_frame_id,
+                        reason=Reason.BOOTSTRAP_FAILED,
+                        expected_workload_id=workload_id,
+                    )
+                    if callable(release)
+                    else False
+                )
+                if not released:
+                    discard = (
+                        getattr(manager, "discard_unbound_registration", None)
+                        if manager is not None
+                        else None
+                    )
+                    if callable(discard):
+                        discard(st.root_frame_id)
+                self._sync_placement_workspace(st, None)
             st.env_name = previous_env
+            st.booted = False
             raise
-        # Publish environment-dependent dispatcher hooks only after the worker
-        # replacement has committed.  This preserves build-first semantics.
+
+        placed = Path(lease.kernel.cwd) if remote is not None else None
+
+        # Publish the selected plane and environment-dependent Host hooks only
+        # after every fallible candidate stage has committed.
+        self._sync_placement_workspace(st, placed)
         disp.active_env_bin = env.bin_dir
         if remote is not None:
             # `host.exec_background` on a cluster session refuses rather than
@@ -4487,27 +5213,25 @@ class SessionRunner:
                 )
 
             disp.background_kernel_factory = _refuse_background
+
+            def _refuse_delegation(_spec: dict) -> None:
+                raise RuntimeError(
+                    "host.delegate is not available on a cluster session: "
+                    "delegated agents would run on the daemon instead of the "
+                    "allocated node. Submit a batch job or release the cluster "
+                    "resource before delegating."
+                )
+
+            disp._delegate_fn = _refuse_delegation
         else:
             disp.background_kernel_factory = lambda: Kernel(
                 dispatcher=disp,
                 **kernel_options,
             )
-        if previous_lease is None or previous_lease.kernel is not lease.kernel:
-            # Run outside the supervisor lock so cancellation can interrupt a
-            # slow sidecar.  The caller's turn_lock still prevents execution
-            # from racing this one-time bootstrap.
-            bootstrap = self._run_bootstrap(st, lease.kernel) or {}
-            if bootstrap.get("status") == "failed":
-                st.kernels.shutdown_if_current(
-                    lease,
-                    reason="bootstrap_failed",
-                    terminal_state="failed",
-                )
-                st.booted = False
-                raise RuntimeError(
-                    "kernel bootstrap failed: "
-                    + str(bootstrap.get("error") or "unknown bootstrap error")
-                )
+            # `_ensure_runtime` ran before placement selection and may have
+            # inherited the previous remote workspace. Rewire future local
+            # delegated children after the local plane is committed.
+            self._wire_delegation(st, disp)
         st.booted = True
         return lease
 
@@ -4646,12 +5370,22 @@ class SessionRunner:
         kernel under the agent's own running code)."""
 
         def sink(name: str) -> None:
+            if self.store.leases.workload_for_session(st.root_frame_id):
+                raise RuntimeError(
+                    "environment switching is unavailable while a cluster "
+                    "compute session is bound; release it and request a new "
+                    "allocation with the desired environment"
+                )
             st.pending_env = name
 
         return sink
 
     def _ensure_kernel(self, st: SessionState) -> None:
-        if st.kernels.alive("python"):
+        # A live local fallback is not the final answer while a cluster
+        # workload remains bound. Re-enter `_spawn_kernel` on each Cell so a
+        # worker that arrived since the previous attempt can be selected; the
+        # supervisor cheaply reuses the local lease when it still has not.
+        if st.kernels.alive("python") and self._placement_workspace(st) is None:
             return
         self._ensure_runtime(st)
         self._seed_messages(st)
@@ -4826,6 +5560,13 @@ class SessionRunner:
             return result
         if result.get("scope") != "running":
             return result
+        state = self._existing_state(root_frame_id)
+        if state is not None:
+            # Language preparation happens before the execution owns a
+            # published KernelLease. A bootstrap candidate is intentionally
+            # unpublished (build-first), but cancellation must still interrupt
+            # its protocol read rather than wait forever for bootstrap.
+            state.kernels.interrupt_preparing()
         owner_result = result.get("owner") or {}
         if owner_result.get("kind") == "agent":
             with self._lock:
@@ -4880,14 +5621,22 @@ class SessionRunner:
         )
         return self._after_execution_cancel(root_frame_id, result)
 
-    def _run_bootstrap(self, st: SessionState, kernel: Kernel | None = None) -> dict:
+    def _run_bootstrap(
+        self,
+        st: SessionState,
+        kernel: Kernel | None = None,
+        *,
+        workspace: Path | None = None,
+    ) -> dict:
         """Run and persist the bootstrap facts observed for one generation."""
 
         target = kernel if kernel is not None else st.kernel
         boot = _maybe_call(getattr(self._skills_for(st), "bootstrap_code", ""))
         if target is None:
             return {"status": "failed", "error": "Python kernel is unavailable"}
-        metadata = bootstrap_python_generation(target, st.workspace, boot)
+        metadata = bootstrap_python_generation(
+            target, workspace if workspace is not None else st.workspace, boot
+        )
         lifecycle_state = (
             "active" if metadata["status"] in {"active", "skipped"} else "bootstrapping"
         )
@@ -4904,6 +5653,16 @@ class SessionRunner:
         clean process, and skill bootstrap is re-run. Variables from prior cells
         are gone (that is the point of a restart); the notebook history is kept.
         """
+        if self.store.leases.workload_for_session(root_frame_id):
+            return {
+                "ok": False,
+                "state": "remote",
+                "frame_id": root_frame_id,
+                "error": (
+                    "a cluster worker cannot be restarted in place; release "
+                    "the compute session and request a fresh allocation"
+                ),
+            }
         st = self._state(root_frame_id, project_id)
         emit = self.hub.emitter(root_frame_id)
         with self._session_execution(
@@ -4965,11 +5724,39 @@ class SessionRunner:
         root_frame_id: str | None = None,
         project_id: str | None = None,
         restart: bool = True,
+        _coordinated: bool = False,
     ) -> dict:
         """pip-install package(s) into the kernel interpreter, then (optionally)
         restart the session kernel so they are importable in a clean process."""
         from openai4s.kernel import preinstall
 
+        if root_frame_id and not _coordinated:
+            st = self._state(root_frame_id, project_id or "default")
+            with self._session_execution(
+                st,
+                owner="lifecycle",
+                owner_id=f"install-{uuid.uuid4().hex[:12]}",
+                language="python",
+                reason="install kernel packages",
+            ):
+                return self.install_packages(
+                    packages,
+                    root_frame_id=root_frame_id,
+                    project_id=project_id,
+                    restart=restart,
+                    _coordinated=True,
+                )
+        if root_frame_id and self.store.leases.workload_for_session(root_frame_id):
+            return {
+                "ok": False,
+                "installed": [],
+                "restarted": False,
+                "error": (
+                    "package installation is unavailable while a cluster "
+                    "compute session is bound; installing here would mutate "
+                    "the daemon environment, not the remote worker"
+                ),
+            }
         res = preinstall.install(packages)
         res["restarted"] = False
         if res.get("ok"):
@@ -4982,8 +5769,17 @@ class SessionRunner:
             self.artifacts.invalidate_freeze_cache()
         if res.get("ok") and restart and root_frame_id:
             try:
-                self.restart_kernel(root_frame_id, project_id or "default")
-                res["restarted"] = True
+                restart_result = self.restart_kernel(
+                    root_frame_id, project_id or "default"
+                )
+                if restart_result.get("ok", True):
+                    res["restarted"] = True
+                else:
+                    res["restart_error"] = str(
+                        restart_result.get("error")
+                        or "the kernel could not be restarted"
+                    )
+                    res["restart_error_code"] = "kernel_restart_failed"
             except Exception as error:  # noqa: BLE001
                 # `POST /frames/<id>/kernel/install` returns this dict straight
                 # to the client, so `str(e)` was a public body. A restart fails
@@ -5193,6 +5989,13 @@ class SessionRunner:
         can be started again to resume. A running turn is cancelled first."""
         st = self._sessions.get(root_frame_id)
         if st is None:
+            manager = getattr(self, "compute_sessions", None)
+            if manager is not None and self.store.leases.workload_for_session(
+                root_frame_id
+            ):
+                from openai4s.orchestration.models import Reason
+
+                manager.release(root_frame_id, reason=Reason.USER_CANCELLED)
             # Same shape as the stopped case. A caller should not have to
             # handle two response shapes from one route depending on whether
             # the session happened to be resident.
@@ -5241,6 +6044,7 @@ class SessionRunner:
                 # Freeze its leases and use ABA-safe exact interrupts rather
                 # than the old broad supervisor interrupt.
                 if not (cancel_result or {}).get("ok"):
+                    st.kernels.interrupt_preparing()
                     for language in ("python", "r"):
                         lease = st.kernels.lease(language)
                         if lease is not None:
@@ -5249,6 +6053,15 @@ class SessionRunner:
                     # Wait for the single protocol reader to leave before
                     # detaching and shutting down its exact worker slots.
                     with st.turn_lock:
+                        manager = getattr(self, "compute_sessions", None)
+                        if (
+                            manager is not None
+                            and self.store.leases.workload_for_session(root_frame_id)
+                        ):
+                            from openai4s.orchestration.models import Reason
+
+                            manager.release(root_frame_id, reason=Reason.USER_CANCELLED)
+                            self._sync_placement_workspace(st, None)
                         st.kernels.stop("python", manual=True, reason="manual_stop")
                         st.kernels.stop("r", manual=True, reason="manual_stop")
                     stopped_status = st.kernels.status("python")
@@ -5359,6 +6172,14 @@ class SessionRunner:
                     'pin one with host.env.use("' + env_name + '")).'
                 )
             }
+        if self.store.leases.workload_for_session(root_frame_id):
+            return {
+                "error": (
+                    "environment switching is unavailable while a cluster "
+                    "compute session is bound; release it and request a new "
+                    "allocation with the desired environment"
+                )
+            }
         st = self._state(root_frame_id, project_id)
         emit = self.hub.emitter(root_frame_id)
         with self._session_execution(
@@ -5367,6 +6188,14 @@ class SessionRunner:
             owner_id=f"env-{uuid.uuid4().hex[:12]}",
             reason="kernel environment change",
         ) as execution:
+            if self.store.leases.workload_for_session(root_frame_id):
+                return {
+                    "error": (
+                        "environment switching is unavailable while a cluster "
+                        "compute session is bound; release it and request a new "
+                        "allocation with the desired environment"
+                    )
+                }
             st.pending_env = None
             alive = st.kernels.alive("python")
             already = alive and st.env_name == env_name
@@ -14195,6 +15024,31 @@ def make_handler(cfg: Config, hub: WSHub, runner: SessionRunner):
                                 }
                             )
                             continue
+                        if _team_auth is not None:
+                            # Visibility is deliberately broader than control:
+                            # a project member may watch a shared session, but
+                            # cannot cancel its owner's active execution. Resolve
+                            # the identity again at the mutation boundary so a
+                            # revoked long-lived socket fails closed.
+                            identity = self._team_identity_from_request()
+                            self._team_identity = identity
+                            frame = store.get_frame(str(rid)) or {}
+                            root = str(frame.get("root_frame_id") or rid)
+                            if not team_policy.may_control_session(
+                                store, identity, root
+                            ):
+                                conn.send_json(
+                                    {
+                                        "type": "execution_cancel_result",
+                                        "ok": False,
+                                        "code": "owner_only",
+                                        "reason": (
+                                            "only the session owner or an admin "
+                                            "may cancel its execution"
+                                        ),
+                                    }
+                                )
+                                continue
                         result = runner.cancel(
                             rid,
                             msg.get("execution_id"),

--- a/openai4s/server/gateway.py
+++ b/openai4s/server/gateway.py
@@ -469,6 +469,21 @@ _TEAM_SCOPE_SHARE = re.compile(r"/shares/([^/]+)")
 #: spellings identical.
 _REPLAY_ROUTE = re.compile(r"/sessions/([^/]+)/replay")
 
+#: The auth paths a guest reaches. Sign-in and sign-out must work or a guest
+#: cannot leave, and `/auth/me` is what the page renders their identity from.
+#: `/auth/me/llm-key` is deliberately absent: it writes the credential broker,
+#: which is not a replay-only surface.
+#: API-relative, like every other value compared against `sub` here.
+_GUEST_AUTH_PATHS = frozenset(
+    {
+        "/auth/login",
+        "/auth/logout",
+        "/auth/me",
+        "/auth/status",
+        "/auth/redeem-invite",
+    }
+)
+
 #: The only paths a `?token=` may be traded for a cookie on -- an allowlist,
 #: not a subtraction. The rule used to be "anything that is not `/api/v1/` and
 #: not `/static/`", which its own docstring described as "paths that serve the
@@ -606,6 +621,11 @@ class WSConnection:
     # outbound queue strictly larger than that snapshot plus its begin/end
     # envelope, with a little room for the execution/approval projections that
     # immediately follow subscription.
+    #: How long `may_receive` trusts a previous answer. Short enough that a
+    #: revocation lands promptly, long enough that a chatty turn does not run
+    #: one ownership query per stdout chunk per viewer.
+    _VIS_TTL_S = 5.0
+
     _QUEUE_CAP = (
         _WS_RESUME_BUFFER_CAP + _WS_REPLAY_ENVELOPE_EVENTS + _WS_REPLAY_QUEUE_HEADROOM
     )
@@ -615,6 +635,12 @@ class WSConnection:
         self.wfile = wfile
         self.subs: set[str] = set()
         self.alive = True
+        #: Team mode: "may this connection still receive that session?", set
+        #: by the WS handler which owns identity re-resolution. None (the
+        #: single-user default) means every subscription stays valid, which is
+        #: the behaviour a daemon with no team mode has always had.
+        self.visibility_check: Any = None
+        self._vis_cache: dict[str, tuple[float, bool]] = {}
         self._q: "queue.Queue" = queue.Queue(maxsize=self._QUEUE_CAP)
         self._q_budget_lock = threading.Lock()
         self._queued_bytes = 0
@@ -664,6 +690,55 @@ class WSConnection:
 
     def close(self) -> None:
         self._drop()
+
+    def may_receive(self, root_frame_id: str) -> bool:
+        """Is this subscription still authorized, right now?
+
+        Subscribing was checked once, at `view_session`, and nothing rechecked
+        it afterwards -- so making a session private, removing a member from
+        its project, or disabling the account revoked every *future* request
+        and none of the stream already flowing. The socket kept delivering
+        cell code, stdout and pending approval prompts for as long as the tab
+        stayed open.
+
+        Cached for a few seconds because this runs per event per subscriber
+        and the answer is a database read; revocation therefore takes effect
+        within `_VIS_TTL_S` rather than instantly, which is the same order as
+        the user noticing. A check that raises is a denial: an ownership row
+        we cannot read is not an open door.
+        """
+        if self.visibility_check is None:
+            return True
+        cached = self._vis_cache.get(root_frame_id)
+        if cached is None:
+            # Never asked. Refuse rather than assume: `refresh_visibility`
+            # runs before every fan-out, so the only way to be here is a
+            # connection that appeared between the refresh and the send.
+            return False
+        return cached[1]
+
+    def refresh_visibility(self, root_frame_id: str) -> None:
+        """Re-ask, at most once per `_VIS_TTL_S`. Never under the hub lock.
+
+        The check reads the database, and `broadcast` holds the hub lock over
+        its sequencing and enqueue — so doing the read there would take the
+        store lock while holding the hub lock, inverting the order every
+        producer that broadcasts *from* a store operation already uses. It is
+        a cheap dict lookup on the hot path and a query only when the cached
+        answer has aged out.
+        """
+        check = self.visibility_check
+        if check is None:
+            return
+        now = time.monotonic()
+        cached = self._vis_cache.get(root_frame_id)
+        if cached is not None and cached[0] > now:
+            return
+        try:
+            allowed = bool(check(root_frame_id))
+        except Exception:  # noqa: BLE001 — undecidable is refused
+            allowed = False
+        self._vis_cache[root_frame_id] = (now + self._VIS_TTL_S, allowed)
 
     def _drain(self) -> None:
         while True:
@@ -1359,6 +1434,14 @@ class WSHub:
         buf["event_bytes"] = sum(buf["event_sizes"])
 
     def broadcast(self, root_frame_id: str | None, obj: dict) -> None:
+        if root_frame_id:
+            # Before the lock, deliberately: see `WSConnection.refresh_visibility`.
+            with self._lock:
+                subscribers = [
+                    c for c in tuple(self._conns) if c.alive and root_frame_id in c.subs
+                ]
+            for c in subscribers:
+                c.refresh_visibility(root_frame_id)
         if root_frame_id is None:
             # No caller passes None today, and a None fan-out would reach
             # every connection regardless of subscription — in team mode that
@@ -1385,7 +1468,11 @@ class WSHub:
             # put.  Keeping enqueue under the hub lock makes its order atomic
             # with subscribe/replay without coupling producers to socket I/O.
             for c in tuple(self._conns):
-                if c.alive and (root_frame_id is None or root_frame_id in c.subs):
+                if (
+                    c.alive
+                    and (root_frame_id is None or root_frame_id in c.subs)
+                    and (root_frame_id is None or c.may_receive(root_frame_id))
+                ):
                     c.send_json(obj)
 
     def is_running(self, root_frame_id: str) -> bool:
@@ -1477,6 +1564,12 @@ class SessionState:
         self.project_id = project_id
         self.branch_id = branch_id or root_frame_id
         self.workspace = workspace
+        #: The workspace this session has when it runs on this machine. A
+        #: cluster placement repoints `workspace` at the workload's directory
+        #: (see `SessionRunner._sync_placement_workspace`); releasing it must
+        #: put the session back where its local files are, so the value it
+        #: came from is kept rather than recomputed.
+        self.local_workspace = workspace
         #: `(profile_id, revision)` this turn was ACCEPTED under, when it came
         #: through the queue. `_pinned_llm_config` prefers it over the frame's
         #: current pin, because the frame's pin is mutable by design and an item
@@ -2820,25 +2913,36 @@ class SessionRunner:
         usable before anybody has organised anything. A project somebody
         has claimed needs participation.
         """
-        from openai4s.server import team_policy
+        from openai4s.server import team_auth, team_policy
 
         if not getattr(self.cfg, "team_mode", False):
             return True
+        # The loopback CLI is admin-equivalent by decision D2 and has no row in
+        # `users`, so it is recognised by its own constant rather than by
+        # failing to be found. That distinction is the whole fix here: absence
+        # used to be the *service* answer AND the answer for a user id that is
+        # not an account AND the answer for a database that would not answer,
+        # and all three admitted.
+        if user_id == team_auth.SERVICE_IDENTITY.user_id:
+            return True
         try:
             user = self.store.team.get_user(user_id)
-        except Exception:  # noqa: BLE001
-            user = None
+        except Exception:  # noqa: BLE001 — undecidable is refused
+            # `team_policy`'s stated contract, applied to its own input: a
+            # lookup that failed is not a lookup that said "no restrictions".
+            return False
         if user is None:
-            return True  # service/loopback identity, or team mode not seeded
-        if str(user.get("role") or "") == "admin":
-            return True
-
-        class _Id:
-            def __init__(self, uid: str) -> None:
-                self.user_id = uid
-                self.is_admin = False
-
-        return team_policy.may_create_session_in(self.store, _Id(user_id), project_id)
+            return False
+        # A real Principal rather than a hand-rolled stand-in with the fields
+        # this one call happens to read. The stub hard-coded `is_admin = False`
+        # and the caller compensated with a role check above it, so "who is
+        # this" had two spellings that had to agree.
+        principal = execution_principal.Principal(
+            user_id=str(user.get("id") or user_id),
+            username=str(user.get("username") or ""),
+            role=str(user.get("role") or ""),
+        )
+        return team_policy.may_create_session_in(self.store, principal, project_id)
 
     def create_session(
         self,
@@ -2950,6 +3054,15 @@ class SessionRunner:
                 self.orchestration_backends["cluster"] = SlurmBackend(
                     cluster=cluster, log_dir=str(log_dir)
                 )
+                # And it becomes the default. `default_backend` was set to
+                # "local" once at construction and never moved, so on a
+                # daemon with a cluster configured every unqualified member
+                # submission resolved to the one backend `_may_submit_to`
+                # refuses them -- "submit to a cluster backend instead", on
+                # the daemon whose whole point is the cluster. The local
+                # backend stays registered and stays reachable by name for
+                # the operator.
+                self.default_backend = "cluster"
         except ClusterConfigError as exc:
             print(
                 f"[openai4s] cluster.toml ignored: {exc}", file=sys.stderr, flush=True
@@ -2983,6 +3096,9 @@ class SessionRunner:
         on_state_lost = None
         try:
             from openai4s.orchestration.bootstrap import (
+                STATE_FILENAME as bootstrap_state_filename,
+            )
+            from openai4s.orchestration.bootstrap import (
                 BootstrapAuthority,
                 load_or_mint_secret,
             )
@@ -2999,7 +3115,7 @@ class SessionRunner:
                 # the shared filesystem the job was given and stays valid for
                 # its whole TTL, so an in-memory nonce set un-burns every
                 # outstanding credential on restart.
-                state_path=self.cfg.data_dir / "worker-bootstrap-state.json",
+                state_path=self.cfg.data_dir / bootstrap_state_filename,
             )
             worker_gateway = gateway_from_environment(authority)
             if worker_gateway is not None:
@@ -4083,8 +4199,54 @@ class SessionRunner:
         except Exception:  # noqa: BLE001 - prompt/bootstrap remains available
             return self.skills
 
+    def _placement_workspace(self, st: SessionState) -> Path | None:
+        """Where this session's cells actually run, or None for this machine.
+
+        A cluster session's worker is started by the scheduler in the
+        workload's own directory (`AttemptPreparer` derives it from
+        `runtime_dir.parent`), so that -- not `agent-workspaces/<root>` -- is
+        the cwd a relative `open()` in a cell resolves against.
+        """
+        manager = getattr(self, "compute_sessions", None)
+        session_id = getattr(st, "root_frame_id", "") or ""
+        if manager is None or not session_id:
+            return None
+        try:
+            workload_id = self.store.leases.workload_for_session(session_id)
+            if not workload_id:
+                return None
+            return Path(manager.workspace_for(workload_id))
+        except Exception:  # noqa: BLE001 — no binding, no placement
+            return None
+
+    def _sync_placement_workspace(self, st: SessionState) -> None:
+        """Point the session's workspace at the directory its cells run in.
+
+        The remote kernel was built with the workload's directory as its cwd
+        while everything on this side of the socket -- the Host dispatcher's
+        file tools, artifact capture, the R kernel, the reported cwd -- stayed
+        anchored to `agent-workspaces/<root_frame_id>`. So a cluster cell
+        wrote `result.csv` and `capture` diffed a directory nothing had
+        touched: no Artifact row, no version, no lineage, and no error either.
+        The inverse failed too, `host.write_file` landing where the cell could
+        not see it.
+
+        Resolved here because `_ensure_runtime` is the one call every path
+        into a session passes through -- the turn, a Cell, the R kernel, the
+        Notebook -- so the answer cannot be current for one of them and stale
+        for the next. Symmetric on purpose: releasing the placement puts the
+        session back on its local workspace rather than leaving it pointed at
+        a workload that no longer exists.
+        """
+        placed = self._placement_workspace(st)
+        target = placed if placed is not None else st.local_workspace
+        if Path(st.workspace) != Path(target):
+            st.workspace = target
+
     def _ensure_runtime(self, st: SessionState):
         """Build the session control plane without acquiring a language worker."""
+
+        self._sync_placement_workspace(st)
 
         def factory():
             disp = build_dispatcher(
@@ -4127,6 +4289,14 @@ class SessionRunner:
             return disp
 
         dispatcher = st.runtime.ensure(factory)
+        # The dispatcher is built once and survives kernel restarts, so the
+        # workspace the factory captured is only right until a placement
+        # changes. `set_workspace` is what binds host-side file operations to
+        # the kernel's actual cwd, and the CLI path already uses it for the
+        # same reason.
+        rebind = getattr(dispatcher, "set_workspace", None)
+        if callable(rebind):
+            rebind(st.workspace)
         # Refresh per-turn model/delegation wiring without replacing the stable
         # dispatcher (and without starting Python).
         self._wire_delegation(st)
@@ -4981,6 +5151,22 @@ class SessionRunner:
         python — this never raises.
         """
         dispatcher = self._ensure_runtime(st)
+        # The same refusal `host.exec_background` makes, for the same reason.
+        # `spawn_r_kernel` starts a local child of the daemon, so on a session
+        # placed on a cluster an ```r cell ran on the head node with none of
+        # the allocated CPUs or GPUs -- silently, because it *worked*, just
+        # somewhere else and on whatever the shared filesystem happened to
+        # show it. Returned rather than raised: this method's contract is a
+        # soft-fail the model reads as an observation and can act on.
+        if self._placement_workspace(st) is not None:
+            return (
+                "R is not available on a cluster session: this session's cells "
+                "run on an allocated node, and an R kernel would start on the "
+                "daemon instead, with none of the allocated resources. Use "
+                "python for this session, submit a batch job with POST "
+                "/orchestration/jobs, or release the cluster resource to run "
+                "this session locally."
+            )
         want = getattr(dispatcher, "active_r_env", None)
         from openai4s.kernel.environments import get_environment
         from openai4s.kernel.r_kernel import spawn_r_kernel
@@ -10230,11 +10416,15 @@ def make_handler(cfg: Config, hub: WSHub, runner: SessionRunner):
             # depend on no session state and must answer before any frame
             # guard can object. Deterministic in both modes — the contract
             # capture drives them with team mode off.
-            if team_routes.handle(self, method, sub, _team_auth, store):
-                return
-            # Guest gate (D3): a guest's whole API surface is auth + replay.
-            # Sits after the auth routes (logout must work) and before
-            # everything else, so no later route needs its own guest check.
+            # Guest gate (D3): a guest's whole API surface is sign-in, sign-out,
+            # who-am-I, and replay.
+            #
+            # It used to sit *after* `team_routes.handle`, on the reading that
+            # the auth routes are only login/logout/me. They are not: the same
+            # group carries `PUT`/`DELETE /auth/me/llm-key`, which write the
+            # credential broker -- so a replay-only guest could store secrets
+            # in the daemon. Naming what a guest may reach, and gating before
+            # the dispatch, keeps the claim in the comment below true.
             _identity = getattr(self, "_team_identity", None)
             if (
                 _team_auth is not None
@@ -10242,11 +10432,18 @@ def make_handler(cfg: Config, hub: WSHub, runner: SessionRunner):
                 and _identity.kind == "user"
                 and _identity.role == "guest"
                 and not (method == "GET" and _REPLAY_ROUTE.fullmatch(sub))
+                and sub not in _GUEST_AUTH_PATHS
             ):
                 self._json(
                     {"error": "guests are replay-only", "code": "guest_readonly"},
                     403,
                 )
+                return
+            # Team auth routes (login/logout/me, invite redemption, and a
+            # member's own LLM key). They depend on no session state and must
+            # answer before any frame guard can object. Deterministic in both
+            # modes — the contract capture drives them with team mode off.
+            if team_routes.handle(self, method, sub, _team_auth, store):
                 return
             # Read-only session replay (M2-3): the web-share sanitized view,
             # served in place — no shares row, no snapshot, no relay. The
@@ -10569,33 +10766,25 @@ def make_handler(cfg: Config, hub: WSHub, runner: SessionRunner):
             # ---- global search (⌘K command palette) ----
             if sub.split("?")[0] == "/search" and method == "GET":
                 query = (q.get("q") or [""])[0]
+                _scope = self._team_visibility_filter()
                 payload = (
-                    store.search(query)
+                    # Scoped in SQL, so `LIMIT` counts rows this caller may
+                    # actually see. Filtering afterwards emptied the page
+                    # whenever the newest matches were colleagues'.
+                    store.search(query, visible_to_user_id=_scope)
                     if query.strip()
                     else {"sessions": [], "artifacts": [], "datapro": []}
                 )
-                if self._team_visibility_filter() is not None:
+                if _scope is not None:
                     # Team mode (INV-13): the command palette must not
                     # enumerate other people's sessions or their artifacts.
                     _user = self._team_identity_dict()
-                    payload["sessions"] = [
-                        s
-                        for s in payload.get("sessions", [])
-                        if store.team.session_visible_to(str(s.get("id")), _user)
-                    ]
-                    payload["artifacts"] = [
-                        a
-                        for a in payload.get("artifacts", [])
-                        if a.get("root_frame_id")
-                        and store.team.session_visible_to(
-                            str(a["root_frame_id"]), _user
-                        )
-                    ]
-                    # The third family. Two of three were filtered and the
-                    # third -- indexed DataPro content, which is exactly the
-                    # query-matched *scientific* text -- rode through
-                    # unchanged. Same predicate, same fail-closed shape: a
-                    # hit with no root to check against is not shown.
+                    # Sessions and artifacts are already scoped by the query.
+                    # The third family -- indexed DataPro content, which is
+                    # exactly the query-matched *scientific* text -- lives in
+                    # its own repository and is still filtered here; same
+                    # fail-closed shape, a hit with no root to check against
+                    # is not shown.
                     payload["datapro"] = [
                         d
                         for d in payload.get("datapro", [])
@@ -11549,10 +11738,37 @@ def make_handler(cfg: Config, hub: WSHub, runner: SessionRunner):
                     self._json({"ok": False, "error": "session not found"}, 404)
                     return
                 root = frame.get("root_frame_id") or m.group(1)
+                # The scope arrives in the body and is written straight into
+                # the durable rule table by `permissions.resolve_result`, which
+                # has no identity to ask. Same rule as `POST /permissions`,
+                # asked here rather than duplicated: a member approving a
+                # prompt in their own session with `"scope": "global"` planted
+                # an allow that every other member's agent then honoured --
+                # exactly what the 403 on the other route refuses them.
+                _decision_scope = str(b.get("scope") or "once")
+                # The scope_id `permissions.resolve_result` will derive: the
+                # session for a conversation rule, its project for a project
+                # one. Asked about the same row the write lands on, so a member
+                # keeps the two scopes they can already reach.
+                _decision_scope_id = {
+                    "conversation": root,
+                    "project": str(frame.get("project_id") or "default"),
+                }.get(_decision_scope)
+                if not team_policy.may_write_permission_rule(
+                    store,
+                    getattr(self, "_team_identity", None),
+                    _decision_scope,
+                    _decision_scope_id,
+                ):
+                    raise GatewayError(
+                        403,
+                        f"a {_decision_scope} permission rule is admin only",
+                        "admin_only",
+                    )
                 resolution = broker().resolve_result(
                     b.get("decision_id"),
                     allow=bool(b.get("allow")),
-                    scope=b.get("scope") or "once",
+                    scope=_decision_scope,
                     pattern=b.get("pattern"),
                     message=b.get("message"),
                     store=store,
@@ -11647,21 +11863,26 @@ def make_handler(cfg: Config, hub: WSHub, runner: SessionRunner):
                 _identity = getattr(self, "_team_identity", None)
                 if (
                     _team_auth is not None
-                    and _identity is not None
-                    and (not _identity.is_admin)
+                    and not team_policy.may_write_permission_rule(
+                        store, _identity, scope, scope_id
+                    )
                 ):
+                    # The predicate answers *whether*; the mapping below is
+                    # this route's answer about *what to say*, which differs
+                    # by scope on purpose (403 names the rule, 404 does not
+                    # confirm that a project or session exists).
                     if scope == "global":
                         raise GatewayError(
                             403, "global permission rules are admin only", "admin_only"
                         )
-                    if scope == "project" and not team_policy.may_read_project(
-                        store, _identity, str(scope_id or "")
-                    ):
-                        raise GatewayError(404, "project not found")
-                    if scope == "conversation" and not team_policy.may_use_session(
-                        store, _identity, str(scope_id or "")
-                    ):
-                        raise GatewayError(404, "session not found")
+                    raise GatewayError(
+                        404,
+                        (
+                            "project not found"
+                            if scope == "project"
+                            else "session not found"
+                        ),
+                    )
                 rid = store.set_permission_rule(
                     scope=scope,
                     scope_id=scope_id or "",
@@ -11700,26 +11921,26 @@ def make_handler(cfg: Config, hub: WSHub, runner: SessionRunner):
                 # deny as an absolute veto, so deleting a global deny is how
                 # a standing refusal becomes an allow for everyone.
                 _identity = getattr(self, "_team_identity", None)
-                if (
-                    rule
-                    and _team_auth is not None
-                    and _identity is not None
-                    and (not _identity.is_admin)
-                ):
+                if rule and _team_auth is not None:
                     _scope = str(rule.get("scope") or "")
                     _scope_id = str(rule.get("scope_id") or "")
-                    if _scope == "global":
+                    if not team_policy.may_write_permission_rule(
+                        store, _identity, _scope, _scope_id
+                    ):
+                        if _scope == "global":
+                            raise GatewayError(
+                                403,
+                                "global permission rules are admin only",
+                                "admin_only",
+                            )
                         raise GatewayError(
-                            403, "global permission rules are admin only", "admin_only"
+                            404,
+                            (
+                                "project not found"
+                                if _scope == "project"
+                                else "session not found"
+                            ),
                         )
-                    if _scope == "project" and not team_policy.may_read_project(
-                        store, _identity, _scope_id
-                    ):
-                        raise GatewayError(404, "project not found")
-                    if _scope == "conversation" and not team_policy.may_use_session(
-                        store, _identity, _scope_id
-                    ):
-                        raise GatewayError(404, "session not found")
                 store.delete_permission_rule(m.group(1))
                 self._json({"ok": True})
                 return
@@ -11886,6 +12107,21 @@ def make_handler(cfg: Config, hub: WSHub, runner: SessionRunner):
                 # record. See `_pinned_image_bytes` for why re-resolving the
                 # artifact at send time is the wrong answer.
                 bound = store.get_artifact(str(art_id)) or {}
+                # The frame is in the path and the artifact is in the *body*,
+                # so the path-matching team guard never saw the artifact --
+                # the same shape `/uploads` was already fixed for. A pin is
+                # not inert: `_pinned_image_bytes` reads the bound version off
+                # disk and inlines it into this session's next prompt, so
+                # pinning a colleague's figure had the model describe it back.
+                if bound and not team_policy.may_use_session(
+                    store,
+                    getattr(self, "_team_identity", None),
+                    str(bound.get("root_frame_id") or ""),
+                ):
+                    # Same sentence as an unknown artifact: which ids exist is
+                    # not this route's information to give out.
+                    self._json({"error": "artifact not found"}, 404)
+                    return
                 anno = store.add_annotation(
                     root_frame_id=fid,
                     artifact_id=str(art_id),
@@ -13814,6 +14050,12 @@ def make_handler(cfg: Config, hub: WSHub, runner: SessionRunner):
             except OSError:
                 return
             conn = WSConnection(self.wfile)
+            # The predicate the fan-out re-asks (see `WSConnection.may_receive`).
+            # It is `_ws_session_visible`, which re-resolves the identity from
+            # the persisted handshake headers on every call -- so a revoked
+            # cookie, a demoted membership or a session flipped to private
+            # stops the *existing* stream, not just the next subscribe.
+            conn.visibility_check = lambda rid: _ws_session_visible(str(rid))
             # Team mode (M1-7): the identity is RE-RESOLVED from the persisted
             # handshake headers on every message, not captured once. A member
             # who is disabled or whose password is reset (both delete their

--- a/openai4s/server/governance_routes.py
+++ b/openai4s/server/governance_routes.py
@@ -284,12 +284,30 @@ def handle(self, method: str, sub: str, q: dict, team_auth: Any, store: Any) -> 
         return True
     if _QUOTA_SET.match(method, sub):
         body = self._body()
+        # `or 0` collapsed "field absent or misspelled" into "limit is zero",
+        # and zero is the engine's hard block (`used >= limit` is true at
+        # used == 0). An admin who wrote `"limit": 100000` got a 200 and a
+        # quota of 0, and every LLM call by that member was refused from that
+        # moment with a number the admin believed said otherwise.
+        raw_limit = body.get("limit_amount")
+        if raw_limit is None:
+            self._json(
+                {"error": "limit_amount is required", "code": "invalid_quota"}, 400
+            )
+            return True
+        try:
+            limit_amount = float(raw_limit)
+        except (TypeError, ValueError):
+            self._json(
+                {"error": "limit_amount must be a number", "code": "invalid_quota"}, 400
+            )
+            return True
         try:
             store.governance.set_quota(
                 scope=str(body.get("scope") or ""),
                 scope_id=str(body.get("scope_id") or ""),
                 kind=str(body.get("kind") or ""),
-                limit_amount=float(body.get("limit_amount") or 0),
+                limit_amount=limit_amount,
                 window=str(body.get("window") or ""),
             )
         except (ValueError, TypeError) as e:

--- a/openai4s/server/kernel_routes.py
+++ b/openai4s/server/kernel_routes.py
@@ -43,7 +43,7 @@ import os
 import re
 from typing import Any
 
-from . import contract, errors
+from . import contract, errors, team_policy
 
 _EXECUTION = contract.RouteSpec(
     "kernel.execution",
@@ -142,6 +142,31 @@ ROUTES = contract.validate_routes(
         _ENV,
     )
 )
+
+
+def _require_session_control(self: Any, store: Any, frame_id: str) -> None:
+    """Keep readable project sessions from becoming shared namespaces."""
+
+    identity = getattr(self, "_team_identity", None)
+    if not team_policy.may_control_session(store, identity, frame_id):
+        raise errors.GatewayError(
+            403,
+            "only the session owner or an admin may control its kernel",
+            "owner_only",
+        )
+
+
+def _require_instance_admin(self: Any, operation: str) -> None:
+    """Gate instance-global mutations while preserving single-user mode."""
+
+    identity = getattr(self, "_team_identity", None)
+    if identity is not None and not identity.is_admin:
+        raise errors.GatewayError(
+            403,
+            f"only an admin may {operation}",
+            "admin_only",
+        )
+
 
 #: Every pattern above is under `/frames/`, so a request that is not cannot
 #: match any of them -- and 56 of the 91 non-`/frames` routes are declared
@@ -248,6 +273,7 @@ def handle(self, method: str, sub: str, q: dict, runner: Any, store: Any) -> boo
             return True
         fid = m.group(1)
         f = store.get_frame(fid) or {}
+        _require_session_control(self, store, fid)
         pid = f.get("project_id") or "default"
         self._json(runner.restart_kernel(fid, pid))
         return True
@@ -263,6 +289,7 @@ def handle(self, method: str, sub: str, q: dict, runner: Any, store: Any) -> boo
             return True
         fid = m.group(1)
         f = store.get_frame(fid) or {}
+        _require_session_control(self, store, fid)
         self._json(runner.stop_kernel(fid, f.get("project_id") or "default"))
         return True
     m = _INTERRUPT.match(method, sub)
@@ -275,6 +302,8 @@ def handle(self, method: str, sub: str, q: dict, runner: Any, store: Any) -> boo
                 403,
             )
             return True
+        fid = m.group(1)
+        _require_session_control(self, store, fid)
         body = self._body()
         owner = body.get("owner") or body.get("owner_kind")
         owner_kind = owner.get("kind") if isinstance(owner, dict) else owner
@@ -283,7 +312,7 @@ def handle(self, method: str, sub: str, q: dict, runner: Any, store: Any) -> boo
             self._json(
                 {
                     "ok": False,
-                    "frame_id": m.group(1),
+                    "frame_id": fid,
                     "error": ("execution_id, owner.kind, and owner.id are required"),
                     "reason": ("execution_id, owner.kind, and owner.id are required"),
                 },
@@ -295,7 +324,7 @@ def handle(self, method: str, sub: str, q: dict, runner: Any, store: Any) -> boo
             "owner": owner,
             "owner_id": str(owner_id),
         }
-        self._json(runner.interrupt_kernel(m.group(1), **kwargs))
+        self._json(runner.interrupt_kernel(fid, **kwargs))
         return True
     m = _START.match(method, sub)
     if m:
@@ -309,6 +338,7 @@ def handle(self, method: str, sub: str, q: dict, runner: Any, store: Any) -> boo
             return True
         fid = m.group(1)
         f = store.get_frame(fid) or {}
+        _require_session_control(self, store, fid)
         self._json(runner.start_kernel(fid, f.get("project_id") or "default"))
         return True
     m = _VARIABLES.match(method, sub)
@@ -354,8 +384,10 @@ def handle(self, method: str, sub: str, q: dict, runner: Any, store: Any) -> boo
     m = _INSTALL.match(method, sub)
     if m:
         # NOT gated by notebook_repl: prebuilt-env package install is a
-        # separate Customize → Compute affordance, not the code REPL, and
-        # the global /kernel/install route is ungated too.
+        # separate Customize → Compute affordance, not the code REPL. Both
+        # this route and global /kernel/install are nevertheless admin-only
+        # in team mode because they mutate the shared runtime environment.
+        _require_instance_admin(self, "install shared kernel packages")
         fid = m.group(1)
         f = store.get_frame(fid) or {}
         pid = f.get("project_id") or "default"
@@ -387,6 +419,7 @@ def handle(self, method: str, sub: str, q: dict, runner: Any, store: Any) -> boo
             return True
         fid = m.group(1)
         f = store.get_frame(fid) or {}
+        _require_session_control(self, store, fid)
         pid = f.get("project_id") or "default"
         b = self._body()
         name = b.get("env") or b.get("name") or ""

--- a/openai4s/server/orchestration_routes.py
+++ b/openai4s/server/orchestration_routes.py
@@ -79,23 +79,22 @@ def _may_see(self, workload: Any) -> bool:
     return workload.owner_user_id == identity.user_id
 
 
-#: Backends that execute as the daemon process itself rather than handing the
-#: work to a scheduler that runs it under the submitting user's own account.
+#: Backends that launch work with daemon-controlled identity or credentials.
 #:
 #: `LocalBackend` runs `Popen(argv)` as the daemon's uid, outside the kernel
 #: sandbox, with the daemon's filesystem access -- which in team mode is every
-#: tenant's sessions, the access-token file and the group LLM credential. That
-#: is the hazard `team_policy.DAEMON_OPERATION_PATHS` already names for
-#: `/compute/jobs`, and it is a property of the *backend*, not of the route:
-#: a member submitting to a scheduler is submitting as themselves, and keeps
-#: it.
+#: tenant's sessions, the access-token file and the group LLM credential.
+#: `SlurmBackend` invokes the scheduler with the daemon's Unix identity and
+#: site credential; OpenAI4S has no authenticated member-to-scheduler-account
+#: mapping, so a browser member is not thereby submitting as themselves. Both
+#: can read or spend instance resources and are operator actions in team mode.
 #:
 #: Deliberately not solved by wrapping `LocalBackend` in the kernel sandbox.
 #: The sandbox degrades visibly rather than failing closed on hosts that
 #: cannot give it namespaces, and a privilege boundary that sometimes is not
 #: there is worse than a refusal. Member-submitted local work wants its own
 #: fail-closed `local-sandboxed` backend, designed as such.
-PRIVILEGED_BACKENDS = frozenset({"local"})
+PRIVILEGED_BACKENDS = frozenset({"cluster", "local"})
 
 
 def backend_for(runner: Any, body: Any) -> str:
@@ -333,8 +332,8 @@ def handle(
             self._json(
                 {
                     "error": (
-                        f"the {backend!r} backend runs jobs as the daemon and is "
-                        f"admin only; submit to a cluster backend instead"
+                        f"the {backend!r} backend launches work with "
+                        f"daemon-managed identity or credentials and is admin only"
                     ),
                     "code": "admin_only",
                     "backend": backend,

--- a/openai4s/server/orchestration_routes.py
+++ b/openai4s/server/orchestration_routes.py
@@ -28,7 +28,7 @@ from openai4s.orchestration.models import (
     WorkloadSpec,
 )
 
-from . import contract
+from . import contract, team_policy
 
 _JOBS = contract.RouteSpec(
     "orchestration.jobs", "GET", r"/orchestration/jobs", mutates=False
@@ -128,7 +128,7 @@ def _job_json(workload: Any, allocation: Any = None) -> dict:
         "execution_epoch": workload.execution_epoch,
         "owner_user_id": workload.owner_user_id,
         "project_id": workload.project_id,
-        "backend": getattr(workload, "backend", "local"),
+        "backend": workload.backend or "local",
         "created_at": getattr(workload, "created_at", None),
         "updated_at": getattr(workload, "updated_at", None),
     }
@@ -213,7 +213,7 @@ def handle(
         if target is not None:
             tail["allocation_id"] = target.id
             backends = getattr(runner, "orchestration_backends", {}) or {}
-            backend = backends.get(getattr(workload, "backend", "local"))
+            backend = backends.get(workload.backend or "local")
             log_paths = getattr(backend, "log_paths", None)
             if callable(log_paths):
                 out_path, err_path = log_paths(target.id)
@@ -343,10 +343,21 @@ def handle(
             )
             return True
 
+        # The project is caller-supplied and lands in the workload row, the
+        # audit trail and the project-scoped usage reporting. The sibling
+        # write -- creating a session -- checks participation for exactly this
+        # reason; this one did not, so a member could file a job into another
+        # team's project and write into their audit log.
+        submit_project = body.get("project_id") or None
+        if submit_project and not team_policy.may_read_project(
+            store, _identity(self), str(submit_project)
+        ):
+            self._json({"error": "project not found", "code": "not_found"}, 404)
+            return True
         workload = store.workloads.create_workload(
             spec=spec,
             owner_user_id=_owner_id(self),
-            project_id=body.get("project_id") or None,
+            project_id=submit_project,
             backend=backend,
         )
         try:

--- a/openai4s/server/team_policy.py
+++ b/openai4s/server/team_policy.py
@@ -134,6 +134,25 @@ def may_use_session(store: Any, identity: Any, session_id: str | None) -> bool:
         return False
 
 
+def may_control_session(store: Any, identity: Any, session_id: str | None) -> bool:
+    """May this principal perform owner-level lifecycle mutations?
+
+    Project visibility is intentionally broader than ownership.  It can make a
+    session readable/collaborative, but it must not let another project member
+    cancel the owner's scheduler allocation or destroy its kernel namespace.
+    """
+
+    if identity is None or identity.is_admin:
+        return True
+    if not session_id:
+        return False
+    try:
+        owner = store.team.session_owner(session_id)
+    except Exception:  # noqa: BLE001 — undecidable is refused
+        return False
+    return bool(owner and owner.get("user_id") == identity.user_id)
+
+
 def may_use_share(store: Any, identity: Any, share_row: Any) -> bool:
     """A share is a projection of a session, so it inherits that session's
     answer. A share whose session cannot be resolved is refused rather than

--- a/openai4s/server/team_policy.py
+++ b/openai4s/server/team_policy.py
@@ -301,22 +301,66 @@ def may_change_instance_config(handler: Any) -> bool:
     return not enabled(handler) or is_admin(handler)
 
 
+# --- permission rules -------------------------------------------------------
+
+
+def may_write_permission_rule(
+    store: Any, identity: Any, scope: str, scope_id: str | None
+) -> bool:
+    """May this identity create or delete a standing permission rule here?
+
+    A standing rule is authorization for *future* actions, and a global one
+    is authorization for everybody's -- `permissions.resolve()` treats a
+    matching global `allow` as an answer for every other member's agent, and
+    a matching global `deny` as an absolute veto that deleting turns back
+    into an allow.
+
+    A function rather than two inlined copies in the REST handlers, because
+    it was two inlined copies and there are four writers. The two that were
+    guarded are `POST /permissions` and `DELETE /permissions/{id}`; the two
+    that were not are in `openai4s/permissions.py`, reached from
+    `POST /frames/{id}/decision` -- a route every member legitimately uses,
+    which passes the client's own `scope` straight through. So a member
+    approving a prompt in their own session with `{"scope": "global"}`
+    planted exactly the rule the 403 next door refuses them.
+    """
+    if identity is None or identity.is_admin:
+        return True
+    if scope == "global":
+        return False
+    if scope == "project":
+        return may_read_project(store, identity, str(scope_id or ""))
+    if scope == "conversation":
+        return may_use_session(store, identity, str(scope_id or ""))
+    # "once" is not a standing rule at all.
+    return True
+
+
 # --- files ------------------------------------------------------------------
 
 
-def may_overwrite_file(identity: Any, owner_user_id: str | None) -> bool:
+def may_overwrite_file(identity: Any, owner_username: str | None) -> bool:
     """Containment inside `data_roots` says where a file may live, not whose
     it is. Overwriting is the destructive verb, so it is the one that needs
-    an owner."""
+    an owner.
+
+    A *username*, because that is what the file area is keyed by:
+    `<root>/users/<username>/` is the whole ownership record a path carries,
+    and `FileArea.personal_area_owner` returns that segment. The parameter
+    used to be spelled `owner_user_id` and compared against
+    `identity.user_id`, which no caller could ever have satisfied -- a member
+    would have been refused their own file. It had no callers, so nothing
+    said so.
+    """
     if identity is None or identity.is_admin:
         return True
-    if not owner_user_id:
-        # No recorded owner: pre-team files and anything written outside the
-        # team surface. Refuse rather than adopt — "we do not know whose
-        # this is" must not resolve to "anyone's", which is the same
-        # fail-closed rule an unowned session already gets.
+    if not owner_username:
+        # No recorded owner: shared space, pre-team files, anything written
+        # outside the team surface. Refuse rather than adopt — "we do not
+        # know whose this is" must not resolve to "anyone's", which is the
+        # same fail-closed rule an unowned session already gets.
         return False
-    return str(owner_user_id) == str(identity.user_id)
+    return str(owner_username) == str(identity.username)
 
 
 def _as_dict(identity: Any) -> dict[str, Any]:
@@ -357,6 +401,7 @@ __all__ = [
     "may_change_instance_config",
     "may_create_session_in",
     "may_overwrite_file",
+    "may_write_permission_rule",
     "may_read_project",
     "may_use_memory_scope",
     "may_use_session",

--- a/openai4s/server/team_routes.py
+++ b/openai4s/server/team_routes.py
@@ -200,6 +200,15 @@ def handle(self, method: str, sub: str, team_auth: Any, store: Any) -> bool:
         if not username or not password:
             self._json({"error": "username and password are required"}, 400)
             return True
+        # The invite first, and read-only. Answering about usernames ahead of
+        # it made this unauthenticated route an enumeration oracle for every
+        # account on the instance: "already exists" and "invalid invite" are
+        # distinguishable with no valid token at all. Asked without consuming
+        # anything, so the property the ordering was written for -- a typo'd
+        # username must not burn a single-use token -- still holds.
+        if not store.governance.invite_is_live(token):
+            self._json({"error": "invalid invite", "code": "invalid_invite"}, 403)
+            return True
         if store.team.get_user_by_username(username) is not None:
             self._json({"error": f"username {username!r} already exists"}, 409)
             return True

--- a/openai4s/storage/frames.py
+++ b/openai4s/storage/frames.py
@@ -19,7 +19,9 @@ from openai4s.execution.dependencies import (
 from openai4s.storage.deletion import SessionDeletionRepository
 
 
-def visible_session_clause(user_id: str, *, table: str = "frames") -> tuple[str, list]:
+def visible_session_clause(
+    user_id: str, *, table: str = "frames", session_expr: str | None = None
+) -> tuple[str, list]:
     """The one team-mode visibility rule, as SQL over a frames-shaped table.
 
     Returns `(clause, params)` for a WHERE conjunct. One function because
@@ -55,7 +57,11 @@ def visible_session_clause(user_id: str, *, table: str = "frames") -> tuple[str,
     `frame_detail` the rows carry cell code and stdout, which a post-read
     filter would have already loaded.
     """
-    session = f"COALESCE({table}.root_frame_id, {table}.frame_id)"
+    # `session_expr` for a table that is not frames-shaped: `artifacts` has a
+    # `root_frame_id` and no `frame_id`, and the ⌘K search needs the same rule
+    # over it. Defaulted rather than required, so every existing caller keeps
+    # the frames spelling.
+    session = session_expr or f"COALESCE({table}.root_frame_id, {table}.frame_id)"
     clause = (
         "(NOT EXISTS (SELECT 1 FROM users gu WHERE gu.id = ? AND gu.role = 'guest')"
         " AND EXISTS (SELECT 1 FROM session_owners so"

--- a/openai4s/storage/governance.py
+++ b/openai4s/storage/governance.py
@@ -81,7 +81,15 @@ CREATE TABLE IF NOT EXISTS usage_ledger (
     ref        TEXT
 );
 CREATE INDEX IF NOT EXISTS ix_usage_user_kind_ts ON usage_ledger(user_id, kind, ts);
-CREATE INDEX IF NOT EXISTS ix_usage_project_ts ON usage_ledger(project_id, ts);
+-- `kind` first, exactly like the user index above. Without it `check_quota`'s
+-- `WHERE kind=? AND ts>=? AND project_id=?` could only range-scan on ts and
+-- then visit every row to test kind -- and `enforce_llm_quota` runs that twice
+-- (once per token kind) before *every* provider request, over a ledger with a
+-- 30-day window and no pruning. Dropped by its old name because
+-- `CREATE INDEX IF NOT EXISTS` will not redefine an index that already exists.
+DROP INDEX IF EXISTS ix_usage_project_ts;
+CREATE INDEX IF NOT EXISTS ix_usage_project_kind_ts
+    ON usage_ledger(project_id, kind, ts);
 CREATE TABLE IF NOT EXISTS quotas (
     scope        TEXT NOT NULL CHECK (scope IN ('user','project')),
     scope_id     TEXT NOT NULL,
@@ -279,6 +287,27 @@ class GovernanceRepository:
             ).fetchone()
             self._connection.commit()
         return {"project_id": row[0], "created_by": row[1]}
+
+    def invite_is_live(self, token: str) -> bool:
+        """Is this invite redeemable right now? Consumes nothing.
+
+        `POST /auth/redeem-invite` is unauthenticated, and it answered
+        "username 'alice' already exists" before it looked at the token at
+        all -- so anyone who could reach the port could enumerate every
+        account on the instance for free, and hand the login limiter a
+        confirmed target list. The route needs to know the invite is real
+        before it says anything about who exists, and it still must not burn
+        the token on a username typo. Hence a separate, read-only question.
+        """
+        digest = invite_digest(token or "")
+        now = self._clock_ms()
+        with self._lock:
+            row = self._connection.execute(
+                "SELECT 1 FROM invites WHERE token_hash=? AND used_at IS NULL"
+                " AND expires_at>?",
+                (digest, now),
+            ).fetchone()
+        return row is not None
 
     def reinstate_invite(self, token: str) -> bool:
         """Undo a redemption whose follow-up work failed.

--- a/openai4s/storage/leases.py
+++ b/openai4s/storage/leases.py
@@ -33,6 +33,7 @@ import sqlite3
 from dataclasses import dataclass
 from typing import Any, Callable
 
+from openai4s.orchestration.models import DesiredState, Reason
 from openai4s.storage.migrations import apply_ddl_script
 
 LEASE_SCHEMA = """
@@ -211,6 +212,76 @@ class LeaseRepository:
                 " WHERE released_at IS NULL"
             ).fetchall()
         return [_row_to_lease(row) for row in rows]
+
+    def expire_if_unchanged(
+        self, lease: Lease, *, now_ms: int, reason: Reason
+    ) -> tuple[bool, bool]:
+        """Atomically stop and release an unchanged, still-expired lease.
+
+        Returns ``(expired, stop_requested)``. ``expired`` is false when a
+        user touched or reopened the lease after the reclaimer took its
+        snapshot. Checking that fact and writing both rows in one transaction
+        is the CAS that prevents a successful renewal from being reclaimed by
+        a stale sweep.
+        """
+
+        if reason is Reason.SESSION_MAX_LIFETIME_EXCEEDED:
+            # Touching renews idle time, never the hard lifetime.  Including
+            # ``last_active_at`` in this CAS let a touch racing a maximum-age
+            # sweep make an already-over-age session immortal one race at a
+            # time.  Reopen still wins because it replaces ``created_at``.
+            unchanged_and_expired = (
+                "workload_id=? AND released_at IS NULL"
+                " AND created_at=? AND max_lifetime_s=?"
+                " AND ? >= created_at + max_lifetime_s * 1000"
+            )
+            snapshot = (
+                lease.workload_id,
+                lease.created_at,
+                lease.max_lifetime_s,
+                int(now_ms),
+            )
+        else:
+            unchanged_and_expired = (
+                "workload_id=? AND released_at IS NULL"
+                " AND created_at=? AND last_active_at=?"
+                " AND idle_ttl_s=? AND max_lifetime_s=?"
+                " AND ? >= last_active_at + idle_ttl_s * 1000"
+            )
+            snapshot = (
+                lease.workload_id,
+                lease.created_at,
+                lease.last_active_at,
+                lease.idle_ttl_s,
+                lease.max_lifetime_s,
+                int(now_ms),
+            )
+        with self._lock:
+            try:
+                stopped = self._conn.execute(
+                    "UPDATE workloads SET desired_state=?, reason=?, updated_at=?"
+                    " WHERE id=? AND phase NOT IN"
+                    " ('COMPLETED','FAILED','CANCELLED','LOST')"
+                    " AND EXISTS (SELECT 1 FROM leases WHERE "
+                    + unchanged_and_expired
+                    + ")",
+                    (
+                        DesiredState.STOPPED.value,
+                        reason.value,
+                        int(now_ms),
+                        lease.workload_id,
+                        *snapshot,
+                    ),
+                )
+                released = self._conn.execute(
+                    "UPDATE leases SET released_at=? WHERE " + unchanged_and_expired,
+                    (int(now_ms), *snapshot),
+                )
+                self._conn.commit()
+            except Exception:
+                self._conn.rollback()
+                raise
+        return released.rowcount > 0, stopped.rowcount > 0
 
     def release(self, workload_id: str) -> None:
         with self._lock:

--- a/openai4s/storage/team.py
+++ b/openai4s/storage/team.py
@@ -45,6 +45,12 @@ _ROLES = ("admin", "member", "guest")
 #: not re-authenticating daily, short enough that a leaked cookie dies.
 SESSION_TTL_S = 14 * 24 * 3600
 
+#: How stale `auth_sessions.last_seen_at` may get before a read refreshes it.
+#: It answers "when was this session last used", which nothing reads at finer
+#: resolution than minutes -- and writing it per request made every read a
+#: durable write. See `resolve_auth_session`.
+_LAST_SEEN_RESOLUTION_MS = 60_000
+
 TEAM_SCHEMA = """
 CREATE TABLE IF NOT EXISTS users (
     id            TEXT PRIMARY KEY,
@@ -191,6 +197,31 @@ class TeamRepository:
         user_id = f"user_{uuid.uuid4().hex[:12]}"
         now = self._clock_ms()
         with self._lock:
+            # Case-insensitively unique, not just `UNIQUE` on the column.
+            #
+            # SQLite's UNIQUE is case-sensitive, so `Alice` and `alice` were
+            # two accounts -- and the file area names each member's personal
+            # directory `<root>/users/<username>/`, which on a
+            # case-insensitive filesystem (APFS by default, most SMB/NFS
+            # exports, Windows) is ONE directory. `personal_area_owner` then
+            # compares the segment the client spelled against the reader's
+            # name with `!=`, so `alice` reading `<root>/users/alice/x.csv`
+            # passed the guard and was served `Alice`'s file -- and could
+            # overwrite it. The two accounts also read as the same person to
+            # every human looking at an audit row.
+            #
+            # Refused at creation rather than papered over at comparison:
+            # casefolding the *guard* would make the collision permitted
+            # rather than impossible.
+            clash = self._connection.execute(
+                "SELECT username FROM users WHERE username=? COLLATE NOCASE",
+                (username,),
+            ).fetchone()
+            if clash is not None:
+                raise ValueError(
+                    f"username {username!r} already exists "
+                    f"(as {str(clash[0])!r}; usernames differ by more than case)"
+                )
             try:
                 self._connection.execute(
                     "INSERT INTO users(id, username, display_name, role,"
@@ -327,25 +358,35 @@ class TeamRepository:
         now = self._clock_ms()
         with self._lock:
             row = self._connection.execute(
-                "SELECT s.user_id, s.expires_at FROM auth_sessions s"
+                "SELECT s.user_id, s.expires_at, s.last_seen_at FROM auth_sessions s"
                 " JOIN users u ON u.id = s.user_id"
                 " WHERE s.token_hash=? AND u.disabled=0",
                 (digest,),
             ).fetchone()
             if row is None:
                 return None
-            user_id, expires_at = row
+            user_id, expires_at, last_seen = row
             if int(expires_at) <= now:
                 self._connection.execute(
                     "DELETE FROM auth_sessions WHERE token_hash=?", (digest,)
                 )
                 self._connection.commit()
                 return None
-            self._connection.execute(
-                "UPDATE auth_sessions SET last_seen_at=? WHERE token_hash=?",
-                (now, digest),
-            )
-            self._connection.commit()
+            # Coarsened deliberately. This runs on *every* request in team
+            # mode -- `_team_admit` resolves the identity before it even
+            # consults the exempt-path list, so each static asset paid for it
+            # too -- and it was an UPDATE plus a durable `commit()` on the
+            # daemon's single shared connection, behind the same lock a turn
+            # needs to append frames. A page load is a dozen requests and an
+            # idle dashboard polls every four seconds, so a handful of users
+            # produced a steady stream of fsync-bearing write transactions to
+            # maintain a field whose value is measured in minutes.
+            if int(last_seen or 0) < now - _LAST_SEEN_RESOLUTION_MS:
+                self._connection.execute(
+                    "UPDATE auth_sessions SET last_seen_at=? WHERE token_hash=?",
+                    (now, digest),
+                )
+                self._connection.commit()
         return self.get_user(str(user_id))
 
     def revoke_auth_session(self, token: str | None) -> bool:

--- a/openai4s/storage/team.py
+++ b/openai4s/storage/team.py
@@ -30,6 +30,7 @@ import hashlib
 import hmac
 import secrets
 import sqlite3
+import unicodedata
 import uuid
 from typing import Any, Callable
 
@@ -163,6 +164,12 @@ def validate_username(username: str) -> str:
     return name
 
 
+def _username_key(username: str) -> str:
+    """Portable account identity for collision checks, not display/storage."""
+
+    return unicodedata.normalize("NFKC", username).casefold()
+
+
 class TeamRepository:
     """Accounts, login sessions, and the team audit log."""
 
@@ -176,6 +183,34 @@ class TeamRepository:
         self._connection = connection
         self._lock = lock
         self._clock_ms = clock_ms
+        self._assert_portable_username_keys()
+
+    def _assert_portable_username_keys(self) -> None:
+        """Fail closed when an upgraded database already contains a clash.
+
+        New account creation prevents these pairs, but databases created by
+        an older release may already contain them.  Continuing would map two
+        authenticated identities onto one case/compatibility-normalizing
+        personal-directory path on common filesystems.  Refusing startup is
+        safer than guessing which account owns the shared files.
+        """
+
+        seen: dict[str, str] = {}
+        with self._lock:
+            rows = self._connection.execute(
+                "SELECT username FROM users ORDER BY created_at, username"
+            ).fetchall()
+        for row in rows:
+            username = str(row[0])
+            key = _username_key(username)
+            previous = seen.get(key)
+            if previous is not None:
+                raise RuntimeError(
+                    "team database contains usernames with the same portable "
+                    f"filesystem identity: {previous!r} and {username!r}; "
+                    "rename or remove one account before starting the daemon"
+                )
+            seen[key] = username
 
     # --- users -----------------------------------------------------------
 
@@ -197,30 +232,33 @@ class TeamRepository:
         user_id = f"user_{uuid.uuid4().hex[:12]}"
         now = self._clock_ms()
         with self._lock:
-            # Case-insensitively unique, not just `UNIQUE` on the column.
+            # Compatibility- and case-insensitively unique, not just `UNIQUE`
+            # on the column.
             #
-            # SQLite's UNIQUE is case-sensitive, so `Alice` and `alice` were
-            # two accounts -- and the file area names each member's personal
-            # directory `<root>/users/<username>/`, which on a
-            # case-insensitive filesystem (APFS by default, most SMB/NFS
-            # exports, Windows) is ONE directory. `personal_area_owner` then
-            # compares the segment the client spelled against the reader's
-            # name with `!=`, so `alice` reading `<root>/users/alice/x.csv`
-            # passed the guard and was served `Alice`'s file -- and could
-            # overwrite it. The two accounts also read as the same person to
-            # every human looking at an audit row.
+            # SQLite NOCASE is ASCII-only, so it catches `Alice`/`alice` but
+            # not Unicode pairs such as `K`/`K`. The file area names each
+            # member's personal directory `<root>/users/<username>/`, and
+            # compatibility/case normalization is common in filesystems and
+            # identity providers. NFKC + casefold is therefore the one account
+            # key, while the original spelling remains the displayed/stored
+            # username.
             #
             # Refused at creation rather than papered over at comparison:
             # casefolding the *guard* would make the collision permitted
             # rather than impossible.
-            clash = self._connection.execute(
-                "SELECT username FROM users WHERE username=? COLLATE NOCASE",
-                (username,),
-            ).fetchone()
+            key = _username_key(username)
+            clash = next(
+                (
+                    row
+                    for row in self._connection.execute("SELECT username FROM users")
+                    if _username_key(str(row[0])) == key
+                ),
+                None,
+            )
             if clash is not None:
                 raise ValueError(
                     f"username {username!r} already exists "
-                    f"(as {str(clash[0])!r}; usernames differ by more than case)"
+                    f"(as {str(clash[0])!r}; usernames have the same canonical key)"
                 )
             try:
                 self._connection.execute(

--- a/openai4s/storage/workloads.py
+++ b/openai4s/storage/workloads.py
@@ -197,6 +197,151 @@ class WorkloadRepository:
             self._connection.commit()
         return workload
 
+    def create_session_workload(
+        self,
+        *,
+        session_id: str,
+        spec: WorkloadSpec,
+        owner_user_id: str,
+        project_id: str | None,
+        backend: str,
+        idle_ttl_s: int,
+        max_lifetime_s: int,
+    ) -> Workload:
+        """Atomically create a session workload, binding and live lease.
+
+        A reconciler submits every RUNNING workload it can see. Committing the
+        workload before its session binding/lease meant a crash or later write
+        failure produced an unreachable orphan that was nevertheless eligible
+        for cluster submission. These three rows are one durable fact.
+        """
+
+        workload = Workload(
+            id=Workload.new_id(),
+            spec=spec,
+            owner_user_id=owner_user_id,
+            project_id=project_id,
+            backend=backend,
+        )
+        now = self._clock_ms()
+        with self._lock:
+            try:
+                self._connection.execute("BEGIN IMMEDIATE")
+                self._connection.execute(
+                    "INSERT INTO workloads(id, kind, owner_user_id, project_id,"
+                    " backend, spec_json, spec_revision, desired_state, phase,"
+                    " execution_epoch, reason, created_at, updated_at)"
+                    " VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                    (
+                        workload.id,
+                        spec.kind.value,
+                        owner_user_id,
+                        project_id,
+                        backend,
+                        _spec_to_json(spec),
+                        spec.spec_revision,
+                        workload.desired_state.value,
+                        workload.phase.value,
+                        workload.execution_epoch,
+                        None,
+                        now,
+                        now,
+                    ),
+                )
+                self._connection.execute(
+                    "INSERT INTO session_workloads"
+                    " (session_id, workload_id, created_at) VALUES (?,?,?)"
+                    " ON CONFLICT(session_id) DO UPDATE SET"
+                    " workload_id=excluded.workload_id,"
+                    " created_at=excluded.created_at",
+                    (session_id, workload.id, now),
+                )
+                self._connection.execute(
+                    "INSERT INTO leases"
+                    " (workload_id, created_at, last_active_at, idle_ttl_s,"
+                    " max_lifetime_s, released_at) VALUES (?,?,?,?,?,NULL)",
+                    (
+                        workload.id,
+                        now,
+                        now,
+                        int(idle_ttl_s),
+                        int(max_lifetime_s),
+                    ),
+                )
+                self._connection.commit()
+            except Exception:
+                self._connection.rollback()
+                raise
+        return workload
+
+    def release_session_workload(
+        self,
+        *,
+        session_id: str,
+        reason: Reason,
+        expected_workload_id: str | None = None,
+    ) -> str | None:
+        """Atomically stop, release and unbind one session workload.
+
+        These rows describe one durable lifecycle fact.  Committing them in
+        three repository calls allowed a crash (or a failed DELETE) to leave
+        a STOPPED, released workload still bound to the session.  On restart
+        ``request_session`` then returned that unusable workload forever.
+
+        The optional workload id is an ABA fence for delayed reclaimer and
+        terminal-event cleanup: an event for W1 must never consume a newer W2
+        binding for the same chat session.
+        """
+
+        now = self._clock_ms()
+        with self._lock:
+            try:
+                self._connection.execute("BEGIN IMMEDIATE")
+                row = self._connection.execute(
+                    "SELECT workload_id FROM session_workloads" " WHERE session_id=?",
+                    (session_id,),
+                ).fetchone()
+                if row is None:
+                    self._connection.rollback()
+                    return None
+                workload_id = str(row[0])
+                if (
+                    expected_workload_id is not None
+                    and workload_id != expected_workload_id
+                ):
+                    self._connection.rollback()
+                    return None
+                self._connection.execute(
+                    "UPDATE workloads SET desired_state=?, reason=?, updated_at=?"
+                    " WHERE id=? AND phase NOT IN"
+                    " ('COMPLETED','FAILED','CANCELLED','LOST')",
+                    (
+                        DesiredState.STOPPED.value,
+                        reason.value,
+                        now,
+                        workload_id,
+                    ),
+                )
+                self._connection.execute(
+                    "UPDATE leases SET released_at=?"
+                    " WHERE workload_id=? AND released_at IS NULL",
+                    (now, workload_id),
+                )
+                deleted = self._connection.execute(
+                    "DELETE FROM session_workloads"
+                    " WHERE session_id=? AND workload_id=?",
+                    (session_id, workload_id),
+                )
+                if deleted.rowcount != 1:
+                    raise RuntimeError(
+                        "session workload binding changed during release"
+                    )
+                self._connection.commit()
+                return workload_id
+            except Exception:
+                self._connection.rollback()
+                raise
+
     def _row_to_workload(self, row: Any) -> Workload:
         workload = Workload(
             id=row["id"],
@@ -247,6 +392,38 @@ class WorkloadRepository:
             ).fetchall()
         return [self._row_to_workload(r) for r in rows]
 
+    def session_cleanup_candidates(self) -> list[tuple[str, str, Reason | None]]:
+        """Return bound sessions whose durable compute cleanup is unfinished.
+
+        Terminal events are edge-triggered, while daemon restart is not. A
+        terminal/stopped workload or a missing/released lease that remains in
+        ``session_workloads`` is therefore a durable cleanup intent which the
+        gateway must replay. Keep this join in the repository so the gateway
+        neither reaches into Store internals nor imposes an arbitrary list
+        limit that can strand an older binding forever.
+        """
+
+        with self._lock:
+            rows = self._connection.execute(
+                "SELECT sw.session_id, sw.workload_id, w.reason "
+                "FROM session_workloads AS sw "
+                "JOIN workloads AS w ON w.id=sw.workload_id "
+                "LEFT JOIN leases AS l ON l.workload_id=sw.workload_id "
+                "WHERE w.phase IN ('COMPLETED','FAILED','CANCELLED','LOST') "
+                "OR w.desired_state='STOPPED' "
+                "OR l.workload_id IS NULL OR l.released_at IS NOT NULL "
+                "ORDER BY sw.created_at, sw.session_id"
+            ).fetchall()
+        candidates = []
+        for row in rows:
+            raw_reason = row["reason"]
+            try:
+                reason = Reason(raw_reason) if raw_reason else None
+            except ValueError:
+                reason = None
+            candidates.append((str(row["session_id"]), str(row["workload_id"]), reason))
+        return candidates
+
     def workloads_needing_attention(self) -> list[Workload]:
         """The reconciler's queue: everything not yet terminal."""
         with self._lock:
@@ -290,16 +467,17 @@ class WorkloadRepository:
             )
             self._connection.commit()
 
-    def open_recovery_epoch(self, allocation: Allocation, workload: Workload) -> None:
-        """Retire the dead allocation and start the next epoch, atomically.
+    def save_allocation_and_workload(
+        self, allocation: Allocation, workload: Workload
+    ) -> None:
+        """Persist one allocation/workload state transition atomically.
 
         Two writes, one commit. Split, the window between them is not
-        theoretical: the allocation goes terminal, the process dies, and the
-        workload comes back still on the old epoch -- so the next tick calls
-        `create_allocation(workload_id, epoch)` with an epoch that already
-        has a row, hits `UNIQUE (workload_id, epoch)`, and raises. Every
-        subsequent tick raises identically, so the session never recovers
-        and the failure repeats forever with no state that can move.
+        theoretical for terminal and rejected attempts: the allocation goes
+        terminal, the process dies, and the workload can come back nonterminal
+        on the same epoch. The next tick then calls
+        `create_allocation(workload_id, epoch)` where a row already exists,
+        hits `UNIQUE (workload_id, epoch)`, and repeats forever.
 
         Swapping the order does not fix it: bumping the epoch first leaves
         the *old* allocation still in the active set, and INV-3's partial
@@ -308,29 +486,41 @@ class WorkloadRepository:
         """
         now = self._clock_ms()
         with self._lock:
-            self._connection.execute(
-                "UPDATE allocations SET phase=?, reason=?, observed_json=?,"
-                " released_at=? WHERE id=?",
-                (
-                    allocation.phase.value,
-                    allocation.reason.value if allocation.reason else None,
-                    json.dumps(allocation.diagnostics or {}, ensure_ascii=False),
-                    now,
-                    allocation.id,
-                ),
-            )
-            self._connection.execute(
-                "UPDATE workloads SET phase=?, execution_epoch=?,"
-                " reason=COALESCE(?, reason), updated_at=? WHERE id=?",
-                (
-                    workload.phase.value,
-                    workload.execution_epoch,
-                    workload.reason.value if workload.reason else None,
-                    now,
-                    workload.id,
-                ),
-            )
-            self._connection.commit()
+            try:
+                self._connection.execute(
+                    "UPDATE allocations SET phase=?, external_backend=?,"
+                    " external_ns=?, external_id=?, reason=?, observed_json=?,"
+                    " released_at=COALESCE(released_at, ?) WHERE id=?",
+                    (
+                        allocation.phase.value,
+                        allocation.handle.backend if allocation.handle else None,
+                        allocation.handle.namespace if allocation.handle else None,
+                        allocation.handle.external_id if allocation.handle else None,
+                        allocation.reason.value if allocation.reason else None,
+                        json.dumps(allocation.diagnostics, sort_keys=True),
+                        now if allocation.phase.is_terminal else None,
+                        allocation.id,
+                    ),
+                )
+                self._connection.execute(
+                    "UPDATE workloads SET phase=?, execution_epoch=?,"
+                    " reason=COALESCE(?, reason), updated_at=? WHERE id=?",
+                    (
+                        workload.phase.value,
+                        workload.execution_epoch,
+                        workload.reason.value if workload.reason else None,
+                        now,
+                        workload.id,
+                    ),
+                )
+                self._connection.commit()
+            except Exception:
+                self._connection.rollback()
+                raise
+
+    def open_recovery_epoch(self, allocation: Allocation, workload: Workload) -> None:
+        """Retire the dead allocation and start the next epoch, atomically."""
+        self.save_allocation_and_workload(allocation, workload)
 
     def request_stop(self, workload_id: str, *, reason: Reason) -> bool:
         """Ask for cancellation. The reconciler runs the barrier; this only
@@ -410,6 +600,33 @@ class WorkloadRepository:
                 (workload_id,),
             ).fetchone()
         return self._row_to_allocation(row) if row else None
+
+    def session_registration_expected(self, allocation_id: str, epoch: int) -> bool:
+        """Whether an authenticated worker still belongs to a live session.
+
+        A scheduler may start the worker long before the user's first Cell.
+        Such a registration is parked in ``WorkerGateway`` but is not an
+        orphan: the durable binding, live lease and active allocation are its
+        owner.  This single query lets gateway housekeeping distinguish that
+        case from a straggler after release/recovery without caching lifecycle
+        state in the transport layer.
+        """
+
+        with self._lock:
+            row = self._connection.execute(
+                f"SELECT 1 FROM allocations AS a"
+                " JOIN workloads AS w ON w.id=a.workload_id"
+                " JOIN session_workloads AS sw ON sw.workload_id=w.id"
+                " JOIN leases AS l ON l.workload_id=w.id"
+                " WHERE a.id=? AND a.epoch=?"
+                f" AND a.phase IN ({_ACTIVE_SQL})"
+                " AND w.execution_epoch=a.epoch"
+                " AND w.desired_state='RUNNING'"
+                " AND w.phase NOT IN ('COMPLETED','FAILED','CANCELLED','LOST')"
+                " AND l.released_at IS NULL LIMIT 1",
+                (allocation_id, int(epoch)),
+            ).fetchone()
+        return row is not None
 
     def list_allocations(self, workload_id: str) -> list[Allocation]:
         with self._lock:

--- a/openai4s/storage/workloads.py
+++ b/openai4s/storage/workloads.py
@@ -169,6 +169,7 @@ class WorkloadRepository:
             spec=spec,
             owner_user_id=owner_user_id,
             project_id=project_id,
+            backend=backend,
         )
         now = self._clock_ms()
         with self._lock:
@@ -194,7 +195,6 @@ class WorkloadRepository:
                 ),
             )
             self._connection.commit()
-        setattr(workload, "backend", backend)
         return workload
 
     def _row_to_workload(self, row: Any) -> Workload:
@@ -207,9 +207,8 @@ class WorkloadRepository:
             phase=Phase(row["phase"]),
             execution_epoch=int(row["execution_epoch"] or 0),
             reason=Reason(row["reason"]) if row["reason"] else None,
+            backend=row["backend"] or "",
         )
-        # Which backend runs it is persistence's business, not the model's.
-        setattr(workload, "backend", row["backend"])
         setattr(workload, "created_at", row["created_at"])
         setattr(workload, "updated_at", row["updated_at"])
         return workload

--- a/openai4s/store.py
+++ b/openai4s/store.py
@@ -81,7 +81,7 @@ from openai4s.storage.datapro_index import (
     create_datapro_index_schema,
 )
 from openai4s.storage.delegation import DelegationProjectionRepository
-from openai4s.storage.frames import FrameRepository
+from openai4s.storage.frames import FrameRepository, visible_session_clause
 from openai4s.storage.governance import (
     GovernanceRepository,
     create_governance_schema,
@@ -812,6 +812,32 @@ _SCOPED_VIEWS = frozenset(
     }
 )
 
+#: A CTE binding one of `_SCOPED_VIEWS` by name. The authorizer's fifth
+#: argument names "the view responsible for this read", and SQLite fills it in
+#: for a *common table expression* exactly as it does for a view -- measured:
+#: `WITH my_messages AS (SELECT * FROM main.messages) SELECT content FROM
+#: my_messages` hands the authorizer `(20, 'messages', 'content', 'main',
+#: 'my_messages')`, which is byte-for-byte what the real temp view produces.
+#: So the one string the escape hatch trusts was a string the caller could
+#: mint, and in team mode that string was the entire tenant boundary for
+#: `host.query`: one CTE returned every colleague's prompts, replies, cell
+#: code and stdout.
+#:
+#: A CTE is the only construct that can bind it -- a subquery alias
+#: (`FROM (SELECT …) AS my_messages`) and a table alias both leave the fifth
+#: argument None, and are already refused. So the rule is narrow: a CTE may
+#: not be named after a scoped view. Matched on the literal-stripped text as
+#: a *pre*-check, with the authorizer's own published-view test below as the
+#: second layer: a text rule and a parse-time rule fail differently, and this
+#: boundary has already been the whole of tenant isolation once.
+_CTE_SHADOW_RE = re.compile(
+    r"\b(" + "|".join(sorted(_SCOPED_VIEWS)) + r")\b"
+    r"\s*(?:\([^()]*\)\s*)?"
+    r"\bas\b\s*(?:not\s+)?(?:materialized\s*)?\(",
+    re.IGNORECASE,
+)
+
+
 #: Base tables reachable only through `_SCOPED_VIEWS`. These were readable
 #: directly and were not on `QUERY_DENYLIST` at all, so one `SELECT` returned
 #: every project's artifacts with their filenames, checksums and absolute
@@ -901,8 +927,19 @@ class _QueryAuthorizer:
     interface, so matching on it would work until it did not.
     """
 
-    def __init__(self, view_only: frozenset[str] | None = None) -> None:
+    def __init__(
+        self,
+        view_only: frozenset[str] | None = None,
+        *,
+        published_views: frozenset[str] = frozenset(),
+    ) -> None:
         self.denied: list[str] = []
+        # Which scoped views this statement may be read *through*. Empty when
+        # the caller supplied no scope, so a query with no scope cannot reach
+        # a view-only base table by claiming a view that was never created --
+        # the escape hatch used to accept the name whether or not anything
+        # answered to it.
+        self._published_views = frozenset(published_views)
         # Which base tables are reachable only through a scoped view. Passed
         # in rather than read from a module constant because the answer
         # depends on the deployment: a team daemon closes the conversation
@@ -953,8 +990,10 @@ class _QueryAuthorizer:
         if table in QUERY_DENYLIST:
             return self._deny(table)
         if table in self._view_only:
-            # Permitted only as the underlying read of a trusted scoped view.
-            if (source or "").lower() in _SCOPED_VIEWS:
+            # Permitted only as the underlying read of a trusted scoped view
+            # that this statement actually published. `_SCOPED_VIEWS` alone was
+            # the test, and the name is caller-mintable through a CTE.
+            if (source or "").lower() in self._published_views:
                 return sqlite3.SQLITE_OK
             return self._deny(table)
         return sqlite3.SQLITE_OK
@@ -4266,21 +4305,46 @@ class Store:
         self._datapro_index.delete_batch(batch_id)
 
     # --- global search (command palette) --------------------------------
-    def search(self, query: str, limit: int = 20) -> dict:
-        """Search sessions, artifacts, and indexed DataPro content for ⌘K."""
+    def search(
+        self, query: str, limit: int = 20, *, visible_to_user_id: str | None = None
+    ) -> dict:
+        """Search sessions, artifacts, and indexed DataPro content for ⌘K.
+
+        `visible_to_user_id` narrows the queries themselves. It used to be a
+        post-filter in the route, applied *after* `LIMIT 20` -- so on a team
+        where the twenty most recently updated matches belong to colleagues,
+        every one of them was dropped and the caller was told their own
+        session does not exist. `visible_session_clause` is the same rule the
+        frame listings use, and it exists precisely because "filter after the
+        read" turns a full page of hidden rows into a phantom empty result.
+        """
         q = f"%{query.strip()}%"
+        frame_scope = artifact_scope = ""
+        frame_params: list = []
+        artifact_params: list = []
+        if visible_to_user_id is not None:
+            clause, frame_params = visible_session_clause(visible_to_user_id)
+            frame_scope = " AND " + clause
+            clause, artifact_params = visible_session_clause(
+                visible_to_user_id,
+                table="artifacts",
+                session_expr="artifacts.root_frame_id",
+            )
+            artifact_scope = " AND " + clause
         with self._lock:
             frames = self._conn.execute(
                 "SELECT frame_id,project_id,name,task_summary,updated_at FROM frames "
-                "WHERE parent_id IS NULL AND (name LIKE ? OR task_summary LIKE ?) "
+                "WHERE parent_id IS NULL AND (name LIKE ? OR task_summary LIKE ?)"
+                f"{frame_scope} "
                 "ORDER BY updated_at DESC LIMIT ?",
-                (q, q, limit),
+                (q, q, *frame_params, limit),
             ).fetchall()
             arts = self._conn.execute(
                 "SELECT artifact_id,filename,content_type,root_frame_id,project_id "
-                "FROM artifacts WHERE filename LIKE ? ORDER BY created_at DESC "
+                f"FROM artifacts WHERE filename LIKE ?{artifact_scope} "
+                "ORDER BY created_at DESC "
                 "LIMIT ?",
-                (q, limit),
+                (q, *artifact_params, limit),
             ).fetchall()
         return {
             "sessions": [
@@ -4727,6 +4791,16 @@ class Store:
         bad = _DENY_WORD_RE.search(deny_scan)
         if bad is not None:
             raise PermissionError(f"host.query: table '{bad.group(0)}' is not readable")
+        shadow = _CTE_SHADOW_RE.search(deny_scan)
+        if shadow is not None:
+            # See `_CTE_SHADOW_RE`: naming a CTE after a scoped view makes
+            # SQLite hand the authorizer that name as the view responsible for
+            # the read, which is how the escape hatch below came to trust a
+            # string the caller wrote.
+            raise PermissionError(
+                f"host.query: {shadow.group(1)!r} is a scoped view and cannot "
+                f"be used as a CTE name"
+            )
         stripped = lowered.lstrip()
         if not (stripped.startswith("select") or stripped.startswith("with")):
             raise ValueError("host.query only allows read-only SELECT/CTE")
@@ -4743,7 +4817,10 @@ class Store:
         # by rule and not by keyword.
         conn = self._conn
         with self._lock:
-            guard = _QueryAuthorizer(view_only=self._query_view_only())
+            guard = _QueryAuthorizer(
+                view_only=self._query_view_only(),
+                published_views=_SCOPED_VIEWS if scope else frozenset(),
+            )
             try:
                 # Views first, with the guard off: creating them is a privileged
                 # setup step, not part of the caller's statement.

--- a/openai4s/store.py
+++ b/openai4s/store.py
@@ -823,19 +823,142 @@ _SCOPED_VIEWS = frozenset(
 #: `host.query`: one CTE returned every colleague's prompts, replies, cell
 #: code and stdout.
 #:
-#: A CTE is the only construct that can bind it -- a subquery alias
-#: (`FROM (SELECT …) AS my_messages`) and a table alias both leave the fifth
-#: argument None, and are already refused. So the rule is narrow: a CTE may
-#: not be named after a scoped view. Matched on the literal-stripped text as
-#: a *pre*-check, with the authorizer's own published-view test below as the
-#: second layer: a text rule and a parse-time rule fail differently, and this
-#: boundary has already been the whole of tenant isolation once.
-_CTE_SHADOW_RE = re.compile(
-    r"\b(" + "|".join(sorted(_SCOPED_VIEWS)) + r")\b"
-    r"\s*(?:\([^()]*\)\s*)?"
-    r"\bas\b\s*(?:not\s+)?(?:materialized\s*)?\(",
-    re.IGNORECASE,
-)
+#: SQLite accepts identifiers quoted with double quotes, brackets, backticks
+#: and (for compatibility) single quotes. The denylist scanner deliberately
+#: removes single-quoted *literals*, so a regex over that scanner can never
+#: distinguish `SELECT 'my_messages'` from `WITH 'my_messages' AS (...)`.
+#: This small lexer keeps quote kind and punctuation, then parses only the
+#: `WITH name [(columns)] AS [NOT] [MATERIALIZED] (...)` binding shape. It is
+#: intentionally not a SQL parser; SQLite's authorizer remains the enforcement
+#: for every other name and operation.
+
+
+def _sql_cte_tokens(sql: str) -> list[tuple[str, str]]:
+    """Tokenize just enough SQL to recognize quoted CTE bindings."""
+
+    tokens: list[tuple[str, str]] = []
+    index = 0
+    length = len(sql or "")
+    while index < length:
+        char = sql[index]
+        if char.isspace():
+            index += 1
+            continue
+        if sql.startswith("--", index):
+            newline = sql.find("\n", index + 2)
+            index = length if newline < 0 else newline + 1
+            continue
+        if sql.startswith("/*", index):
+            end = sql.find("*/", index + 2)
+            index = length if end < 0 else end + 2
+            continue
+        if char in "'\"`[":
+            closing = "]" if char == "[" else char
+            index += 1
+            value: list[str] = []
+            while index < length:
+                current = sql[index]
+                if current == closing:
+                    # SQLite doubles quote delimiters inside quoted names.
+                    if index + 1 < length and sql[index + 1] == closing:
+                        value.append(closing)
+                        index += 2
+                        continue
+                    index += 1
+                    break
+                value.append(current)
+                index += 1
+            tokens.append(("quoted", "".join(value)))
+            continue
+        if char in "(),":
+            tokens.append(("punct", char))
+            index += 1
+            continue
+        # SQLite's ALPHABETIC class includes every non-ASCII code point, not
+        # only characters Python calls alphanumeric. Combining marks are a
+        # practical example: ``e\u0301`` is one valid bare identifier. Treating
+        # the mark as an unknown token let an attacker put that harmless CTE
+        # first and hide a scoped-view shadow later in the same WITH list.
+        if char.isalnum() or char in "_$" or ord(char) >= 0x80:
+            start = index
+            while index < length and (
+                sql[index].isalnum() or sql[index] in "_$" or ord(sql[index]) >= 0x80
+            ):
+                index += 1
+            tokens.append(("word", sql[start:index]))
+            continue
+        tokens.append(("other", char))
+        index += 1
+    return tokens
+
+
+def _after_sql_parentheses(tokens: list[tuple[str, str]], index: int) -> int | None:
+    """Return the token after one balanced parenthesized span."""
+
+    if index >= len(tokens) or tokens[index] != ("punct", "("):
+        return None
+    depth = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if token == ("punct", "("):
+            depth += 1
+        elif token == ("punct", ")"):
+            depth -= 1
+            if depth == 0:
+                return index + 1
+        index += 1
+    return None
+
+
+def _is_sql_word(token: tuple[str, str], word: str) -> bool:
+    return token[0] == "word" and token[1].casefold() == word
+
+
+def _cte_shadow_name(sql: str) -> str | None:
+    """Return a scoped-view name rebound by any CTE in *sql*."""
+
+    tokens = _sql_cte_tokens(sql)
+    for start, token in enumerate(tokens):
+        if not _is_sql_word(token, "with"):
+            continue
+        index = start + 1
+        if index < len(tokens) and _is_sql_word(tokens[index], "recursive"):
+            index += 1
+        while index < len(tokens):
+            kind, spelling = tokens[index]
+            if kind not in {"word", "quoted"}:
+                break
+            name = spelling.casefold()
+            index += 1
+            if index < len(tokens) and tokens[index] == ("punct", "("):
+                after_columns = _after_sql_parentheses(tokens, index)
+                if after_columns is None:
+                    break
+                index = after_columns
+            if index >= len(tokens) or not _is_sql_word(tokens[index], "as"):
+                break
+            index += 1
+            if index < len(tokens) and _is_sql_word(tokens[index], "not"):
+                index += 1
+                if index >= len(tokens) or not _is_sql_word(
+                    tokens[index], "materialized"
+                ):
+                    break
+                index += 1
+            elif index < len(tokens) and _is_sql_word(tokens[index], "materialized"):
+                index += 1
+            if index >= len(tokens) or tokens[index] != ("punct", "("):
+                break
+            if name in _SCOPED_VIEWS:
+                return name
+            after_body = _after_sql_parentheses(tokens, index)
+            if after_body is None:
+                break
+            index = after_body
+            if index >= len(tokens) or tokens[index] != ("punct", ","):
+                break
+            index += 1
+    return None
 
 
 #: Base tables reachable only through `_SCOPED_VIEWS`. These were readable
@@ -4791,14 +4914,14 @@ class Store:
         bad = _DENY_WORD_RE.search(deny_scan)
         if bad is not None:
             raise PermissionError(f"host.query: table '{bad.group(0)}' is not readable")
-        shadow = _CTE_SHADOW_RE.search(deny_scan)
+        shadow = _cte_shadow_name(sql)
         if shadow is not None:
-            # See `_CTE_SHADOW_RE`: naming a CTE after a scoped view makes
+            # See `_cte_shadow_name`: naming a CTE after a scoped view makes
             # SQLite hand the authorizer that name as the view responsible for
             # the read, which is how the escape hatch below came to trust a
             # string the caller wrote.
             raise PermissionError(
-                f"host.query: {shadow.group(1)!r} is a scoped view and cannot "
+                f"host.query: {shadow!r} is a scoped view and cannot "
                 f"be used as a CTE name"
             )
         stripped = lowered.lstrip()

--- a/openai4s/tools/env_use.py
+++ b/openai4s/tools/env_use.py
@@ -53,8 +53,8 @@ class EnvUseTool(Tool):
             if runtime.on_env_switch is not None:
                 try:
                     runtime.on_env_switch(name)
-                except Exception:  # noqa: BLE001
-                    note = "R env switch failed to register"
+                except Exception as exc:  # noqa: BLE001
+                    return {"error": f"env switch refused: {exc}"}
             return {
                 "ok": True,
                 "env": {
@@ -72,8 +72,8 @@ class EnvUseTool(Tool):
                     f"switching to '{name}' before the next cell — put your "
                     "imports in a new cell"
                 )
-            except Exception:  # noqa: BLE001
-                note = "env switch failed to register"
+            except Exception as exc:  # noqa: BLE001
+                return {"error": f"env switch refused: {exc}"}
         else:
             note = "env switching is only available in the web session kernel"
         return {

--- a/tests/test_artifact_scope_closure.py
+++ b/tests/test_artifact_scope_closure.py
@@ -259,14 +259,18 @@ def test_a_scoped_view_may_read_its_base_table_but_a_cell_may_not():
     Skill legitimately reads `artifact_versions.source`."""
     import sqlite3
 
-    from openai4s.store import _QueryAuthorizer
+    from openai4s.store import _SCOPED_VIEWS, _QueryAuthorizer
 
-    guard = _QueryAuthorizer()
+    # `published_views` is what the statement actually created. `query()` passes
+    # the scoped set when it published the views and an empty one when it did
+    # not; the class defaults to empty, so "nothing said a view exists" reads as
+    # refused rather than as allowed.
+    guard = _QueryAuthorizer(published_views=_SCOPED_VIEWS)
     assert (
         guard(sqlite3.SQLITE_READ, "artifact_versions", "source", "main", None)
         == sqlite3.SQLITE_DENY
     )
-    guard = _QueryAuthorizer()
+    guard = _QueryAuthorizer(published_views=_SCOPED_VIEWS)
     assert (
         guard(
             sqlite3.SQLITE_READ,
@@ -278,9 +282,22 @@ def test_a_scoped_view_may_read_its_base_table_but_a_cell_may_not():
         == sqlite3.SQLITE_OK
     )
     # And a view name the caller invented does not count.
-    guard = _QueryAuthorizer()
+    guard = _QueryAuthorizer(published_views=_SCOPED_VIEWS)
     assert (
         guard(sqlite3.SQLITE_READ, "artifact_versions", "source", "main", "my_own_view")
+        == sqlite3.SQLITE_DENY
+    )
+    # Nor does the real name when no scope published the views: a statement that
+    # created nothing has no view to have been read through.
+    guard = _QueryAuthorizer()
+    assert (
+        guard(
+            sqlite3.SQLITE_READ,
+            "artifact_versions",
+            "source",
+            "main",
+            "my_artifact_versions",
+        )
         == sqlite3.SQLITE_DENY
     )
 

--- a/tests/test_cell_execution_service.py
+++ b/tests/test_cell_execution_service.py
@@ -792,3 +792,19 @@ def test_a_timeout_still_says_the_kernel_was_reset():
 
     assert "variables from earlier cells were cleared" in published
     assert "/srv/run" not in published
+
+
+def test_a_bootstrap_failure_after_reset_does_not_claim_cluster_work_continues():
+    from openai4s.execution.watchdog import KernelResetUnavailableTimeout
+    from openai4s.server.cell_run import _worker_failure_text
+    from openai4s.server.errors import public_exception
+
+    exc = KernelResetUnavailableTimeout("private bootstrap detail")
+    public, _status = public_exception(
+        exc, surface="cell:worker", error_code="cell_timeout"
+    )
+    published = _worker_failure_text(exc, public)
+
+    assert "variables from earlier cells were cleared" in published
+    assert "replacement could not be initialized" in published
+    assert "cluster" not in published and "allocation" not in published

--- a/tests/test_cell_watchdog.py
+++ b/tests/test_cell_watchdog.py
@@ -255,3 +255,69 @@ def test_bootstrap_failure_detaches_the_restarted_generation():
 
     assert supervisor.current("python") is None
     assert kernel.restart_calls == kernel.shutdown_calls == 1
+
+
+def test_a_worker_that_cannot_be_respawned_is_not_reported_as_reset():
+    """The ladder assumed its last rung always lands.
+
+    A kernel this daemon did not spawn cannot be respawned by it -- a cluster
+    session's worker dialled in from a compute node, so `restart()` refuses --
+    and the refusal was swallowed one line before a message that told the user
+    their kernel had been reset and their variables cleared. Neither was true:
+    the interpreter is untouched on the node and the cell may still be running
+    there, which is exactly when a user needs to be told to go look.
+    """
+    from openai4s.execution.watchdog import KernelNotResetTimeout
+
+    supervisor, kernel, lease = _lease()
+    release = threading.Event()
+    kernel.on_kill = release.set
+
+    def _refuse_restart():
+        kernel.restart_calls += 1
+        raise RuntimeError("this worker cannot be respawned in place")
+
+    kernel.restart = _refuse_restart
+
+    def run(worker):
+        assert release.wait(1)
+        raise RuntimeError("worker pipe closed")
+
+    with pytest.raises(KernelNotResetTimeout, match="could not be reset"):
+        execute_with_watchdog(
+            supervisor,
+            lease,
+            run,
+            policy=WatchdogPolicy(
+                timeout_s=0.001,
+                poll_s=0.001,
+                interrupt_grace_s=0.001,
+                kill_grace_s=0.1,
+            ),
+        )
+    assert kernel.restart_calls == 1, "the ladder skipped the restart attempt"
+
+
+def test_a_real_reset_still_says_so():
+    """The positive control: the honest branch must not swallow the ordinary
+    case, or the reworded message becomes the only message."""
+    supervisor, kernel, lease = _lease()
+    release = threading.Event()
+    kernel.on_kill = release.set
+
+    def run(worker):
+        assert release.wait(1)
+        raise RuntimeError("worker pipe closed")
+
+    with pytest.raises(TimeoutError, match="the kernel was reset"):
+        execute_with_watchdog(
+            supervisor,
+            lease,
+            run,
+            policy=WatchdogPolicy(
+                timeout_s=0.001,
+                poll_s=0.001,
+                interrupt_grace_s=0.001,
+                kill_grace_s=0.1,
+            ),
+        )

--- a/tests/test_cell_watchdog.py
+++ b/tests/test_cell_watchdog.py
@@ -228,6 +228,11 @@ def test_host_call_zombie_is_abandoned_without_touching_a_future_worker():
 
 
 def test_bootstrap_failure_detaches_the_restarted_generation():
+    from openai4s.execution.watchdog import (
+        KernelNotResetTimeout,
+        KernelResetUnavailableTimeout,
+    )
+
     supervisor, kernel, lease = _lease()
     release = threading.Event()
     kernel.on_kill = release.set
@@ -239,7 +244,9 @@ def test_bootstrap_failure_detaches_the_restarted_generation():
     def broken_bootstrap(worker):
         raise RuntimeError("bootstrap failed")
 
-    with pytest.raises(TimeoutError):
+    with pytest.raises(
+        KernelResetUnavailableTimeout, match="replacement failed to initialize"
+    ) as raised:
         execute_with_watchdog(
             supervisor,
             lease,
@@ -253,6 +260,48 @@ def test_bootstrap_failure_detaches_the_restarted_generation():
             after_restart=broken_bootstrap,
         )
 
+    assert not isinstance(raised.value, KernelNotResetTimeout)
+    assert supervisor.current("python") is None
+    assert kernel.restart_calls == kernel.shutdown_calls == 1
+
+
+def test_local_respawn_failure_is_a_cleared_but_unavailable_namespace():
+    from openai4s.execution.watchdog import (
+        KernelNotResetTimeout,
+        KernelResetUnavailableTimeout,
+    )
+    from openai4s.kernel.errors import KernelRestartFailed
+
+    supervisor, kernel, lease = _lease()
+    release = threading.Event()
+    kernel.on_kill = release.set
+
+    def run(worker):
+        assert release.wait(1)
+        raise RuntimeError("old worker pipe closed")
+
+    def failed_local_respawn():
+        kernel.restart_calls += 1
+        kernel.live = False
+        raise KernelRestartFailed("replacement process failed to start")
+
+    kernel.restart = failed_local_respawn
+    with pytest.raises(
+        KernelResetUnavailableTimeout, match="replacement failed to initialize"
+    ) as raised:
+        execute_with_watchdog(
+            supervisor,
+            lease,
+            run,
+            policy=WatchdogPolicy(
+                timeout_s=0.001,
+                poll_s=0.001,
+                interrupt_grace_s=0.001,
+                kill_grace_s=0.1,
+            ),
+        )
+
+    assert not isinstance(raised.value, KernelNotResetTimeout)
     assert supervisor.current("python") is None
     assert kernel.restart_calls == kernel.shutdown_calls == 1
 

--- a/tests/test_cluster_session_production_wiring.py
+++ b/tests/test_cluster_session_production_wiring.py
@@ -22,7 +22,12 @@ import re
 
 import pytest
 
-from openai4s.orchestration.models import Phase, ResourceProfile
+from openai4s.orchestration.models import (
+    Phase,
+    ResourceProfile,
+    WorkloadKind,
+    WorkloadSpec,
+)
 from tests.test_team_auth_routes import (  # noqa: F401  (fixture reuse)
     _fast_pbkdf2,
     _free_port,
@@ -290,3 +295,102 @@ def test_a_recovery_does_not_reuse_the_dead_workers_kernel(daemon):
 
     _, second_key = daemon.runner._remote_kernel_factory(st, disp)
     assert first_key != second_key, "a recovered session would reuse the dead kernel"
+
+
+def test_the_session_workspace_follows_the_placement(daemon):
+    """Where the cells run and where the daemon looks have to be one directory.
+
+    The remote kernel was built with the workload's directory as its cwd while
+    artifact capture, the Host dispatcher's file tools and the R kernel stayed
+    on `agent-workspaces/<root_frame_id>`. So a cluster cell wrote `result.csv`
+    into one directory and `capture` diffed another: empty figures, empty
+    files_written, no Artifact row -- and no error to say so. Asserted through
+    `_ensure_runtime`, because that is the call every path into a session makes
+    and therefore the one that has to agree with the kernel.
+    """
+    session_id, project_id = _session(daemon)
+    st = daemon.runner._state(session_id, project_id)
+    manager = daemon.runner.compute_sessions
+
+    local = st.workspace
+    daemon.runner._ensure_runtime(st)
+    assert st.workspace == local, "a session with no placement must not move"
+
+    workload = _request_cluster(daemon, session_id)
+    placed = manager.workspace_for(workload.id)
+    assert placed != local
+
+    disp = daemon.runner._ensure_runtime(st)
+    assert st.workspace == placed, (
+        "the session still points at its local workspace while its cells run "
+        "on the workload's -- artifact capture would diff a directory nothing "
+        "wrote to"
+    )
+    assert (
+        disp.workspace_path == placed.resolve()
+    ), "host.write_file would land where the remote cell cannot see it"
+
+    # And back again: a released placement must not leave the session pointed
+    # at a workload that no longer exists.
+    from openai4s.orchestration.models import Reason
+
+    manager.release(session_id, reason=Reason.USER_CANCELLED)
+    daemon.runner._ensure_runtime(st)
+    assert st.workspace == local
+
+
+def test_r_is_refused_on_a_cluster_session(daemon):
+    """`spawn_r_kernel` starts a child of the daemon, so an ```r cell on a
+    placed session ran on the head node with none of the allocated resources
+    -- and worked, which is what made it silent. `host.exec_background`
+    already refuses for the same reason; this is the other half."""
+    session_id, project_id = _session(daemon)
+    st = daemon.runner._state(session_id, project_id)
+
+    _request_cluster(daemon, session_id)
+    refusal = daemon.runner._ensure_r_kernel(st)
+    assert refusal is not None and "cluster session" in refusal, refusal
+    assert st.kernels.lease("r") is None, "an R worker was started anyway"
+
+
+def test_a_backend_that_will_not_answer_is_unknown_not_absent(daemon):
+    """INV-8 inverted: `submit` asked whether anything already carries this
+    token, caught the scheduler being unreachable, and read the silence as
+    "nothing does" -- then submitted. `find_by_comment` raises on a timeout
+    precisely because absence of an answer is not an answer of absence."""
+    from openai4s.orchestration.ports import Unknown
+    from openai4s.orchestration.slurm.backend import SlurmBackend
+    from openai4s.orchestration.slurm.broker import SlurmCommandError
+
+    class _MuteBroker:
+        submitted: list = []
+
+        def find_by_comment(self, comment):
+            raise SlurmCommandError(
+                "squeue timed out", command=("squeue",), timed_out=True
+            )
+
+        def submit(self, spec):  # pragma: no cover - must not be reached
+            _MuteBroker.submitted.append(spec)
+            return "12345"
+
+    cluster = daemon.runner.cluster_config
+    backend = SlurmBackend(cluster=cluster, log_dir="/tmp", broker=_MuteBroker())
+    workload = daemon.store.workloads.create_workload(
+        spec=WorkloadSpec(
+            kind=WorkloadKind.BATCH,
+            profile=ResourceProfile(name="cpu"),
+            command=("true",),
+        ),
+        owner_user_id="u",
+        backend="cluster",
+    )
+    allocation = daemon.store.workloads.create_allocation(workload.id, 0)
+
+    result = backend.submit(
+        allocation=allocation,
+        spec=workload.spec,
+        profile=ResourceProfile(name="cpu"),
+    )
+    assert isinstance(result, Unknown), result
+    assert not _MuteBroker.submitted, "a second job was submitted on a silence"

--- a/tests/test_cluster_session_production_wiring.py
+++ b/tests/test_cluster_session_production_wiring.py
@@ -19,6 +19,9 @@ from __future__ import annotations
 
 import json
 import re
+import threading
+import time
+from pathlib import Path
 
 import pytest
 
@@ -84,6 +87,15 @@ def _grant(daemon, workload_id):
     return allocation
 
 
+def _wait_for(predicate, *, timeout=2.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return bool(predicate())
+
+
 # -- the daemon holds up its end ---------------------------------------------
 
 
@@ -92,6 +104,435 @@ def test_the_daemon_exposes_a_manager_and_a_listener(daemon):
     assert daemon.runner.worker_gateway is not None
     assert daemon.runner.worker_gateway.address is not None
     assert daemon.runner.lease_reclaimer is not None
+
+
+def test_terminal_cleanup_does_not_block_the_orchestration_callback(daemon):
+    """A long Cell in one session cannot stall reconciliation for another."""
+
+    first_session, first_project = _session(daemon)
+    second_session, second_project = _session(daemon)
+    first_workload = _request_cluster(daemon, first_session)
+    second_workload = _request_cluster(daemon, second_session)
+    first_state = daemon.runner._state(first_session, first_project)
+    daemon.runner._state(second_session, second_project)
+
+    entered = threading.Event()
+    release_cell = threading.Event()
+
+    def hold_session_barrier():
+        with daemon.runner._session_execution(
+            first_state,
+            owner="user_repl",
+            owner_id="long-cell",
+            language="python",
+            reason="test long cell",
+        ):
+            entered.set()
+            release_cell.wait(5.0)
+
+    holder = threading.Thread(target=hold_session_barrier, daemon=True)
+    holder.start()
+    assert entered.wait(1.0)
+
+    started = time.monotonic()
+    daemon.runner._on_orchestration_event(
+        "workload_terminal",
+        {"workload_id": first_workload.id, "reason": "WORKER_LOST"},
+    )
+    daemon.runner._on_orchestration_event(
+        "workload_terminal",
+        {"workload_id": second_workload.id, "reason": "WORKER_LOST"},
+    )
+    callback_elapsed = time.monotonic() - started
+
+    try:
+        assert callback_elapsed < 0.2
+        assert _wait_for(
+            lambda: daemon.store.leases.workload_for_session(second_session) is None
+        ), "the first session's FIFO stalled cleanup of a second workload"
+        assert (
+            daemon.store.leases.workload_for_session(first_session) == first_workload.id
+        )
+    finally:
+        release_cell.set()
+        holder.join(2.0)
+    assert not holder.is_alive()
+    assert _wait_for(
+        lambda: daemon.store.leases.workload_for_session(first_session) is None
+    )
+
+
+def test_cleanup_admission_timeout_prevents_worker_pool_head_of_line(daemon):
+    """Four occupied FIFOs cannot monopolize all cleanup workers forever."""
+
+    sessions = []
+    workloads = []
+    states = []
+    for _index in range(5):
+        session_id, project_id = _session(daemon)
+        sessions.append(session_id)
+        workloads.append(_request_cluster(daemon, session_id))
+        states.append(daemon.runner._state(session_id, project_id))
+
+    entered = [threading.Event() for _index in range(4)]
+    release_cells = threading.Event()
+    holders = []
+
+    def hold(index):
+        with daemon.runner._session_execution(
+            states[index],
+            owner="user_repl",
+            owner_id=f"blocked-cell-{index}",
+            language="python",
+            reason="test occupied FIFO",
+        ):
+            entered[index].set()
+            release_cells.wait(5.0)
+
+    for index in range(4):
+        holder = threading.Thread(target=hold, args=(index,), daemon=True)
+        holders.append(holder)
+        holder.start()
+    assert all(event.wait(1.0) for event in entered)
+
+    for workload in workloads[:4]:
+        daemon.runner._on_orchestration_event(
+            "workload_terminal",
+            {"workload_id": workload.id, "reason": "WORKER_LOST"},
+        )
+    assert _wait_for(
+        lambda: sum(
+            bool(task.get("running"))
+            for task in daemon.runner._orchestration_cleanup_tasks.values()
+        )
+        == 4
+    )
+
+    daemon.runner._on_orchestration_event(
+        "workload_terminal",
+        {"workload_id": workloads[4].id, "reason": "WORKER_LOST"},
+    )
+    try:
+        assert _wait_for(
+            lambda: daemon.store.leases.workload_for_session(sessions[4]) is None,
+            timeout=1.5,
+        ), "four queued lifecycle cleanups starved a fifth free session"
+        assert all(
+            daemon.store.leases.workload_for_session(session_id) == workload.id
+            for session_id, workload in zip(sessions[:4], workloads[:4])
+        )
+    finally:
+        release_cells.set()
+        for holder in holders:
+            holder.join(2.0)
+    assert all(not holder.is_alive() for holder in holders)
+    assert _wait_for(
+        lambda: all(
+            daemon.store.leases.workload_for_session(session_id) is None
+            for session_id in sessions[:4]
+        )
+    )
+
+
+def test_cleanup_deadline_covers_stop_admission_before_fifo_submit(daemon):
+    """Four Stops cannot pin workers before lifecycle tickets even exist."""
+
+    sessions = []
+    workloads = []
+    states = []
+    for _index in range(5):
+        session_id, project_id = _session(daemon)
+        sessions.append(session_id)
+        workloads.append(_request_cluster(daemon, session_id))
+        states.append(daemon.runner._state(session_id, project_id))
+
+    for state in states[:4]:
+        state.stop_finished.clear()
+        state.stop_requested.set()
+
+    try:
+        for workload in workloads[:4]:
+            daemon.runner._on_orchestration_event(
+                "workload_terminal",
+                {"workload_id": workload.id, "reason": "WORKER_LOST"},
+            )
+        assert _wait_for(
+            lambda: sum(
+                bool(task.get("running"))
+                for task in daemon.runner._orchestration_cleanup_tasks.values()
+            )
+            == 4
+        )
+
+        daemon.runner._on_orchestration_event(
+            "workload_terminal",
+            {"workload_id": workloads[4].id, "reason": "WORKER_LOST"},
+        )
+        assert _wait_for(
+            lambda: daemon.store.leases.workload_for_session(sessions[4]) is None,
+            timeout=1.5,
+        ), "Stop pre-admission waits starved a fifth free session"
+        for session_id in sessions[:4]:
+            snapshot = daemon.runner.executions.snapshot(session_id)
+            assert snapshot.get("owner") is None
+            assert snapshot.get("queue") == []
+    finally:
+        for state in states[:4]:
+            state.stop_requested.clear()
+            state.stop_finished.set()
+
+    assert _wait_for(
+        lambda: all(
+            daemon.store.leases.workload_for_session(session_id) is None
+            for session_id in sessions[:4]
+        )
+    )
+
+
+def test_cleanup_deadline_covers_legacy_turn_barrier_after_admission(daemon):
+    """Legacy review-style holders cannot pin four admitted cleanup tickets."""
+
+    sessions = []
+    workloads = []
+    states = []
+    for _index in range(5):
+        session_id, project_id = _session(daemon)
+        sessions.append(session_id)
+        workloads.append(_request_cluster(daemon, session_id))
+        states.append(daemon.runner._state(session_id, project_id))
+
+    entered = [threading.Event() for _index in range(4)]
+    release_barriers = threading.Event()
+    holders = []
+
+    def hold_legacy_barrier(index):
+        # Reviewer still uses this compatibility barrier without reserving a
+        # coordinator ticket. That is the exact seam this regression pins.
+        with states[index].execution_barrier():
+            entered[index].set()
+            release_barriers.wait(5.0)
+
+    for index in range(4):
+        holder = threading.Thread(
+            target=hold_legacy_barrier, args=(index,), daemon=True
+        )
+        holders.append(holder)
+        holder.start()
+    assert all(event.wait(1.0) for event in entered)
+
+    try:
+        for workload in workloads[:4]:
+            daemon.runner._on_orchestration_event(
+                "workload_terminal",
+                {"workload_id": workload.id, "reason": "WORKER_LOST"},
+            )
+        assert _wait_for(
+            lambda: sum(
+                bool(task.get("running"))
+                for task in daemon.runner._orchestration_cleanup_tasks.values()
+            )
+            == 4
+        )
+
+        daemon.runner._on_orchestration_event(
+            "workload_terminal",
+            {"workload_id": workloads[4].id, "reason": "WORKER_LOST"},
+        )
+        assert _wait_for(
+            lambda: daemon.store.leases.workload_for_session(sessions[4]) is None,
+            timeout=1.5,
+        ), "legacy turn locks starved a fifth cleanup after FIFO admission"
+    finally:
+        release_barriers.set()
+        for holder in holders:
+            holder.join(2.0)
+
+    assert all(not holder.is_alive() for holder in holders)
+    assert _wait_for(
+        lambda: all(
+            daemon.store.leases.workload_for_session(session_id) is None
+            for session_id in sessions[:4]
+        )
+    )
+
+
+def test_terminal_cleanup_retries_a_temporary_admission_failure(daemon, monkeypatch):
+    """A queue-full/error return from emit cannot permanently lose cleanup."""
+
+    from openai4s.execution import QueueDepthExceeded
+
+    session_id, _project_id = _session(daemon)
+    workload = _request_cluster(daemon, session_id)
+    original = daemon.runner.release_session_compute
+    attempts = []
+
+    def flaky_release(*args, **kwargs):
+        attempts.append(time.monotonic())
+        if len(attempts) == 1:
+            raise QueueDepthExceeded("temporary full session lifecycle queue")
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(daemon.runner, "release_session_compute", flaky_release)
+    daemon.runner._on_orchestration_event(
+        "lease_expired",
+        {"workload_id": workload.id, "reason": "SESSION_IDLE_TIMEOUT"},
+    )
+
+    assert _wait_for(lambda: len(attempts) >= 2)
+    assert _wait_for(
+        lambda: daemon.store.leases.workload_for_session(session_id) is None
+    )
+
+
+def test_delayed_w1_cleanup_cannot_cancel_or_erase_rebound_w2(daemon, monkeypatch):
+    """The event ABA fence covers both execution cancellation and task removal."""
+
+    from openai4s.orchestration.models import Reason
+
+    session_id, project_id = _session(daemon)
+    state = daemon.runner._state(session_id, project_id)
+    first = _request_cluster(daemon, session_id)
+    original_release = daemon.runner.release_session_compute
+    first_entered = threading.Event()
+    release_first = threading.Event()
+
+    def delay_first(*args, **kwargs):
+        if kwargs.get("expected_workload_id") == first.id:
+            first_entered.set()
+            assert release_first.wait(2.0)
+        return original_release(*args, **kwargs)
+
+    monkeypatch.setattr(daemon.runner, "release_session_compute", delay_first)
+    daemon.runner._on_orchestration_event(
+        "workload_terminal",
+        {"workload_id": first.id, "reason": "WORKER_LOST"},
+    )
+    assert first_entered.wait(1.0)
+
+    # A legitimate replacement wins while W1 cleanup is delayed.
+    assert daemon.runner.compute_sessions.release(
+        session_id,
+        reason=Reason.WORKER_LOST,
+        expected_workload_id=first.id,
+    )
+    second = _request_cluster(daemon, session_id)
+
+    cell_entered = threading.Event()
+    finish_cell = threading.Event()
+
+    def hold_second_cell():
+        with daemon.runner._session_execution(
+            state,
+            owner="user_repl",
+            owner_id="w2-cell",
+            language="python",
+            reason="test W2 cell",
+        ):
+            cell_entered.set()
+            finish_cell.wait(5.0)
+
+    holder = threading.Thread(target=hold_second_cell, daemon=True)
+    holder.start()
+    assert cell_entered.wait(1.0)
+    daemon.runner._on_orchestration_event(
+        "workload_terminal",
+        {"workload_id": second.id, "reason": "WORKER_LOST"},
+    )
+    release_first.set()
+
+    try:
+        assert _wait_for(
+            lambda: bool(
+                daemon.runner._orchestration_cleanup_tasks.get(session_id, {}).get(
+                    "running"
+                )
+            )
+        )
+        assert not state.cancel.is_set(), "stale W1 cleanup cancelled W2's Cell"
+        assert daemon.store.leases.workload_for_session(session_id) == second.id
+    finally:
+        finish_cell.set()
+        holder.join(2.0)
+    assert not holder.is_alive()
+    assert _wait_for(
+        lambda: daemon.store.leases.workload_for_session(session_id) is None
+    ), "W1 completion erased W2's pending cleanup task"
+
+
+def test_startup_restores_stale_durable_session_cleanup(tmp_path, monkeypatch):
+    """A terminal event lost to process death is replayed from durable state."""
+
+    from openai4s.config import Config
+    from openai4s.orchestration.models import DesiredState, Reason
+    from openai4s.store import get_store
+
+    cfg = Config(data_dir=tmp_path)
+    cfg.ensure_dirs()
+    store = get_store(cfg.db_path)
+    workload = store.workloads.create_session_workload(
+        session_id="stale-session",
+        spec=WorkloadSpec(
+            kind=WorkloadKind.SESSION,
+            profile=PROFILE,
+            command=(),
+        ),
+        owner_user_id="u1",
+        project_id=None,
+        backend="local",
+        idle_ttl_s=3600,
+        max_lifetime_s=7200,
+    )
+    store.workloads.request_stop(workload.id, reason=Reason.WORKER_LOST)
+    assert (
+        store.workloads.get_workload(workload.id).desired_state is DesiredState.STOPPED
+    )
+    store.close()
+
+    monkeypatch.setenv("OPENAI4S_WORKER_LISTEN", f"127.0.0.1:{_free_port()}")
+    node = _TeamDaemon(tmp_path)
+    try:
+        assert _wait_for(
+            lambda: node.store.leases.workload_for_session("stale-session") is None
+        )
+    finally:
+        node.close()
+
+
+def test_blocked_terminal_cleanup_cannot_hang_daemon_close(daemon, monkeypatch):
+    """Cleanup workers are daemon-owned and shutdown never joins a stuck one."""
+
+    session_id, _project_id = _session(daemon)
+    workload = _request_cluster(daemon, session_id)
+    entered = threading.Event()
+    unblock = threading.Event()
+
+    def blocked_release(*_args, **_kwargs):
+        entered.set()
+        unblock.wait(5.0)
+        return False
+
+    monkeypatch.setattr(daemon.runner, "release_session_compute", blocked_release)
+    daemon.runner._on_orchestration_event(
+        "workload_terminal",
+        {"workload_id": workload.id, "reason": "WORKER_LOST"},
+    )
+    assert entered.wait(1.0)
+    assert daemon.runner._orchestration_cleanup_threads
+    assert all(thread.daemon for thread in daemon.runner._orchestration_cleanup_threads)
+
+    closed = threading.Event()
+
+    def close_runner():
+        daemon.runner.close()
+        closed.set()
+
+    closer = threading.Thread(target=close_runner, daemon=True)
+    closer.start()
+    returned_without_cleanup = closed.wait(1.0)
+    unblock.set()
+    closer.join(2.0)
+    assert returned_without_cleanup, "close waited for a blocked cleanup worker"
+    assert not closer.is_alive()
 
 
 def test_a_users_execution_renews_the_lease_and_nothing_else_does(daemon):
@@ -240,6 +681,40 @@ def test_a_cluster_session_gets_a_kernel_over_its_workers_transport(daemon):
     assert manager.readiness(session_id).ready is True
 
 
+def test_a_remote_candidate_is_not_published_before_generation_commit(
+    daemon, monkeypatch
+):
+    """Compute readiness and supervisor ownership are one commit boundary.
+
+    Publishing ``runtime.kernel`` from the candidate factory made a failed
+    generation write leave readiness pointing at the dead candidate while the
+    supervisor correctly kept its prior slot.
+    """
+    session_id, project_id = _session(daemon)
+    workload = _request_cluster(daemon, session_id)
+    allocation = _grant(daemon, workload.id)
+    transport = _FakeTransport()
+    manager = daemon.runner.compute_sessions
+    manager._gateway._arrived[(allocation.id, 0)] = [_Registration(transport)]
+    st = daemon.runner._state(session_id, project_id)
+
+    def fail_generation(*_args, **_kwargs):
+        raise RuntimeError("generation store unavailable")
+
+    monkeypatch.setattr(st.kernels, "_begin_generation", fail_generation)
+    with pytest.raises(RuntimeError, match="generation store unavailable"):
+        daemon.runner._spawn_kernel(st)
+
+    runtime = manager.runtime(session_id)
+    assert st.kernels.lease("python") is None
+    assert runtime is None
+    assert daemon.store.leases.workload_for_session(session_id) is None
+    stopped = daemon.store.workloads.get_workload(workload.id)
+    assert stopped.desired_state.value == "STOPPED"
+    assert manager.readiness(session_id).ready is False
+    assert transport.closed is True
+
+
 def test_a_session_that_never_asked_for_a_cluster_stays_local(daemon):
     """INV-1's shape here: the resolver must answer None for every session
     that is not on a cluster, on a daemon that has a listener."""
@@ -249,24 +724,46 @@ def test_a_session_that_never_asked_for_a_cluster_stays_local(daemon):
     assert daemon.runner._remote_kernel_factory(st, disp) is None
 
 
-def test_a_granted_allocation_whose_worker_never_arrives_stays_local(daemon):
-    """A queue wait is not an error and must not block a cell: the session
-    runs locally for this attempt and is asked for again on the next."""
+def test_a_bound_session_refuses_local_execution_until_its_worker_arrives(daemon):
+    """A placement request fixes the execution plane before any Cell runs.
+
+    Running locally while queued and switching to remote later silently loses
+    the local namespace and splits workspace files across two directories.
+    """
     session_id, project_id = _session(daemon)
     workload = _request_cluster(daemon, session_id)
-    _grant(daemon, workload.id)
+    allocation = _grant(daemon, workload.id)
 
     st = daemon.runner._state(session_id, project_id)
+    local = st.local_workspace
     disp = daemon.runner._ensure_runtime(st)
     import openai4s.server.gateway as gateway_mod
 
     original = gateway_mod._REMOTE_ATTACH_TIMEOUT_S
     gateway_mod._REMOTE_ATTACH_TIMEOUT_S = 0.1
     try:
-        assert daemon.runner._remote_kernel_factory(st, disp) is None
+        with pytest.raises(RuntimeError, match="has not registered yet"):
+            daemon.runner._ensure_kernel(st)
     finally:
         gateway_mod._REMOTE_ATTACH_TIMEOUT_S = original
+
+    assert st.kernels.lease("python") is None
+    assert st.workspace == local
+    assert disp.workspace_path == local.resolve()
     assert not daemon.runner.compute_sessions.readiness(session_id).ready
+
+    # The next ordinary ensure retries placement once rank 0 arrives, with no
+    # local namespace having been created and then silently discarded.
+    transport = _FakeTransport()
+    daemon.runner.compute_sessions._gateway._arrived[(allocation.id, 0)] = [
+        _Registration(transport)
+    ]
+    daemon.runner._ensure_kernel(st)
+
+    remote = st.kernels.lease("python")
+    assert remote is not None and remote.kernel._transport is transport
+    assert st.workspace == daemon.runner.compute_sessions.workspace_for(workload.id)
+    assert disp.workspace_path == st.workspace.resolve()
 
 
 def test_a_recovery_does_not_reuse_the_dead_workers_kernel(daemon):
@@ -305,8 +802,8 @@ def test_the_session_workspace_follows_the_placement(daemon):
     on `agent-workspaces/<root_frame_id>`. So a cluster cell wrote `result.csv`
     into one directory and `capture` diffed another: empty figures, empty
     files_written, no Artifact row -- and no error to say so. Asserted through
-    `_ensure_runtime`, because that is the call every path into a session makes
-    and therefore the one that has to agree with the kernel.
+    the production spawn: the durable workload binding is a request, while the
+    attached worker selected there is the execution plane.
     """
     session_id, project_id = _session(daemon)
     st = daemon.runner._state(session_id, project_id)
@@ -320,7 +817,17 @@ def test_the_session_workspace_follows_the_placement(daemon):
     placed = manager.workspace_for(workload.id)
     assert placed != local
 
+    # Requesting a worker does not mean one exists. A tools-only turn (or a
+    # local fallback while the scheduler is queued) must stay on the local
+    # workspace and retain the sandbox deny over the cluster credential tree.
     disp = daemon.runner._ensure_runtime(st)
+    assert st.workspace == local
+    assert disp.workspace_path == local.resolve()
+
+    allocation = _grant(daemon, workload.id)
+    transport = _FakeTransport()
+    manager._gateway._arrived[(allocation.id, 0)] = [_Registration(transport)]
+    daemon.runner._ensure_kernel(st)
     assert st.workspace == placed, (
         "the session still points at its local workspace while its cells run "
         "on the workload's -- artifact capture would diff a directory nothing "
@@ -334,9 +841,13 @@ def test_the_session_workspace_follows_the_placement(daemon):
     # at a workload that no longer exists.
     from openai4s.orchestration.models import Reason
 
-    manager.release(session_id, reason=Reason.USER_CANCELLED)
+    daemon.runner.release_session_compute(session_id, reason=Reason.USER_CANCELLED)
+    # No Python spawn is needed to restore the control plane. A tools-only
+    # turn immediately after release must already use the local workspace.
+    assert st.kernels.lease("python") is None
     daemon.runner._ensure_runtime(st)
     assert st.workspace == local
+    assert disp.workspace_path == local.resolve()
 
 
 def test_r_is_refused_on_a_cluster_session(daemon):
@@ -365,7 +876,7 @@ def test_a_backend_that_will_not_answer_is_unknown_not_absent(daemon):
     class _MuteBroker:
         submitted: list = []
 
-        def find_by_comment(self, comment):
+        def find_by_comment(self, comment, *, job_name):
             raise SlurmCommandError(
                 "squeue timed out", command=("squeue",), timed_out=True
             )

--- a/tests/test_compute_session_routes.py
+++ b/tests/test_compute_session_routes.py
@@ -17,6 +17,7 @@ information about what a colleague is working on (INV-13).
 from __future__ import annotations
 
 import json
+import time
 from pathlib import Path
 
 import pytest
@@ -76,8 +77,8 @@ def test_a_daemon_with_no_listener_says_the_session_runs_locally(daemon):
 def test_asking_for_a_cluster_session_without_a_listener_is_refused_with_a_reason(
     daemon,
 ):
-    cookie = _login(daemon, "alice", "fake-pw-a")
-    session_id = _session_of(daemon, "alice")
+    cookie = _login(daemon, "root", "fake-pw-r")
+    session_id = _session_of(daemon, "root")
 
     status, raw = _post(
         daemon.port,
@@ -151,8 +152,12 @@ def _put(port: int, path: str, body: dict, cookie: str, method: str = "POST"):
 def listening_daemon(tmp_path, monkeypatch):
     """A daemon that actually has a worker listener, so the requests that a
     default install refuses at the door get as far as the code under test."""
+    from openai4s.orchestration.slurm.profiles import EXAMPLE_CLUSTER_TOML
+
+    (tmp_path / "cluster.toml").write_text(EXAMPLE_CLUSTER_TOML, encoding="utf-8")
     monkeypatch.setenv("OPENAI4S_WORKER_LISTEN", f"127.0.0.1:{_free_port()}")
     node = _TeamDaemon(tmp_path)
+    node.seed_user("root", "fake-pw-r", role="admin")
     node.seed_user("alice", "fake-pw-a")
     try:
         yield node
@@ -168,8 +173,8 @@ def test_checkpoint_recovery_answers_501_not_400(listening_daemon):
     assert (
         daemon.runner.compute_sessions is not None
     ), "the listener did not come up, so this would be testing the 409 path"
-    cookie = _login(daemon, "alice", "fake-pw-a")
-    session_id = _session_of(daemon, "alice")
+    cookie = _login(daemon, "root", "fake-pw-r")
+    session_id = _session_of(daemon, "root")
     status, raw = _put(
         daemon.port,
         f"/api/v1/sessions/{session_id}/compute",
@@ -185,8 +190,8 @@ def test_checkpoint_recovery_answers_501_not_400(listening_daemon):
 
 def test_an_unconfigured_profile_is_refused_rather_than_guessed(listening_daemon):
     daemon = listening_daemon
-    cookie = _login(daemon, "alice", "fake-pw-a")
-    session_id = _session_of(daemon, "alice")
+    cookie = _login(daemon, "root", "fake-pw-r")
+    session_id = _session_of(daemon, "root")
     status, raw = _put(
         daemon.port,
         f"/api/v1/sessions/{session_id}/compute",
@@ -195,3 +200,57 @@ def test_an_unconfigured_profile_is_refused_rather_than_guessed(listening_daemon
     )
     assert status == 400
     assert _body(raw)["code"] == "unknown_profile"
+
+
+def test_cluster_session_placement_is_admin_only_before_any_write(
+    listening_daemon,
+):
+    daemon = listening_daemon
+    member = _login(daemon, "alice", "fake-pw-a")
+    member_session = _session_of(daemon, "alice")
+
+    status, raw = _put(
+        daemon.port,
+        f"/api/v1/sessions/{member_session}/compute",
+        {"profile": "gpu-interactive"},
+        member,
+    )
+    assert status == 403, raw[:300]
+    assert _body(raw)["code"] == "admin_only"
+    assert daemon.store.leases.workload_for_session(member_session) is None
+
+    admin = _login(daemon, "root", "fake-pw-r")
+    admin_session = _session_of(daemon, "root")
+    status, raw = _put(
+        daemon.port,
+        f"/api/v1/sessions/{admin_session}/compute",
+        {"profile": "gpu-interactive"},
+        admin,
+    )
+    assert status == 201, raw[:300]
+    first = _body(raw)
+    assert first["workload"] is not None
+    assert first["allocation"] is None
+
+    workload_id = first["workload"]["id"]
+    deadline = time.monotonic() + 2.0
+    while (
+        daemon.store.workloads.active_allocation(workload_id) is None
+        and time.monotonic() < deadline
+    ):
+        time.sleep(0.01)
+    assert daemon.store.workloads.active_allocation(workload_id) is not None
+
+    # Repeating the idempotent request returns the same durable workload and
+    # the now-existing allocation. Exercising both eventual states in one
+    # real HTTP test keeps the frozen response schema deterministic.
+    status, raw = _put(
+        daemon.port,
+        f"/api/v1/sessions/{admin_session}/compute",
+        {"profile": "gpu-interactive"},
+        admin,
+    )
+    assert status == 201, raw[:300]
+    second = _body(raw)
+    assert second["workload"]["id"] == workload_id
+    assert second["allocation"] is not None

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -832,6 +832,17 @@ def test_ws_subscribe_replay_enqueue_is_atomic_with_live_broadcast():
             self.replay_started = threading.Event()
             self.release_replay = threading.Event()
 
+        def refresh_visibility(self, root_frame_id):
+            """Re-asked outside the hub lock before every fan-out; a no-op
+            here, as it is on a daemon with no team mode."""
+
+        def may_receive(self, root_frame_id):
+            """The fan-out re-checks team visibility per delivery. A double
+            that is a subscriber has to answer the same question a real
+            connection does -- single-user is the permissive answer, which is
+            what this test is about."""
+            return True
+
         def send_json(self, event):
             self.events.append(dict(event))
             if event.get("type") == "replay_begin":

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -881,6 +881,161 @@ def test_ws_subscribe_replay_enqueue_is_atomic_with_live_broadcast():
     ] == ["old", "new"]
 
 
+def test_ws_broadcast_refreshes_a_subscription_added_during_authorization():
+    """A subscriber may arrive while broadcast checks viewers outside its lock.
+
+    It receives the replay before the new event is recorded, so broadcast must
+    either refresh and deliver that event or keep it out until the event can be
+    replayed. Silently including the connection only in the final fan-out loses
+    exactly one event.
+    """
+    hub = gateway_mod.WSHub()
+    root = "root-subscribe-refresh-race"
+
+    class CheckedConnection:
+        def __init__(self, *, block_first=False):
+            self.alive = True
+            self.subs = set()
+            self.events = []
+            self.checked = set()
+            self.block_first = block_first
+            self.refresh_started = threading.Event()
+            self.release_refresh = threading.Event()
+
+        def refresh_visibility(self, root_frame_id):
+            if self.block_first:
+                self.block_first = False
+                self.refresh_started.set()
+                assert self.release_refresh.wait(2)
+            self.checked.add(root_frame_id)
+
+        def may_receive(self, root_frame_id):
+            return root_frame_id in self.checked
+
+        def send_json(self, event):
+            self.events.append(dict(event))
+
+    existing = CheckedConnection(block_first=True)
+    hub.add(existing)
+    hub.subscribe(root, existing)
+    existing.events.clear()
+
+    live = threading.Thread(
+        target=hub.broadcast,
+        args=(root, {"type": "text_chunk", "frame_id": root, "chunk": "new"}),
+    )
+    live.start()
+    assert existing.refresh_started.wait(2)
+
+    arriving = CheckedConnection()
+    hub.add(arriving)
+    hub.subscribe(root, arriving)
+    arriving.events.clear()
+
+    existing.release_refresh.set()
+    live.join(2)
+    assert not live.is_alive()
+    assert [event.get("chunk") for event in arriving.events] == ["new"]
+
+
+def test_ws_restored_visibility_replays_the_denied_sequence_gap():
+    hub = gateway_mod.WSHub()
+    root = "root-visibility-gap"
+
+    class VisibilityConnection:
+        refresh_visibility = gateway_mod.WSConnection.refresh_visibility
+        commit_visibility = gateway_mod.WSConnection.commit_visibility
+        note_delivered = gateway_mod.WSConnection.note_delivered
+
+        def __init__(self):
+            self.alive = True
+            self.subs = set()
+            self.events = []
+            self.allowed = True
+            self.visibility_check = lambda _root: self.allowed
+            self._visibility_denied = set()
+            self._last_delivered_seq = {}
+
+        def send_json(self, event):
+            self.events.append(dict(event))
+
+    conn = VisibilityConnection()
+    hub.broadcast(root, {"type": "text_reset", "frame_id": root})
+    hub.add(conn)
+    hub.subscribe(root, conn)
+    conn.events.clear()
+
+    hub.broadcast(root, {"type": "step", "marker": "before"})
+    conn.allowed = False
+    hub.broadcast(root, {"type": "step", "marker": "denied"})
+    conn.allowed = True
+    hub.broadcast(root, {"type": "step", "marker": "restored"})
+
+    markers = [event.get("marker") for event in conn.events if event.get("marker")]
+    assert markers == ["before", "denied", "restored"]
+    sequences = [event["seq"] for event in conn.events if "seq" in event]
+    assert sequences == [2, 3, 4]
+    types = [event.get("type") for event in conn.events]
+    assert types[1:5] == ["replay_begin", "step", "replay_end", "step"]
+
+
+def test_ws_idle_delta_gap_is_declared_when_visibility_returns():
+    hub = gateway_mod.WSHub()
+    root = "root-idle-visibility-gap"
+
+    class VisibilityConnection:
+        refresh_visibility = gateway_mod.WSConnection.refresh_visibility
+        commit_visibility = gateway_mod.WSConnection.commit_visibility
+        note_delivered = gateway_mod.WSConnection.note_delivered
+
+        def __init__(self):
+            self.alive = True
+            self.subs = set()
+            self.events = []
+            self.allowed = True
+            self.visibility_check = lambda _root: self.allowed
+            self._visibility_denied = set()
+            self._last_delivered_seq = {}
+
+        def send_json(self, event):
+            self.events.append(dict(event))
+
+    conn = VisibilityConnection()
+    hub.add(conn)
+    hub.subscribe(root, conn, 0, hub.epoch)
+    conn.events.clear()
+
+    conn.allowed = False
+    hub.broadcast(root, {"type": "kernel_status", "status": "busy"})
+    assert root not in hub._live  # idle deltas do not invent a running turn
+    conn.allowed = True
+    hub.broadcast(root, {"type": "kernel_status", "status": "idle"})
+
+    begin = next(e for e in conn.events if e.get("type") == "replay_begin")
+    assert begin["gap"] is True
+    delivered = [e for e in conn.events if e.get("type") == "kernel_status"]
+    assert [e["seq"] for e in delivered] == [2]
+
+
+def test_ws_replay_declares_an_unbuffered_idle_delta_at_the_tail():
+    hub = gateway_mod.WSHub()
+    root = "root-replay-tail-gap"
+    hub.broadcast(root, {"type": "text_reset", "frame_id": root})  # seq 1
+    hub.broadcast(root, {"type": "text_chunk", "chunk": "kept"})  # seq 2
+    # Approval cards replay from their durable source, so they advance the
+    # stream counter but intentionally do not enter the live-turn buffer.
+    hub.broadcast(root, {"type": "await_permission", "request_id": "p1"})  # seq 3
+
+    conn = _Recorder()
+    hub.add(conn)
+    # Exercise the envelope directly with a retained prefix and an unbuffered
+    # tail; subscribe intentionally omits completed live windows.
+    with hub._lock:
+        hub._enqueue_replay_locked(root, conn, hub._live[root]["events"], 1)
+
+    assert conn.replay_begin()["gap"] is True
+
+
 def test_ws_outbound_queue_covers_a_complete_resume_envelope():
     assert gateway_mod.WSConnection._QUEUE_CAP >= (
         gateway_mod.WSHub._BUFFER_CAP + gateway_mod._WS_REPLAY_ENVELOPE_EVENTS

--- a/tests/test_gateway_kernel_lifecycle.py
+++ b/tests/test_gateway_kernel_lifecycle.py
@@ -370,7 +370,9 @@ def test_environment_replacement_keeps_session_dispatcher_and_commits_active_env
     monkeypatch.setattr(gateway_mod, "Kernel", FakeKernel)
     monkeypatch.setattr(runner, "_wire_delegation", lambda *args, **kwargs: None)
     monkeypatch.setattr(
-        runner, "_run_bootstrap", lambda state, kernel=None: bootstrapped.append(kernel)
+        runner,
+        "_run_bootstrap",
+        lambda state, kernel=None, workspace=None: bootstrapped.append(kernel),
     )
 
     st.desired_env = "base"

--- a/tests/test_gateway_lazy_runtime.py
+++ b/tests/test_gateway_lazy_runtime.py
@@ -155,7 +155,7 @@ def _install_fake_runtime(monkeypatch, runner, *, expect_attempt_for=None):
 
     monkeypatch.setattr(gateway_mod, "build_dispatcher", build_dispatcher)
     monkeypatch.setattr(gateway_mod, "Kernel", FakeKernel)
-    monkeypatch.setattr(runner, "_wire_delegation", lambda state: None)
+    monkeypatch.setattr(runner, "_wire_delegation", lambda *args, **kwargs: None)
     monkeypatch.setattr(runner, "_spawn_title_summary", lambda *args, **kwargs: None)
     runner.skills = SimpleNamespace(system_context="", bootstrap_code="")
     return dispatchers, kernels

--- a/tests/test_orchestration_distributed.py
+++ b/tests/test_orchestration_distributed.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import json
 import socket
 import threading
+import time
 
 import pytest
 
@@ -28,6 +29,8 @@ from openai4s.orchestration.bootstrap import BootstrapAuthority, load_or_mint_se
 from openai4s.orchestration.models import (
     Allocation,
     ExternalHandle,
+    Phase,
+    Reason,
     ResourceProfile,
     SubmissionToken,
     TaskSpec,
@@ -36,7 +39,7 @@ from openai4s.orchestration.ports import TaskRunner
 from openai4s.orchestration.session import ComputeSessionManager, SessionReadiness
 from openai4s.orchestration.slurm.backend import SlurmBackend
 from openai4s.orchestration.slurm.broker import SlurmBroker, StepSpec
-from openai4s.orchestration.worker_gateway import WorkerGateway
+from openai4s.orchestration.worker_gateway import Registration, WorkerGateway
 from openai4s.store import get_store
 
 PROFILE = ResourceProfile(name="gpu-multi", cpus=8, gpus=4, nodes=2)
@@ -68,6 +71,7 @@ def test_the_step_names_the_job_it_runs_inside():
     assert "--jobid=4242" in argv
     assert "--ntasks=8" in argv and "--nodes=2" in argv
     assert "--cpus-per-task=4" in argv
+    assert "--export=NONE" in argv
     assert argv[argv.index("--") + 1 :] == ["python", "train.py"]
 
 
@@ -83,6 +87,7 @@ def test_the_step_is_run_through_the_real_argv(monkeypatch):
 
     def fake_runner(command, **kwargs):
         seen["command"] = list(command)
+        seen["timeout"] = kwargs.get("timeout")
 
         class _Done:
             returncode = 0
@@ -100,6 +105,7 @@ def test_the_step_is_run_through_the_real_argv(monkeypatch):
     assert result.output.split() == ["node-01", "node-02"]
     assert result.handle.allocation_id == "alloc_1"
     assert result.handle.tasks == 2
+    assert seen["timeout"] is None
 
 
 def test_a_slurm_backend_is_a_task_runner():
@@ -119,6 +125,18 @@ def test_a_step_refuses_an_unsafe_job_id():
     broker = SlurmBroker()
     with pytest.raises(ValueError, match="unsafe job id"):
         broker.build_step_argv("4242; rm -rf /", StepSpec(command=("x",)))
+
+
+def test_a_slurm_worker_selects_the_credential_for_its_rank(monkeypatch):
+    from openai4s.kernel import worker as worker_mod
+
+    monkeypatch.setenv(
+        "OPENAI4S_WORKER_BOOTSTRAP_PATH_TEMPLATE", "/shared/bootstrap-r{rank}.json"
+    )
+    monkeypatch.setenv("OPENAI4S_WORKER_RANK_ENV", "SLURM_PROCID")
+    monkeypatch.setenv("SLURM_PROCID", "3")
+
+    assert worker_mod._remote_credential_path() == "/shared/bootstrap-r3.json"
 
 
 # -- M4-3: gang readiness -----------------------------------------------------
@@ -209,16 +227,133 @@ def test_an_unawaited_registration_is_reaped(gateway, monkeypatch):
     lifetime. One leaked fd triple per straggler, ending in EMFILE."""
     import openai4s.orchestration.worker_gateway as wg
 
-    monkeypatch.setattr(wg, "ORPHAN_REGISTRATION_TTL_S", 0.0)
+    monkeypatch.setattr(wg, "ORPHAN_REGISTRATION_TTL_S", 0.05)
     node, authority = gateway
     sock = _dial(node, authority.issue(allocation_id="alloc_orphan", epoch=0, rank=0))
     try:
-        # Nobody ever awaits `alloc_orphan`; a wait on any other key sweeps.
-        node.await_workers("alloc_other", 0, expected=1, timeout_s=0.2)
+        # The ack is sent before the registration is parked, so first wait for
+        # the server-side handoff. Then do *nothing*: the final orphan must age
+        # out even when no later worker arrives and nobody calls await_workers.
+        deadline = time.monotonic() + 2
+        while node.accepted < 1 and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert node.accepted == 1
+        deadline = time.monotonic() + 2
+        while node.reaped < 1 and time.monotonic() < deadline:
+            time.sleep(0.01)
         assert node.reaped >= 1
         assert ("alloc_orphan", 0) not in node._arrived
     finally:
         sock.close()
+
+
+def test_a_live_bound_session_registration_survives_orphan_housekeeping(
+    tmp_path, monkeypatch
+):
+    """Worker readiness may precede the first Cell by ordinary user think-time.
+
+    The live lease/allocation owns that parked socket, so the orphan TTL must
+    only reap it after release, recovery or another durable fence makes the
+    attempt unexpected.
+    """
+    import openai4s.orchestration.worker_gateway as wg
+
+    monkeypatch.setattr(wg, "ORPHAN_REGISTRATION_TTL_S", 0.05)
+    store = get_store(str(tmp_path / "state.db"))
+    authority = BootstrapAuthority(load_or_mint_secret(tmp_path))
+    node = WorkerGateway(authority, bind=("127.0.0.1", 0))
+    node.start()
+    sock = None
+    try:
+        manager = ComputeSessionManager(
+            store=store,
+            gateway=node,
+            authority=authority,
+            workspace_root=tmp_path / "ws",
+        )
+        workload = manager.request_session(
+            session_id="s1",
+            owner_user_id="u1",
+            profile=ResourceProfile(name="single"),
+            backend="fake",
+        )
+        allocation = store.workloads.create_allocation(workload.id, 0)
+        allocation.phase = Phase.ACTIVE
+        store.workloads.save_allocation(allocation)
+
+        sock = _dial(
+            node,
+            authority.issue(allocation_id=allocation.id, epoch=0, rank=0),
+        )
+        deadline = time.monotonic() + 2
+        while node.accepted < 1 and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert node.accepted == 1
+        # The accept-loop housekeeping tick is 0.5s, well past this test TTL.
+        time.sleep(0.7)
+        assert node.reaped == 0
+        assert store.workloads.session_registration_expected(allocation.id, 0)
+
+        assert manager.release("s1", reason=Reason.USER_CANCELLED)
+        assert not store.workloads.session_registration_expected(allocation.id, 0)
+        deadline = time.monotonic() + 2
+        while node.reaped < 1 and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert node.reaped == 1
+        assert (allocation.id, 0) not in node._arrived
+    finally:
+        if sock is not None:
+            sock.close()
+        node.stop()
+        store.close()
+
+
+def test_a_wait_timeout_sweeps_an_orphan_that_arrived_after_the_first_check(
+    gateway, monkeypatch
+):
+    """An arrival can be parked while an unrelated wait is sleeping. Its
+    timeout is gateway activity too, and must sweep what the first check could
+    not have seen."""
+    import openai4s.orchestration.worker_gateway as wg
+
+    monkeypatch.setattr(wg, "ORPHAN_REGISTRATION_TTL_S", 0.0)
+    _, authority = gateway
+    # No accept thread: this test isolates the timeout branch deterministically
+    # rather than letting the listener's periodic sweep win the race first.
+    node = WorkerGateway(authority, bind=("127.0.0.1", 0))
+
+    class _Transport:
+        closed = False
+
+        def close(self, *, graceful=True):
+            self.closed = True
+
+    transport = _Transport()
+    orphan = Registration(
+        allocation_id="alloc_orphan",
+        epoch=0,
+        rank=0,
+        transport=transport,
+        peer="test",
+    )
+    real_reap = node._reap_locked
+    planted = False
+
+    def reap_then_plant_once():
+        nonlocal planted
+        dropped = real_reap()
+        if not planted:
+            # `_reap_locked` is called with the gateway lock held. Plant after
+            # the initial sweep to reproduce an arrival during waiter.sleep.
+            node._arrived[("alloc_orphan", 0)] = [orphan]
+            planted = True
+        return dropped
+
+    monkeypatch.setattr(node, "_reap_locked", reap_then_plant_once)
+    node.await_workers("alloc_other", 0, expected=1, timeout_s=0.0)
+
+    assert transport.closed is True
+    assert ("alloc_orphan", 0) not in node._arrived
 
 
 def test_a_late_rank_completes_the_gang(gateway):
@@ -287,6 +422,68 @@ def test_a_multi_node_session_is_not_ready_on_one_rank(tmp_path):
         assert readiness.blocked_on == "worker"
         # and the partial set is kept, so those workers can still be released
         assert manager.runtime("s1").registrations == ["rank0"]
+    finally:
+        store.close()
+
+
+def test_a_reaped_partial_rank_cannot_satisfy_later_gang_readiness(tmp_path):
+    """Gateway and manager share a transport while a partial gang is parked.
+
+    If the orphan TTL closes rank 0 before rank 1 arrives, the manager must
+    drop that stale registration rather than count two ranks and build the
+    driver Kernel over rank 0's closed socket.
+    """
+    store = get_store(str(tmp_path / "state.db"))
+    try:
+        authority = BootstrapAuthority(load_or_mint_secret(tmp_path))
+
+        class _Transport:
+            def __init__(self):
+                self.live = True
+
+            def alive(self):
+                return self.live
+
+        class _Rank:
+            def __init__(self, rank):
+                self.rank = rank
+                self.transport = _Transport()
+
+        rank0 = _Rank(0)
+        rank1 = _Rank(1)
+        rounds = [[rank0], [rank1]]
+
+        class _Gateway:
+            def await_workers(self, allocation_id, epoch, *, expected, timeout_s):
+                return rounds.pop(0)
+
+        built = []
+        manager = ComputeSessionManager(
+            store=store,
+            gateway=_Gateway(),
+            authority=authority,
+            workspace_root=tmp_path / "ws",
+            kernel_factory=lambda registration: built.append(registration),
+        )
+        workload = manager.request_session(
+            session_id="s1",
+            owner_user_id="u1",
+            profile=PROFILE,
+            backend="fake",
+        )
+        allocation = store.workloads.create_allocation(workload.id, 0)
+        allocation.phase = Phase.ACTIVE
+        store.workloads.save_allocation(allocation)
+
+        assert manager.attach_worker("s1", timeout_s=0) is False
+        rank0.transport.live = False  # the gateway's TTL reaper closed it
+        assert manager.attach_worker("s1", timeout_s=0) is False
+
+        readiness = manager.readiness("s1")
+        assert readiness.workers_registered == 1
+        assert not readiness.ready
+        assert manager.runtime("s1").registrations == [rank1]
+        assert built == []
     finally:
         store.close()
 

--- a/tests/test_orchestration_reconciler.py
+++ b/tests/test_orchestration_reconciler.py
@@ -80,6 +80,19 @@ class _Store:
     def save_workload(self, workload: Workload) -> None:
         self.workloads[workload.id] = workload
 
+    def open_recovery_epoch(self, allocation: Allocation, workload: Workload) -> None:
+        """The `WorkloadStore` Protocol's atomic retire-and-bump.
+
+        The double was missing it, which is why `Reconciler.recover` could
+        keep writing the two halves separately -- the fake answered whatever
+        the method under test happened to call, so the non-atomic version
+        looked fine here. Counted as one save of each, because that is what
+        the real repository does in one transaction.
+        """
+        self.saved_allocations += 1
+        self.allocations[allocation.id] = allocation
+        self.workloads[workload.id] = workload
+
 
 class _FakeBackend:
     """A backend whose every answer a test can dictate."""
@@ -364,18 +377,45 @@ def test_cancelling_a_workload_with_no_allocation_is_immediate():
 
 
 def test_recovery_is_a_new_epoch_not_a_rewrite():
-    """INV-6/INV-7: history stands, the epoch advances."""
+    """INV-6/INV-7: history stands, the epoch advances.
+
+    Driven through `tick()`, because there used to be two recoveries and this
+    test drove the one nothing called. The public `recover()` wrote the dead
+    allocation and the epoch bump as two commits -- the split the comment in
+    `_recover_session` exists to forbid, since a crash between them strands
+    the workload on an epoch whose allocation already exists -- so the method
+    under test could not fail in the way production could. There is one
+    recovery now, and this is it.
+    """
     store, backend = _Store(), _FakeBackend()
-    workload = store.add(_workload())
+    # A SESSION: `_recover_session` refuses a BATCH by design, so a batch
+    # workload would have exercised nothing.
+    workload = store.add(
+        Workload(
+            id=Workload.new_id(),
+            spec=WorkloadSpec(
+                kind=WorkloadKind.SESSION,
+                profile=ResourceProfile(name="cpu-interactive"),
+            ),
+            owner_user_id="user_1",
+        )
+    )
     rec = _reconciler(store, backend)
     rec.tick()
     first = store.active_allocation(workload.id)
     assert first.epoch == 0
 
-    rec.recover(workload, reason=Reason.NODE_FAILED)
+    # The node it was placed on goes away.
+    backend.observations.append(
+        Observation(phase=Phase.LOST, reason=Reason.NODE_FAILED)
+    )
+    rec.tick()
     assert store.allocations[first.id].phase is Phase.LOST
     assert store.allocations[first.id].reason is Reason.NODE_FAILED
-    assert workload.execution_epoch == 1
+    assert store.workloads[workload.id].execution_epoch == 1
+    assert not store.workloads[
+        workload.id
+    ].phase.is_terminal, "a recovered session is emphatically not terminal"
 
     rec.tick()
     second = store.active_allocation(workload.id)

--- a/tests/test_orchestration_reconciler.py
+++ b/tests/test_orchestration_reconciler.py
@@ -80,6 +80,13 @@ class _Store:
     def save_workload(self, workload: Workload) -> None:
         self.workloads[workload.id] = workload
 
+    def save_allocation_and_workload(
+        self, allocation: Allocation, workload: Workload
+    ) -> None:
+        self.saved_allocations += 1
+        self.allocations[allocation.id] = allocation
+        self.workloads[workload.id] = workload
+
     def open_recovery_epoch(self, allocation: Allocation, workload: Workload) -> None:
         """The `WorkloadStore` Protocol's atomic retire-and-bump.
 
@@ -89,9 +96,7 @@ class _Store:
         looked fine here. Counted as one save of each, because that is what
         the real repository does in one transaction.
         """
-        self.saved_allocations += 1
-        self.allocations[allocation.id] = allocation
-        self.workloads[workload.id] = workload
+        self.save_allocation_and_workload(allocation, workload)
 
 
 class _FakeBackend:
@@ -424,6 +429,113 @@ def test_recovery_is_a_new_epoch_not_a_rewrite():
     assert second.submission_token != first.submission_token
 
 
+def test_recovery_never_commits_the_dead_allocation_before_the_epoch_bump(tmp_path):
+    """A crash before the atomic pair must leave a retryable old attempt."""
+    from openai4s.config import Config
+    from openai4s.store import get_store
+
+    real_store = get_store(Config(data_dir=tmp_path).db_path)
+    workload = real_store.workloads.create_workload(
+        spec=WorkloadSpec(
+            kind=WorkloadKind.SESSION,
+            profile=ResourceProfile(name="cpu-interactive"),
+        ),
+        owner_user_id="u1",
+    )
+    workload.phase = Phase.ACTIVE
+    real_store.workloads.save_workload(workload)
+    allocation = real_store.workloads.create_allocation(workload.id, 0)
+    allocation.phase = Phase.ACTIVE
+    allocation.handle = ExternalHandle(backend="fake", external_id="1")
+    real_store.workloads.save_allocation(allocation)
+
+    class _FailFirstRecoveryCommit:
+        def __init__(self, delegate):
+            self.delegate = delegate
+            self.fail = True
+
+        def __getattr__(self, name):
+            return getattr(self.delegate, name)
+
+        def open_recovery_epoch(self, dead, recovering):
+            if self.fail:
+                raise RuntimeError("crash before atomic recovery commit")
+            return self.delegate.open_recovery_epoch(dead, recovering)
+
+    repository = _FailFirstRecoveryCommit(real_store.workloads)
+    backend = _FakeBackend()
+    backend.observations = [Observation(phase=Phase.LOST, reason=Reason.NODE_FAILED)]
+    rec = Reconciler(store=repository, backends={"local": backend})
+
+    first = rec.tick()
+    assert first.errors
+    persisted_allocation = real_store.workloads.active_allocation(workload.id)
+    persisted_workload = real_store.workloads.get_workload(workload.id)
+    assert persisted_allocation is not None
+    assert persisted_allocation.phase is Phase.ACTIVE
+    assert persisted_workload.execution_epoch == 0
+
+    repository.fail = False
+    backend.observations = [Observation(phase=Phase.LOST, reason=Reason.NODE_FAILED)]
+    assert not rec.tick().errors
+    assert real_store.workloads.active_allocation(workload.id) is None
+    recovered = real_store.workloads.get_workload(workload.id)
+    assert recovered.execution_epoch == 1
+    assert recovered.phase is Phase.PENDING
+    real_store.close()
+
+
+def test_a_batch_terminal_transition_is_one_database_commit(tmp_path):
+    """A failed pair leaves both rows active and the next tick retryable."""
+    from openai4s.config import Config
+    from openai4s.store import get_store
+
+    real_store = get_store(Config(data_dir=tmp_path).db_path)
+    workload = real_store.workloads.create_workload(
+        spec=WorkloadSpec(
+            kind=WorkloadKind.BATCH,
+            profile=ResourceProfile(name="cpu"),
+            command=("true",),
+        ),
+        owner_user_id="u1",
+    )
+    workload.phase = Phase.ACTIVE
+    real_store.workloads.save_workload(workload)
+    allocation = real_store.workloads.create_allocation(workload.id, 0)
+    allocation.phase = Phase.ACTIVE
+    allocation.handle = ExternalHandle(backend="fake", external_id="1")
+    real_store.workloads.save_allocation(allocation)
+
+    class _FailFirstPair:
+        def __init__(self, delegate):
+            self.delegate = delegate
+            self.fail = True
+
+        def __getattr__(self, name):
+            return getattr(self.delegate, name)
+
+        def save_allocation_and_workload(self, observed, parent):
+            if self.fail:
+                raise RuntimeError("crash before atomic terminal commit")
+            return self.delegate.save_allocation_and_workload(observed, parent)
+
+    repository = _FailFirstPair(real_store.workloads)
+    backend = _FakeBackend()
+    backend.observations = [Observation(phase=Phase.COMPLETED)]
+    rec = Reconciler(store=repository, backends={"local": backend})
+
+    assert rec.tick().errors
+    assert real_store.workloads.get_workload(workload.id).phase is Phase.ACTIVE
+    assert real_store.workloads.active_allocation(workload.id).phase is Phase.ACTIVE
+
+    repository.fail = False
+    backend.observations = [Observation(phase=Phase.COMPLETED)]
+    assert not rec.tick().errors
+    assert real_store.workloads.get_workload(workload.id).phase is Phase.COMPLETED
+    assert real_store.workloads.active_allocation(workload.id) is None
+    real_store.close()
+
+
 # -- resilience ---------------------------------------------------------------
 
 
@@ -531,6 +643,46 @@ def test_local_backend_cancels_a_running_process(local_backend):
 
     workload.desired_state = DesiredState.STOPPED
     assert _drive_to_terminal(rec, store, workload) is Phase.CANCELLED
+
+
+def test_local_backend_cancels_descendants_after_the_leader_exits(local_backend):
+    """A short-lived wrapper is not the allocation when its child survives."""
+    from openai4s.execution.process_group import group_alive
+
+    allocation = Allocation(
+        id=Allocation.new_id(),
+        workload_id="wl_descendant",
+        epoch=0,
+        submission_token=SubmissionToken.mint(),
+    )
+    # The wrapper launches the actual work into its inherited process group
+    # and exits cleanly. This is the exact state where a leader-only poll used
+    # to publish COMPLETED and make cancel return without signalling anything.
+    code = (
+        "import subprocess,sys; "
+        "subprocess.Popen([sys.executable,'-c','import time; time.sleep(60)'])"
+    )
+    spec = WorkloadSpec(
+        kind=WorkloadKind.BATCH,
+        profile=ResourceProfile(name="cpu"),
+        command=(sys.executable, "-c", code),
+    )
+    created = local_backend.submit(
+        allocation=allocation, spec=spec, profile=spec.profile
+    )
+    assert isinstance(created, Created)
+    job = local_backend._jobs[allocation.id]
+    deadline = time.monotonic() + 5
+    while job.process.poll() is None and time.monotonic() < deadline:
+        time.sleep(0.02)
+    assert job.process.poll() == 0
+    assert group_alive(job.pgid), "the child did not survive its wrapper"
+    assert local_backend.observe(allocation).phase is Phase.ACTIVE
+
+    local_backend.cancel(allocation, reason=Reason.USER_CANCELLED)
+
+    assert not group_alive(job.pgid)
+    assert local_backend.observe(allocation).phase is Phase.CANCELLED
 
 
 def test_local_backend_honours_the_token_like_a_cluster_does(local_backend):

--- a/tests/test_orchestration_routes.py
+++ b/tests/test_orchestration_routes.py
@@ -385,9 +385,12 @@ def test_one_live_allocation_per_workload_is_enforced_by_the_database(daemon):
 # -- the cluster backend, through the same routes -----------------------------
 
 
-def test_a_cluster_job_uses_the_same_routes(tmp_path, monkeypatch):
-    """The point of the abstraction: a cluster job is the same API call with
-    a different backend name."""
+def test_a_cluster_job_is_admin_only_and_uses_the_same_routes(tmp_path, monkeypatch):
+    """Cluster credentials belong to the daemon, so members cannot spend them.
+
+    An admin still uses the backend-neutral job API; no scheduler identity is
+    exposed at the boundary.
+    """
     from tests.test_orchestration_slurm import _install_fake_scheduler
 
     state = tmp_path / "state"
@@ -442,10 +445,13 @@ printf '0' > "{s}/in_queue"; printf 'CANCELLED' > "{s}/acct_state"
     )
     node = _TeamDaemon(home)
     node.seed_user("alice", "fake-pw-a")
+    node.seed_user("root", "fake-pw-r", role="admin")
     try:
-        cookie = _login(node, "alice", "fake-pw-a")
+        member_cookie = _login(node, "alice", "fake-pw-a")
 
-        status, raw = _get(node.port, "/api/v1/orchestration/profiles", cookie=cookie)
+        status, raw = _get(
+            node.port, "/api/v1/orchestration/profiles", cookie=member_cookie
+        )
         payload = _body(raw)
         assert payload["configured"] is True
         assert payload["profiles"][0]["name"] == "gpu-batch"
@@ -454,6 +460,22 @@ printf '0' > "{s}/in_queue"; printf 'CANCELLED' > "{s}/acct_state"
             '"gpus"', ""
         )
 
+        status, raw = _post(
+            node.port,
+            "/api/v1/orchestration/jobs",
+            {
+                "command": ["echo", "hello"],
+                "profile": "gpu-batch",
+                "backend": "cluster",
+            },
+            cookie=member_cookie,
+        )
+        assert status == 403, raw[:300]
+        assert _body(raw)["code"] == "admin_only"
+        assert _body(raw)["backend"] == "cluster"
+        assert node.store.workloads.list_workloads(limit=50) == []
+
+        cookie = _login(node, "root", "fake-pw-r")
         status, raw = _post(
             node.port,
             "/api/v1/orchestration/jobs",

--- a/tests/test_orchestration_session.py
+++ b/tests/test_orchestration_session.py
@@ -18,6 +18,9 @@ The three things worth failing over:
 
 from __future__ import annotations
 
+import os
+import sqlite3
+import threading
 from pathlib import Path
 
 import pytest
@@ -44,6 +47,7 @@ from openai4s.orchestration.session import (
     ComputeSessionManager,
     SessionReadiness,
 )
+from openai4s.security.permissions import is_owner_only
 from openai4s.store import get_store
 
 PROFILE = ResourceProfile(name="gpu-interactive", cpus=4, gpus=1)
@@ -135,6 +139,30 @@ def manager(store, tmp_path):
         workspace_root=tmp_path / "workspaces",
         kernel_factory=lambda registration: _FakeKernel(),
     )
+
+
+def test_manager_precreates_private_workspace_root_before_any_workload(store, tmp_path):
+    root = tmp_path / "cluster-workspaces"
+    authority = BootstrapAuthority(load_or_mint_secret(tmp_path))
+    assert not root.exists()
+
+    # Prove the mode is explicit rather than an accident of the test runner's
+    # ordinary umask: this directory is the mount point bwrap must see before
+    # any local kernel starts, and later holds bootstrap credentials.
+    previous_umask = os.umask(0)
+    try:
+        ComputeSessionManager(
+            store=store,
+            gateway=FakeGateway(),
+            authority=authority,
+            workspace_root=root,
+        )
+    finally:
+        os.umask(previous_umask)
+
+    assert root.is_dir()
+    if os.name == "posix":
+        assert is_owner_only(root)
 
 
 class _FakeKernel:
@@ -551,6 +579,42 @@ def test_a_user_executing_something_renews_the_lease(store, manager, lease_clock
     )
 
 
+def test_a_touch_after_the_sweep_snapshot_wins_the_expiry_cas(
+    store, manager, lease_clock, monkeypatch
+):
+    """Renewal and reclamation are one race, not two independent writes.
+
+    The old sweep decided from a stale ``live_leases`` object and then wrote
+    STOPPED plus released the lease even when ``touch`` had already returned
+    True. Interpose the touch at the repository CAS boundary to make that
+    ordering deterministic.
+    """
+    workload = manager.request_session(
+        session_id="s1", owner_user_id="u1", profile=PROFILE, backend="fake"
+    )
+    clock = lease_clock
+    store.leases.open_lease(workload.id, idle_ttl_s=60, max_lifetime_s=7200)
+    reclaimer = LeaseReclaimer(
+        leases=store.leases, workloads=store.workloads, clock_ms=clock
+    )
+    clock.advance_s(61)
+
+    expire = store.leases.expire_if_unchanged
+
+    def touch_then_expire(lease, *, now_ms, reason):
+        assert store.leases.touch(lease.workload_id) is True
+        return expire(lease, now_ms=now_ms, reason=reason)
+
+    monkeypatch.setattr(store.leases, "expire_if_unchanged", touch_then_expire)
+    report = reclaimer.sweep()
+
+    assert report.expired == 0 and report.stopped == 0
+    assert store.leases.get(workload.id).released_at is None
+    assert (
+        store.workloads.get_workload(workload.id).desired_state is DesiredState.RUNNING
+    )
+
+
 def test_the_maximum_lifetime_cannot_be_renewed_past(store, manager, lease_clock):
     """And it is reported as itself: 'come back later' is the wrong thing
     to tell somebody whose session cannot come back."""
@@ -568,6 +632,37 @@ def test_the_maximum_lifetime_cannot_be_renewed_past(store, manager, lease_clock
         manager.touch("s1")
         reclaimer.sweep()
 
+    reloaded = store.workloads.get_workload(workload.id)
+    assert reloaded.desired_state is DesiredState.STOPPED
+    assert reloaded.reason is Reason.SESSION_MAX_LIFETIME_EXCEEDED
+
+
+def test_a_touch_racing_the_maximum_lifetime_cannot_renew_it(
+    store, manager, lease_clock, monkeypatch
+):
+    """The maximum lifetime is a hard bound even at the CAS boundary."""
+    workload = manager.request_session(
+        session_id="s1", owner_user_id="u1", profile=PROFILE, backend="fake"
+    )
+    clock = lease_clock
+    store.leases.open_lease(workload.id, idle_ttl_s=3600, max_lifetime_s=60)
+    reclaimer = LeaseReclaimer(
+        leases=store.leases, workloads=store.workloads, clock_ms=clock
+    )
+    clock.advance_s(61)
+
+    expire = store.leases.expire_if_unchanged
+
+    def touch_then_expire(lease, *, now_ms, reason):
+        assert reason is Reason.SESSION_MAX_LIFETIME_EXCEEDED
+        assert store.leases.touch(lease.workload_id) is True
+        return expire(lease, now_ms=now_ms, reason=reason)
+
+    monkeypatch.setattr(store.leases, "expire_if_unchanged", touch_then_expire)
+    report = reclaimer.sweep()
+
+    assert report.expired == 1 and report.stopped == 1
+    assert store.leases.get(workload.id).released_at is not None
     reloaded = store.workloads.get_workload(workload.id)
     assert reloaded.desired_state is DesiredState.STOPPED
     assert reloaded.reason is Reason.SESSION_MAX_LIFETIME_EXCEEDED
@@ -633,6 +728,82 @@ def test_asking_twice_for_a_session_returns_the_same_workload(store, manager):
     assert first.id == second.id
 
 
+def test_a_terminal_binding_is_atomically_replaced_by_a_new_workload(store, manager):
+    first = manager.request_session(
+        session_id="s1", owner_user_id="u1", profile=PROFILE, backend="fake"
+    )
+    first.phase = Phase.COMPLETED
+    store.workloads.save_workload(first)
+
+    second = manager.request_session(
+        session_id="s1", owner_user_id="u1", profile=PROFILE, backend="fake"
+    )
+
+    assert second.id != first.id
+    assert store.leases.workload_for_session("s1") == second.id
+    assert store.leases.get(second.id).released_at is None
+
+
+def test_session_workload_binding_and_lease_roll_back_together(store, manager):
+    store._conn.execute(
+        "CREATE TRIGGER reject_session_lease BEFORE INSERT ON leases "
+        "BEGIN SELECT RAISE(ABORT, 'injected lease failure'); END"
+    )
+    store._conn.commit()
+
+    with pytest.raises(sqlite3.IntegrityError, match="injected lease failure"):
+        manager.request_session(
+            session_id="s1", owner_user_id="u1", profile=PROFILE, backend="fake"
+        )
+
+    assert store.workloads.list_workloads() == []
+    assert store.leases.workload_for_session("s1") is None
+
+
+def test_concurrent_session_requests_publish_only_one_workload(
+    store, manager, monkeypatch
+):
+    real_create = store.workloads.create_session_workload
+    first_entered = threading.Event()
+    release_first = threading.Event()
+    calls = 0
+    calls_lock = threading.Lock()
+
+    def delayed_create(**kwargs):
+        nonlocal calls
+        with calls_lock:
+            calls += 1
+            ordinal = calls
+        if ordinal == 1:
+            first_entered.set()
+            assert release_first.wait(2)
+        return real_create(**kwargs)
+
+    monkeypatch.setattr(store.workloads, "create_session_workload", delayed_create)
+    results = []
+
+    def request():
+        results.append(
+            manager.request_session(
+                session_id="s1", owner_user_id="u1", profile=PROFILE, backend="fake"
+            )
+        )
+
+    first = threading.Thread(target=request)
+    second = threading.Thread(target=request)
+    first.start()
+    assert first_entered.wait(2)
+    second.start()
+    release_first.set()
+    first.join(2)
+    second.join(2)
+
+    assert not first.is_alive() and not second.is_alive()
+    assert len({workload.id for workload in results}) == 1
+    assert len(store.workloads.list_workloads()) == 1
+    assert calls == 1
+
+
 def test_releasing_a_session_asks_for_a_stop_and_ends_the_lease(store, manager):
     workload = manager.request_session(
         session_id="s1", owner_user_id="u1", profile=PROFILE, backend="fake"
@@ -642,6 +813,67 @@ def test_releasing_a_session_asks_for_a_stop_and_ends_the_lease(store, manager):
     assert reloaded.desired_state is DesiredState.STOPPED
     assert store.leases.get(workload.id).released_at is not None
     assert manager.touch("s1") is False
+
+
+def test_session_cleanup_candidates_are_complete_durable_intents(store, manager):
+    active = manager.request_session(
+        session_id="active", owner_user_id="u1", profile=PROFILE, backend="fake"
+    )
+    stopped = manager.request_session(
+        session_id="stopped", owner_user_id="u1", profile=PROFILE, backend="fake"
+    )
+    released = manager.request_session(
+        session_id="released", owner_user_id="u1", profile=PROFILE, backend="fake"
+    )
+    missing = manager.request_session(
+        session_id="missing", owner_user_id="u1", profile=PROFILE, backend="fake"
+    )
+    terminal = manager.request_session(
+        session_id="terminal", owner_user_id="u1", profile=PROFILE, backend="fake"
+    )
+
+    store.workloads.request_stop(stopped.id, reason=Reason.USER_CANCELLED)
+    store.leases.release(released.id)
+    with store._lock:
+        store._conn.execute("DELETE FROM leases WHERE workload_id=?", (missing.id,))
+        store._conn.commit()
+    terminal.phase = Phase.FAILED
+    terminal.reason = Reason.WORKER_LOST
+    store.workloads.save_workload(terminal)
+
+    candidates = {
+        session_id: (workload_id, reason)
+        for session_id, workload_id, reason in (
+            store.workloads.session_cleanup_candidates()
+        )
+    }
+    assert "active" not in candidates
+    assert candidates["stopped"] == (stopped.id, Reason.USER_CANCELLED)
+    assert candidates["released"][0] == released.id
+    assert candidates["missing"][0] == missing.id
+    assert candidates["terminal"] == (terminal.id, Reason.WORKER_LOST)
+    assert active.id not in {
+        workload_id for workload_id, _reason in candidates.values()
+    }
+
+
+def test_session_release_rolls_back_stop_lease_and_binding_together(store, manager):
+    workload = manager.request_session(
+        session_id="s1", owner_user_id="u1", profile=PROFILE, backend="fake"
+    )
+    store._conn.execute(
+        "CREATE TRIGGER reject_session_unbind BEFORE DELETE ON session_workloads "
+        "BEGIN SELECT RAISE(ABORT, 'injected unbind failure'); END"
+    )
+    store._conn.commit()
+
+    with pytest.raises(sqlite3.IntegrityError, match="injected unbind failure"):
+        manager.release("s1", reason=Reason.USER_CANCELLED)
+
+    reloaded = store.workloads.get_workload(workload.id)
+    assert reloaded.desired_state is DesiredState.RUNNING
+    assert store.leases.get(workload.id).released_at is None
+    assert store.leases.workload_for_session("s1") == workload.id
 
 
 def test_the_reason_a_session_was_reclaimed_survives_the_backend(store, manager):

--- a/tests/test_orchestration_slurm.py
+++ b/tests/test_orchestration_slurm.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import os
 import stat
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -44,9 +45,16 @@ from openai4s.orchestration.slurm import (
     SlurmBroker,
     SlurmCommandError,
     SubmitSpec,
+)
+from openai4s.orchestration.slurm import broker as broker_mod
+from openai4s.orchestration.slurm import (
     parse_cluster_config,
 )
-from openai4s.orchestration.slurm.profiles import EXAMPLE_CLUSTER_TOML
+from openai4s.orchestration.slurm.broker import StepSpec
+from openai4s.orchestration.slurm.profiles import (
+    EXAMPLE_CLUSTER_TOML,
+    _parse_toml_subset,
+)
 
 # -- the fake cluster ---------------------------------------------------------
 
@@ -83,8 +91,12 @@ def fake_cluster(tmp_path, monkeypatch):
         script={
             "sbatch": f"""
 comment=""
+job_name=""
 for arg in "$@"; do
-  case "$arg" in --comment=*) comment="${{arg#--comment=}}" ;; esac
+  case "$arg" in
+    --comment=*) comment="${{arg#--comment=}}" ;;
+    --job-name=*) job_name="${{arg#--job-name=}}" ;;
+  esac
 done
 cat > "{s}/last_script"
 printf '%s\\n' "$@" > "{s}/last_argv"
@@ -93,6 +105,7 @@ if [ -f "{s}/sbatch_hang" ]; then sleep 30; fi
 if [ -f "{s}/sbatch_fail" ]; then echo "sbatch: error: refused" >&2; exit 1; fi
 jid=$(cat "{s}/next_job_id")
 printf '%s' "$comment" > "{s}/job_comment"
+printf '%s' "$job_name" > "{s}/job_name"
 printf '%s' "$jid" > "{s}/job_id"
 echo "$jid"
 """,
@@ -106,6 +119,7 @@ if [ "$(cat "{s}/in_queue")" != "1" ]; then exit 0; fi
 jid=$(cat "{s}/job_id")
 st=$(cat "{s}/queue_state")
 cm=$(cat "{s}/job_comment")
+jn=$(cat "{s}/job_name")
 reason=""
 if [ -f "{s}/queue_reason" ]; then reason=$(cat "{s}/queue_reason"); fi
 fmt=""
@@ -117,6 +131,7 @@ for arg in "$@"; do
 done
 case "$fmt" in
   *%r*) echo "$jid|$st|$reason|$cm" ;;
+  *%j*) echo "$jid|$cm|$jn" ;;
   *) echo "$jid|$cm" ;;
 esac
 """,
@@ -126,12 +141,14 @@ st=$(cat "{s}/acct_state")
 if [ -z "$st" ]; then exit 0; fi
 jid=$(cat "{s}/job_id")
 cm=$(cat "{s}/job_comment")
+jn=$(cat "{s}/job_name")
 fmt=""
 for arg in "$@"; do
   case "$arg" in --format=*) fmt="${{arg#--format=}}" ;; esac
 done
 case "$fmt" in
   *ExitCode*) echo "$jid|$st|0:0|$cm" ;;
+  *JobName*) echo "$jid|$cm|$jn" ;;
   *) echo "$jid|$cm" ;;
 esac
 """,
@@ -140,6 +157,7 @@ echo cancelled > "{s}/cancelled"
 printf '0' > "{s}/in_queue"
 printf 'CANCELLED' > "{s}/acct_state"
 """,
+            "srun": 'exec "$@"\n',
         },
     )
     monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ['PATH']}")
@@ -211,6 +229,29 @@ def test_submit_observe_complete(fake_cluster):
     assert observed.reason is None
 
 
+def test_reconciliation_survives_sites_that_do_not_account_job_comments(
+    fake_cluster,
+):
+    backend = _backend()
+    allocation = _allocation()
+    spec = _spec()
+    assert isinstance(
+        backend.submit(allocation=allocation, spec=spec, profile=spec.profile), Created
+    )
+    fake_cluster.set("in_queue", "0")
+    fake_cluster.set("acct_state", "COMPLETED")
+    # Slurm persists Comment only with AccountingStoreFlags=job_comment.
+    fake_cluster.set("job_comment", "")
+
+    assert (
+        backend._broker.find_by_comment(
+            allocation.submission_token.value,
+            job_name=backend._job_name_for_token(allocation.submission_token),
+        )
+        == "4242"
+    )
+
+
 @pytest.mark.parametrize(
     "state,phase,reason",
     [
@@ -220,6 +261,8 @@ def test_submit_observe_complete(fake_cluster):
         ("PREEMPTED", Phase.LOST, Reason.PREEMPTED),
         ("CANCELLED", Phase.CANCELLED, Reason.USER_CANCELLED),
         ("FAILED", Phase.FAILED, None),
+        ("LAUNCH_FAILED", Phase.FAILED, Reason.BOOTSTRAP_FAILED),
+        ("RECONFIG_FAIL", Phase.FAILED, None),
     ],
 )
 def test_terminal_state_mapping(fake_cluster, state, phase, reason):
@@ -236,6 +279,21 @@ def test_terminal_state_mapping(fake_cluster, state, phase, reason):
     assert observed.reason is reason
     # the scheduler's own word survives where nothing branches on it
     assert observed.diagnostics.get("state") == state
+
+
+@pytest.mark.parametrize(
+    "state", ["SPECIAL_EXIT", "REQUEUE_HOLD", "REQUEUE_FED", "RESV_DEL_HOLD"]
+)
+def test_requeue_hold_states_remain_pending(fake_cluster, state):
+    backend = _backend()
+    allocation = _allocation()
+    spec = _spec()
+    allocation.handle = backend.submit(
+        allocation=allocation, spec=spec, profile=spec.profile
+    ).handle
+    fake_cluster.set("queue_state", state)
+
+    assert backend.observe(allocation).phase is Phase.PENDING
 
 
 def test_cancel_is_idempotent(fake_cluster):
@@ -342,6 +400,95 @@ def test_an_unreachable_scheduler_is_not_a_failed_job(tmp_path, monkeypatch):
     assert observed.reason is Reason.BACKEND_UNAVAILABLE
 
 
+@pytest.mark.parametrize("operation", ["queue", "accounting", "find", "cancel"])
+def test_a_generic_scheduler_error_is_not_treated_as_absence(operation):
+    """Permission/configuration/controller failures are unknown answers. Only
+    a successful empty query is evidence that a job is absent."""
+
+    def refused(command, **kwargs):
+        return subprocess.CompletedProcess(
+            command, returncode=1, stdout="", stderr="permission denied"
+        )
+
+    broker = SlurmBroker(runner=refused)
+    call = {
+        "queue": lambda: broker.queue_status("42"),
+        "accounting": lambda: broker.accounting_status("42"),
+        "find": lambda: broker.find_by_comment("tok_a", job_name="openai4s-tok_a"),
+        "cancel": lambda: broker.cancel("42"),
+    }[operation]
+
+    with pytest.raises(SlurmCommandError) as failed:
+        call()
+    assert failed.value.returncode == 1
+    assert failed.value.stderr == "permission denied"
+
+
+def test_the_specific_unknown_job_error_falls_back_to_accounting():
+    calls = []
+
+    def runner(command, **kwargs):
+        calls.append(command[0])
+        if command[0] == "squeue":
+            return subprocess.CompletedProcess(
+                command,
+                returncode=1,
+                stdout="",
+                stderr="slurm_load_jobs error: Invalid job id specified",
+            )
+        return subprocess.CompletedProcess(
+            command,
+            returncode=0,
+            stdout="42|COMPLETED|0:0|tok_a\n",
+            stderr="",
+        )
+
+    broker = SlurmBroker(runner=runner)
+    assert broker.queue_status("42") is None
+    assert broker.accounting_status("42").state == "COMPLETED"
+    assert calls == ["squeue", "sacct"]
+
+
+def test_a_failed_token_lookup_never_reaches_sbatch():
+    calls = []
+
+    def refused(command, **kwargs):
+        calls.append(command[0])
+        return subprocess.CompletedProcess(
+            command, returncode=1, stdout="", stderr="permission denied"
+        )
+
+    backend = SlurmBackend(broker=SlurmBroker(runner=refused))
+    allocation = _allocation()
+    spec = _spec()
+
+    result = backend.submit(allocation=allocation, spec=spec, profile=spec.profile)
+
+    assert isinstance(result, Unknown)
+    assert calls == ["squeue"], "an unknown lookup submitted a second job"
+
+
+def test_a_failed_accounting_query_preserves_the_last_known_phase():
+    def runner(command, **kwargs):
+        if command[0] == "squeue":
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+        return subprocess.CompletedProcess(
+            command, 1, stdout="", stderr="accounting permission denied"
+        )
+
+    from openai4s.orchestration.models import ExternalHandle
+
+    backend = SlurmBackend(broker=SlurmBroker(runner=runner))
+    allocation = _allocation()
+    allocation.phase = Phase.ACTIVE
+    allocation.handle = ExternalHandle(backend="slurm", external_id="42")
+
+    observed = backend.observe(allocation)
+
+    assert observed.phase is Phase.ACTIVE
+    assert observed.reason is Reason.BACKEND_UNAVAILABLE
+
+
 def test_a_refused_submission_is_rejected(fake_cluster):
     fake_cluster.touch("sbatch_fail")
     backend = _backend()
@@ -367,6 +514,9 @@ def test_unschedulable_pending_reason_becomes_a_failure(fake_cluster):
     # ordinary waiting stays waiting — a busy cluster is not a broken one
     fake_cluster.set("queue_reason", "Resources")
     assert backend.observe(allocation).phase is Phase.PENDING
+    for temporary_reason in ("QOSGrpCpuLimit", "NodeDown"):
+        fake_cluster.set("queue_reason", temporary_reason)
+        assert backend.observe(allocation).phase is Phase.PENDING
 
 
 # -- INV-9: argv construction and secret hygiene ------------------------------
@@ -398,6 +548,39 @@ def test_argv_is_constructed_not_concatenated():
     # no environment named -> nothing inherited, so daemon API keys cannot
     # ride along by default
     assert "--export=NONE" in argv
+
+
+def test_a_step_with_no_environment_inherits_nothing():
+    argv = SlurmBroker().build_step_argv("4242", StepSpec(command=("hostname",)))
+    assert "--export=NONE" in argv
+
+
+def test_a_long_step_has_no_control_plane_timeout():
+    seen = {}
+
+    def runner(command, **kwargs):
+        seen.update(kwargs)
+
+        class Done:
+            returncode = 0
+            stdout = "ok"
+            stderr = ""
+
+        return Done()
+
+    assert (
+        SlurmBroker(timeout_s=0.01, runner=runner).run_step(
+            "4242", StepSpec(command=("sleep", "60"))
+        )
+        == "ok"
+    )
+    assert seen["timeout"] is None
+
+
+def test_step_output_is_drained_but_retained_with_a_hard_cap(monkeypatch):
+    monkeypatch.setattr(broker_mod, "MAX_STEP_OUTPUT_BYTES", 64)
+    output = SlurmBroker()._run_step_capped([sys.executable, "-c", "print('x' * 1000)"])
+    assert output == "x" * 64
 
 
 def test_a_hostile_name_is_an_argument_never_a_command(fake_cluster):
@@ -458,6 +641,22 @@ def test_the_submitted_script_quotes_its_command(fake_cluster):
     assert "'print('\"'\"'it works'\"'\"')'" in script
 
 
+def test_a_multi_node_session_launches_one_ranked_worker_per_node():
+    profile = ResourceProfile(name="gang", cpus=3, nodes=2)
+    spec = WorkloadSpec(
+        kind=WorkloadKind.SESSION,
+        profile=profile,
+        command=("python", "-u", "/opt/openai4s/worker.py"),
+        environment={"OPENAI4S_WORKER_BOOTSTRAP_PATH_TEMPLATE": "/run/r{rank}.json"},
+    )
+
+    submitted = _backend()._submit_spec(_allocation(), spec, profile)
+
+    assert "'srun' '--nodes=2' '--ntasks=2' '--ntasks-per-node=1'" in submitted.script
+    assert "'--cpus-per-task=3'" in submitted.script
+    assert submitted.environment["OPENAI4S_WORKER_RANK_ENV"] == "SLURM_PROCID"
+
+
 # -- cluster.toml -------------------------------------------------------------
 
 
@@ -472,6 +671,15 @@ def test_example_config_parses_on_every_supported_python():
     assert batch.resources.gpus == 1
     assert batch.resources.walltime_s == 172800
     assert cfg.job_name_prefix == "openai4s"
+
+
+def test_the_python310_reader_accepts_a_comment_after_a_table_header():
+    data = _parse_toml_subset(
+        '[profiles."gpu#large"] # site-local profile\npartition = "gpu"\n',
+        source="cluster.toml",
+    )
+
+    assert data == {"profiles": {"gpu#large": {"partition": "gpu"}}}
 
 
 def test_profile_public_view_never_names_a_queue():
@@ -494,6 +702,28 @@ def test_malformed_config_is_refused_with_its_location():
     ):
         with pytest.raises(ClusterConfigError):
             parse_cluster_config(text, source="cluster.toml")
+
+
+@pytest.mark.parametrize(
+    "text,unknown",
+    [
+        ("[cluster]\npartiton = 'gpu'\n", "partiton"),
+        ("[profiles.x]\ngpu = 4\n", "gpu"),
+        ("[profiles.x]\nmem_mb = 8192\n", "mem_mb"),
+        ("[extra]\nvalue = 1\n", "extra"),
+    ],
+)
+def test_unknown_cluster_keys_are_refused_instead_of_using_defaults(text, unknown):
+    with pytest.raises(ClusterConfigError, match=unknown):
+        parse_cluster_config(text, source="cluster.toml")
+
+
+def test_the_python310_reader_refuses_basic_string_escapes_it_cannot_decode():
+    with pytest.raises(ClusterConfigError, match="escape sequences"):
+        _parse_toml_subset(
+            '[profiles.x]\npartition = "gpu\\\\queue"\n',
+            source="cluster.toml",
+        )
 
 
 def test_absent_config_is_not_an_error(tmp_path):

--- a/tests/test_public_exception_projector.py
+++ b/tests/test_public_exception_projector.py
@@ -2432,6 +2432,15 @@ class _FakeConn:
     def send_json(self, obj: dict) -> None:
         self.sent.append(dict(obj))
 
+    # Team mode re-checks visibility per delivery: the hub refreshes outside
+    # its lock and then asks. A daemon with no team mode has no check to run,
+    # which is what these two answer.
+    def refresh_visibility(self, root_frame_id):
+        return None
+
+    def may_receive(self, root_frame_id):
+        return True
+
 
 def _turn_events(conn):
     return [

--- a/tests/test_query_scoping_team_mode.py
+++ b/tests/test_query_scoping_team_mode.py
@@ -46,7 +46,12 @@ def test_team_mode_refuses_a_direct_read_of_everyone_s_messages(store, monkeypat
     scope = {"root_frame_id": mine, "project_id": "p"}
 
     for table in ("messages", "execution_log", "frames"):
-        with pytest.raises(Exception) as caught:
+        # `PermissionError`, not `Exception`. A *missing* table raises
+        # `sqlite3.OperationalError: no such table: …`, which is also an
+        # Exception and also contains the table name -- so the loose spelling
+        # could not tell "the denylist refused it" from "the migration never
+        # created it", and would have gone on reporting green.
+        with pytest.raises(PermissionError) as caught:
             store.query(f"SELECT * FROM {table}", scope=scope)
         assert table in str(caught.value).lower(), str(caught.value)
 
@@ -77,8 +82,17 @@ def test_the_credential_table_is_denied_outright(store, monkeypatch):
     """No scoped view for this one: there is no legitimate agent read of a
     table holding a broker reference and every user's id."""
     monkeypatch.setenv("OPENAI4S_TEAM_MODE", "1")
+    # These three are exactly the tables the two newest migrations create, so
+    # a bare `pytest.raises(Exception)` here would have reported green for a
+    # database where those migrations never ran -- "no such table" and "not
+    # readable" are both Exceptions naming the table.
     for table in ("user_llm_keys", "leases", "session_workloads"):
-        with pytest.raises(Exception) as caught:
+        row = store._conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
+            (table,),
+        ).fetchone()
+        assert row is not None, f"{table} does not exist; the denial proves nothing"
+        with pytest.raises(PermissionError) as caught:
             store.query(f"SELECT * FROM {table}")
         assert table in str(caught.value).lower()
 
@@ -134,4 +148,56 @@ def test_every_table_is_classified(store):
         "identity, another tenant's state), in _TEAM_VIEW_ONLY_TABLES "
         "(per-session or per-project content), or in _DELIBERATELY_PUBLIC "
         "above if it is genuinely the agent's own working data."
+    )
+
+
+def test_a_cte_cannot_impersonate_a_scoped_view(store, monkeypatch):
+    """The authorizer's fifth argument is not caller-proof.
+
+    SQLite names "the view responsible for this read" in that argument, and it
+    fills it in for a CTE exactly as it does for a view -- so a caller who
+    names a CTE `my_messages` produced the byte-identical callback the real
+    temp view produces, and the escape hatch let it through. In team mode that
+    one string was the entire tenant boundary for `host.query`: this query used
+    to return the other person's prompt.
+    """
+    monkeypatch.setenv("OPENAI4S_TEAM_MODE", "1")
+    mine, theirs = _seed(store)
+    scope = store.resolve_frame_scope(mine)
+
+    for view, table in (
+        ("my_messages", "messages"),
+        ("my_frames", "frames"),
+        ("my_execution_log", "execution_log"),
+        ("my_artifacts", "artifacts"),
+    ):
+        sql = f"WITH {view} AS (SELECT * FROM main.{table}) SELECT * FROM {view}"
+        with pytest.raises(PermissionError, match=view):
+            store.query(sql, scope=scope)
+
+    # The real view still answers, and still answers only for this session.
+    rows = store.query("SELECT content FROM my_messages", scope=scope)
+    assert [r["content"] for r in rows] == ["my own question"]
+
+
+def test_the_authorizer_refuses_a_view_name_nothing_published(monkeypatch):
+    """Second layer, independent of the text check above.
+
+    The escape hatch used to accept any name in `_SCOPED_VIEWS` whether or not
+    a view answered to it, so it was a decision about a string rather than
+    about the statement. It now asks what this statement actually created:
+    `query()` passes the scoped set when it published the views and an empty
+    one when it did not.
+    """
+    from openai4s.store import _SCOPED_VIEWS, _QueryAuthorizer
+
+    published = _QueryAuthorizer(published_views=_SCOPED_VIEWS)
+    assert (
+        published(sqlite3.SQLITE_READ, "artifacts", "name", "main", "my_artifacts")
+        == sqlite3.SQLITE_OK
+    )
+    unpublished = _QueryAuthorizer()
+    assert (
+        unpublished(sqlite3.SQLITE_READ, "artifacts", "name", "main", "my_artifacts")
+        == sqlite3.SQLITE_DENY
     )

--- a/tests/test_query_scoping_team_mode.py
+++ b/tests/test_query_scoping_team_mode.py
@@ -171,13 +171,44 @@ def test_a_cte_cannot_impersonate_a_scoped_view(store, monkeypatch):
         ("my_execution_log", "execution_log"),
         ("my_artifacts", "artifacts"),
     ):
-        sql = f"WITH {view} AS (SELECT * FROM main.{table}) SELECT * FROM {view}"
-        with pytest.raises(PermissionError, match=view):
-            store.query(sql, scope=scope)
+        for quoted in (
+            view,
+            f'"{view}"',
+            f"[{view}]",
+            f"`{view}`",
+            f"'{view}'",
+        ):
+            sql = (
+                f"WITH {quoted} AS (SELECT * FROM main.{table}) "
+                f"SELECT * FROM {quoted}"
+            )
+            with pytest.raises(PermissionError, match=view):
+                store.query(sql, scope=scope)
+
+    # SQLite treats every non-ASCII code point as part of a bare identifier.
+    # A combining mark therefore used to stop the small lexer at the first,
+    # harmless CTE and hide the scoped shadow after the comma.
+    with pytest.raises(PermissionError, match="my_messages"):
+        store.query(
+            "WITH e\u0301 AS (SELECT 1), "
+            "my_messages AS (SELECT * FROM main.messages) "
+            "SELECT content FROM my_messages",
+            scope=scope,
+        )
 
     # The real view still answers, and still answers only for this session.
     rows = store.query("SELECT content FROM my_messages", scope=scope)
     assert [r["content"] for r in rows] == ["my own question"]
+
+    # A named WINDOW uses the same ``name AS (...)`` spelling but is not a
+    # CTE and cannot replace a scoped view. The guard must not reject valid
+    # SQLite syntax merely because the window happens to share a view name.
+    ranked = store.query(
+        "SELECT row_number() OVER my_messages AS n FROM my_frames "
+        "WINDOW my_messages AS (ORDER BY frame_id)",
+        scope=scope,
+    )
+    assert [row["n"] for row in ranked] == [1]
 
 
 def test_the_authorizer_refuses_a_view_name_nothing_published(monkeypatch):

--- a/tests/test_team_governance_routes.py
+++ b/tests/test_team_governance_routes.py
@@ -164,6 +164,116 @@ def test_project_members_see_each_other_but_not_private(daemon):
     assert _get(daemon.port, f"/api/v1/frames/{fid_priv}", cookie=r)[0] == 200
 
 
+@pytest.mark.stubbed_backend
+def test_project_member_cannot_control_another_members_kernel(daemon):
+    """Project visibility is read access, not shared namespace ownership."""
+
+    alice = _login(daemon, "alice", "fake-pw-a")
+    bob = _login(daemon, "bob", "fake-pw-b")
+    pid = _pid(daemon)
+    for name in ("alice", "bob"):
+        daemon.store.governance.set_member(pid, _uid(daemon, name), "member")
+    fid = _create_session(daemon, alice)
+    daemon.cfg.notebook_repl = True
+
+    called = []
+    daemon.runner.restart_kernel = lambda *args, **kwargs: called.append("restart")
+    daemon.runner.stop_kernel = lambda *args, **kwargs: called.append("stop")
+    daemon.runner.start_kernel = lambda *args, **kwargs: called.append("start")
+    daemon.runner.set_env = lambda *args, **kwargs: called.append("env")
+    daemon.runner.interrupt_kernel = lambda *args, **kwargs: called.append("interrupt")
+
+    # Positive control: Bob is a real project member and may read the session.
+    assert _get(daemon.port, f"/api/v1/frames/{fid}", cookie=bob)[0] == 200
+    for suffix, body in (
+        ("restart", {}),
+        ("stop", {}),
+        ("start", {}),
+        ("env", {"name": "struct"}),
+        (
+            "interrupt",
+            {"execution_id": "owner-run", "owner": {"kind": "agent", "id": "x"}},
+        ),
+    ):
+        status, raw = _post(
+            daemon.port,
+            f"/api/v1/frames/{fid}/kernel/{suffix}",
+            body,
+            cookie=bob,
+        )
+        assert status == 403, (suffix, raw[:200])
+        assert _body(raw).get("code") == "owner_only"
+    assert called == [], "a refused member must not reach a lifecycle method"
+
+
+@pytest.mark.stubbed_backend
+@pytest.mark.parametrize(
+    "username,password", [("alice", "fake-pw-a"), ("root", "fake-pw-r")]
+)
+def test_owner_and_admin_may_control_a_session_kernel(daemon, username, password):
+    alice = _login(daemon, "alice", "fake-pw-a")
+    caller = _login(daemon, username, password)
+    fid = _create_session(daemon, alice)
+    daemon.cfg.notebook_repl = True
+
+    daemon.runner.restart_kernel = lambda *args, **kwargs: {"ok": True}
+    daemon.runner.stop_kernel = lambda *args, **kwargs: {"ok": True}
+    daemon.runner.start_kernel = lambda *args, **kwargs: {"ok": True}
+    daemon.runner.set_env = lambda *args, **kwargs: {"ok": True}
+    daemon.runner.interrupt_kernel = lambda *args, **kwargs: {"ok": True}
+
+    for suffix, body in (
+        ("restart", {}),
+        ("stop", {}),
+        ("start", {}),
+        ("env", {"name": "struct"}),
+        (
+            "interrupt",
+            {"execution_id": "owner-run", "owner": {"kind": "agent", "id": "x"}},
+        ),
+    ):
+        status, raw = _post(
+            daemon.port,
+            f"/api/v1/frames/{fid}/kernel/{suffix}",
+            body,
+            cookie=caller,
+        )
+        assert status == 200, (username, suffix, raw[:200])
+
+
+@pytest.mark.stubbed_backend
+def test_frame_scoped_kernel_install_is_admin_only_in_team_mode(daemon):
+    alice = _login(daemon, "alice", "fake-pw-a")
+    root = _login(daemon, "root", "fake-pw-r")
+    fid = _create_session(daemon, alice)
+    called = []
+
+    def install(packages, **kwargs):
+        called.append(packages)
+        return {"ok": True, "installed": packages}
+
+    daemon.runner.install_packages = install
+
+    status, raw = _post(
+        daemon.port,
+        f"/api/v1/frames/{fid}/kernel/install",
+        {"package": "numpy"},
+        cookie=alice,
+    )
+    assert status == 403, raw[:200]
+    assert _body(raw).get("code") == "admin_only"
+    assert called == []
+
+    status, raw = _post(
+        daemon.port,
+        f"/api/v1/frames/{fid}/kernel/install",
+        {"package": "numpy"},
+        cookie=root,
+    )
+    assert status == 200, raw[:200]
+    assert called == [["numpy"]]
+
+
 def test_admin_read_of_private_session_is_audited_per_view(daemon):
     a = _login(daemon, "alice", "fake-pw-a")
     r = _login(daemon, "root", "fake-pw-r")

--- a/tests/test_team_isolation_hardening.py
+++ b/tests/test_team_isolation_hardening.py
@@ -705,3 +705,31 @@ def test_a_member_may_not_publish_a_global_specialist(daemon):
     assert status == 403, raw[:300]
     assert _body(raw)["code"] == "admin_only"
     assert daemon.store.get_agent("planted") is None
+
+
+def test_search_does_not_lose_your_own_hits_behind_colleagues(daemon):
+    """The palette filtered after `LIMIT 20`, so a full page of other people's
+    matches came back empty instead of showing yours.
+
+    Twenty-one sessions match; the twenty most recently updated are bob's, and
+    alice's is the oldest. Post-filtering drops all twenty and tells alice her
+    own session does not exist.
+    """
+    a = _login(daemon, "alice", "fake-pw-a")
+    b = _login(daemon, "bob", "fake-pw-b")
+
+    mine = _create_session(daemon, a)
+    daemon.store.update_frame(mine, name="RNA-seq run alice")
+    for index in range(20):
+        theirs = _create_session(daemon, b)
+        daemon.store.update_frame(theirs, name=f"RNA-seq run bob {index}")
+
+    status, raw = _get(daemon.port, "/api/v1/search?q=RNA-seq", cookie=a)
+    assert status == 200, raw[:200]
+    payload = _body(raw)
+    ids = {s.get("id") for s in payload.get("sessions", [])}
+    assert mine in ids, (
+        "alice's own matching session is missing; the visible page was spent "
+        "on rows she may not see"
+    )
+    assert not (ids - {mine}), f"a colleague's session leaked into the palette: {ids}"

--- a/tests/test_team_repository.py
+++ b/tests/test_team_repository.py
@@ -60,6 +60,49 @@ def test_duplicate_username_and_bad_role_refused(store):
         store.team.create_user(username="carol", password="")
 
 
+def test_compatibility_equivalent_usernames_are_refused(store):
+    """SQLite NOCASE is ASCII-only, while usernames name filesystem areas.
+
+    Kelvin sign normalizes to ``K`` under NFKC, so allowing both would create
+    two account rows for one portable/case-insensitive path identity.
+    """
+    store.team.create_user(username="K", password="test-password-not-real")
+    with pytest.raises(ValueError, match="already exists"):
+        store.team.create_user(username="K", password="other-fake-password")
+
+
+def test_an_upgraded_database_with_portable_username_collisions_fails_closed(
+    store,
+):
+    """Creation guards cannot repair conflicting rows from an older release."""
+    path = store.db_path
+    original = store.team.create_user(username="K", password="test-password-not-real")
+    row = store._conn.execute(
+        "SELECT password_hash, password_salt, iterations, created_at"
+        " FROM users WHERE id=?",
+        (original["id"],),
+    ).fetchone()
+    store._conn.execute(
+        "INSERT INTO users(id,username,display_name,role,password_hash,"
+        "password_salt,iterations,disabled,created_at) VALUES(?,?,?,?,?,?,?,0,?)",
+        (
+            "legacy_collision",
+            "K",
+            None,
+            "member",
+            row["password_hash"],
+            row["password_salt"],
+            row["iterations"],
+            row["created_at"] + 1,
+        ),
+    )
+    store._conn.commit()
+    store.close()
+
+    with pytest.raises(RuntimeError, match="same portable filesystem identity"):
+        get_store(path)
+
+
 def test_password_hash_never_stored_plaintext(store):
     store.team.create_user(username="alice", password="test-password-not-real")
     row = store._conn.execute(

--- a/tests/test_team_session_ownership.py
+++ b/tests/test_team_session_ownership.py
@@ -42,7 +42,15 @@ def _project_id(daemon) -> str:
     return str(daemon.store.list_projects()[0]["project_id"])
 
 
-def _create_session(daemon, cookie: str) -> str:
+def _create_session(daemon, cookie: str, *, name: str | None = None) -> str:
+    """A session, and by default a *named* one.
+
+    The listing hides "abandoned empty" sessions -- no messages, no cells, no
+    name -- so a bare frame is invisible to everybody including its owner.
+    The enumeration tests below then compared two empty sets and passed with
+    the ownership filter removed entirely; a name is the cheapest thing that
+    makes the row real.
+    """
     status, raw = _post(
         daemon.port,
         "/api/v1/frames",
@@ -52,6 +60,15 @@ def _create_session(daemon, cookie: str) -> str:
     assert status == 200, raw[:300]
     fid = _body(raw).get("frame_id") or _body(raw).get("id")
     assert fid
+    # The listing route hides "abandoned empty" sessions -- no messages, no
+    # cells, no name -- and an invisible row makes every assertion below
+    # vacuous. A *message* rather than a name, because `frames.name` is null
+    # in every other offline test and the frozen response shapes record it as
+    # null-only; naming sessions here would widen that contract for a reason
+    # that has nothing to do with the contract.
+    daemon.store.add_message(
+        root_frame_id=str(fid), role="user", content=name or "seeded activity"
+    )
     return str(fid)
 
 
@@ -73,11 +90,14 @@ def test_enumeration_is_ownership_filtered(daemon):
     status, raw = _get(daemon.port, "/api/v1/frames?project_id=all", cookie=a)
     assert status == 200
     ids = {f.get("frame_id") or f.get("id") for f in _body(raw)["frames"]}
-    assert fid_a in ids or ids == set()  # empty-session hiding may drop both
+    # The positive control first: without it `fid_b not in ids` is satisfied
+    # by an empty listing, which is what this assertion used to allow.
+    assert fid_a in ids, ids
     assert fid_b not in ids
 
     status, raw = _get(daemon.port, "/api/v1/frames?project_id=all", cookie=b)
     ids = {f.get("frame_id") or f.get("id") for f in _body(raw)["frames"]}
+    assert fid_b in ids, ids
     assert fid_a not in ids
 
 
@@ -205,3 +225,37 @@ def test_service_identity_sees_everything(daemon):
     fid_a = _create_session(daemon, a)
     status, _ = _get(daemon.port, f"/api/v1/frames/{fid_a}", token=daemon.token)
     assert status == 200
+
+
+def test_an_undecidable_creator_is_refused_not_admitted(daemon, monkeypatch):
+    """`team_policy`'s contract is "undecidable means refused", and its caller
+    was the exception.
+
+    `_may_create_session_in` reconstructed an identity from a bare user id and
+    read three different absences as the same permissive answer: the loopback
+    service (correct), a user id that is not an account, and a database that
+    would not answer. Only the first is a decision.
+    """
+    from openai4s.server import team_auth
+
+    runner = daemon.runner
+    project_id = _project_id(daemon)
+    alice = daemon.store.team.get_user_by_username("alice")["id"]
+
+    # The service identity is admin-equivalent by decision D2, and is
+    # recognised by its own constant rather than by failing to be found.
+    assert runner._may_create_session_in(project_id, team_auth.SERVICE_IDENTITY.user_id)
+    # A real member still gets the ordinary participation answer.
+    assert runner._may_create_session_in(project_id, alice) in (True, False)
+
+    # An id that is not an account is not "no restrictions".
+    assert not runner._may_create_session_in(project_id, "user_does_not_exist")
+
+    # Nor is a lookup that raised.
+    from openai4s.storage.team import TeamRepository
+
+    def _boom(self, user_id):
+        raise RuntimeError("team table unreadable")
+
+    monkeypatch.setattr(TeamRepository, "get_user", _boom)
+    assert not runner._may_create_session_in(project_id, alice)

--- a/tests/test_team_ws_isolation.py
+++ b/tests/test_team_ws_isolation.py
@@ -223,3 +223,59 @@ def test_cross_user_ws_cancel_is_refused(daemon):
         assert reply["reason"] == "session not found"
     finally:
         ws.close()
+
+
+def test_a_live_stream_stops_when_the_subscription_is_revoked(daemon, monkeypatch):
+    """Subscribing was checked once and never again.
+
+    `test_ws_subscription_stops_working_after_the_user_is_disabled` in
+    tests/test_team_isolation_hardening.py asserts that a *new* subscribe and
+    a *mutating* inbound are refused after revocation — which they were. The
+    standing subscription was not: `WSHub.broadcast` fanned out on
+    `root_frame_id in c.subs` alone, so the socket kept delivering cell code,
+    stdout and pending approval prompts to an account that had just been
+    disabled, for as long as the tab stayed open.
+
+    The re-check is cached for a few seconds so a chatty turn does not run an
+    ownership query per chunk per viewer; pinned to 0 here so the test is
+    about the rule and not about the clock.
+    """
+    from openai4s.server.gateway import WSConnection
+
+    monkeypatch.setattr(WSConnection, "_VIS_TTL_S", 0.0)
+
+    a = _login(daemon, "alice", "fake-pw-a")
+    fid_a = _session_for(daemon, a)
+
+    ws = _WSClient(daemon.port, a)
+    try:
+        ws.send({"type": "view_session", "root_frame_id": fid_a})
+        first = ws.recv_json()
+        assert first is not None and first["type"] != "view_denied"
+        while ws.recv_json(timeout=0.5) is not None:
+            pass
+
+        # Still hers: the broadcast arrives.
+        daemon.runner.hub.broadcast(fid_a, {"type": "frame_update", "frame_id": fid_a})
+        seen = []
+        while True:
+            msg = ws.recv_json(timeout=1.0)
+            if msg is None:
+                break
+            seen.append(msg)
+        assert any(m.get("type") == "frame_update" for m in seen), seen
+
+        # Revoked. The socket is still open and still subscribed.
+        uid = daemon.store.team.get_user_by_username("alice")["id"]
+        daemon.store.team.set_disabled(uid, True)
+
+        daemon.runner.hub.broadcast(fid_a, {"type": "frame_update", "frame_id": fid_a})
+        after = []
+        while True:
+            msg = ws.recv_json(timeout=1.0)
+            if msg is None:
+                break
+            after.append(msg)
+        assert not [m for m in after if m.get("type") == "frame_update"], after
+    finally:
+        ws.close()

--- a/tests/test_team_ws_isolation.py
+++ b/tests/test_team_ws_isolation.py
@@ -225,7 +225,84 @@ def test_cross_user_ws_cancel_is_refused(daemon):
         ws.close()
 
 
-def test_a_live_stream_stops_when_the_subscription_is_revoked(daemon, monkeypatch):
+@pytest.mark.stubbed_backend
+def test_project_member_may_view_but_cannot_cancel_the_owners_execution(daemon):
+    """Project visibility must not become an execution-control capability."""
+
+    alice = _login(daemon, "alice", "fake-pw-a")
+    bob = _login(daemon, "bob", "fake-pw-b")
+    pid = str(daemon.store.list_projects()[0]["project_id"])
+    for username in ("alice", "bob"):
+        user = daemon.store.team.get_user_by_username(username)
+        daemon.store.governance.set_member(pid, str(user["id"]), "member")
+    fid = _session_for(daemon, alice)
+
+    called = []
+    daemon.runner.cancel = lambda *args, **kwargs: called.append((args, kwargs)) or {
+        "ok": True
+    }
+
+    ws = _WSClient(daemon.port, bob)
+    try:
+        ws.send({"type": "view_session", "root_frame_id": fid})
+        first = ws.recv_json()
+        assert first is not None and first["type"] != "view_denied", first
+        while ws.recv_json(timeout=0.5) is not None:
+            pass
+
+        ws.send(
+            {
+                "type": "cancel_execution",
+                "root_frame_id": fid,
+                "execution_id": "owner-active-run",
+                "owner": "agent",
+                "owner_id": "owner-agent",
+            }
+        )
+        reply = ws.recv_json()
+        assert reply is not None
+        assert reply["type"] == "execution_cancel_result"
+        assert reply["ok"] is False
+        assert reply["code"] == "owner_only"
+        assert called == [], "a visible project member reached runner.cancel"
+    finally:
+        ws.close()
+
+
+@pytest.mark.stubbed_backend
+@pytest.mark.parametrize("username", ["alice", "root"])
+def test_owner_and_admin_may_cancel_an_execution_over_ws(daemon, username):
+    if username == "root":
+        daemon.seed_user("root", "fake-pw-r", role="admin")
+    alice = _login(daemon, "alice", "fake-pw-a")
+    caller = alice if username == "alice" else _login(daemon, "root", "fake-pw-r")
+    fid = _session_for(daemon, alice)
+    called = []
+
+    def cancel(*args, **kwargs):
+        called.append((args, kwargs))
+        return {"ok": True, "frame_id": fid}
+
+    daemon.runner.cancel = cancel
+    ws = _WSClient(daemon.port, caller)
+    try:
+        ws.send(
+            {
+                "type": "cancel_execution",
+                "root_frame_id": fid,
+                "execution_id": "owner-active-run",
+                "owner": "agent",
+                "owner_id": "owner-agent",
+            }
+        )
+        reply = ws.recv_json()
+        assert reply is not None and reply["ok"] is True, reply
+        assert len(called) == 1
+    finally:
+        ws.close()
+
+
+def test_a_live_stream_stops_when_the_subscription_is_revoked(daemon):
     """Subscribing was checked once and never again.
 
     `test_ws_subscription_stops_working_after_the_user_is_disabled` in
@@ -236,14 +313,10 @@ def test_a_live_stream_stops_when_the_subscription_is_revoked(daemon, monkeypatc
     stdout and pending approval prompts to an account that had just been
     disabled, for as long as the tab stayed open.
 
-    The re-check is cached for a few seconds so a chatty turn does not run an
-    ownership query per chunk per viewer; pinned to 0 here so the test is
-    about the rule and not about the clock.
+    A successful check is deliberately not cached: the next event must see a
+    revocation immediately under the production defaults, not only after a
+    test shortens an authorization TTL.
     """
-    from openai4s.server.gateway import WSConnection
-
-    monkeypatch.setattr(WSConnection, "_VIS_TTL_S", 0.0)
-
     a = _login(daemon, "alice", "fake-pw-a")
     fid_a = _session_for(daemon, a)
 
@@ -277,5 +350,6 @@ def test_a_live_stream_stops_when_the_subscription_is_revoked(daemon, monkeypatc
                 break
             after.append(msg)
         assert not [m for m in after if m.get("type") == "frame_update"], after
+
     finally:
         ws.close()

--- a/tests/test_worker_tcp_transport.py
+++ b/tests/test_worker_tcp_transport.py
@@ -27,7 +27,7 @@ from pathlib import Path
 import pytest
 
 from openai4s.kernel.manager import Kernel
-from openai4s.kernel.transport import OutboundTcpTransport
+from openai4s.kernel.transport import OutboundTcpTransport, WorkerConnectionRefused
 from openai4s.orchestration.bootstrap import (
     BootstrapAuthority,
     BootstrapCredential,
@@ -43,6 +43,19 @@ from openai4s.orchestration.worker_gateway import (
 )
 
 _WORKER = Path(__file__).resolve().parent.parent / "openai4s" / "kernel" / "worker.py"
+
+
+def test_remote_protocol_rejects_invalid_utf8_without_replacement():
+    local, peer = socket.socketpair()
+    transport = OutboundTcpTransport(local, peer="invalid-utf8")
+    try:
+        peer.sendall(b'{"type":"result","value":"\xff"}\n')
+        with pytest.raises(WorkerConnectionRefused, match="invalid UTF-8"):
+            transport.read_line()
+        assert transport.alive() is False
+    finally:
+        peer.close()
+        transport.close(graceful=False)
 
 
 # -- the credential -----------------------------------------------------------
@@ -583,10 +596,162 @@ def test_a_corrupt_fence_refuses_admission_rather_than_forgetting(tmp_path):
     # The replay the review reproduced.
     with pytest.raises(BootstrapError, match="could not be read"):
         revived.consume(burned)
-    # And nothing else is admitted either, since the fence cannot answer for
-    # any nonce.
+    # Issuance is a mutation too. Allowing it to rewrite the corrupt file with
+    # an empty in-memory fence would make a third daemon trust that empty file
+    # and re-admit `burned`.
+    corrupt = state.read_text(encoding="utf-8")
     with pytest.raises(BootstrapError, match="could not be read"):
-        revived.consume(revived.issue(allocation_id="alloc_2", epoch=0))
+        revived.issue(allocation_id="alloc_2", epoch=0)
+    assert state.read_text(encoding="utf-8") == corrupt
+
+    restarted = BootstrapAuthority(secret, state_path=state)
+    with pytest.raises(BootstrapError, match="could not be read"):
+        restarted.consume(burned)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        {"consumed": [], "epochs": {}},
+        {"consumed": {}, "epochs": []},
+        {"consumed": {"nonce": "tomorrow"}, "epochs": {}},
+        {"consumed": {}, "epochs": {"alloc_1": True}},
+        {"consumed": {}, "epochs": {}, "unexpected": True},
+    ],
+)
+def test_a_wrong_shaped_fence_fails_closed(tmp_path, payload):
+    """Valid JSON is not necessarily a valid authorization record. Missing
+    or mistyped fields must not silently become empty nonce/epoch maps."""
+    state = tmp_path / "fence.json"
+    state.write_text(json.dumps(payload), encoding="utf-8")
+    authority = BootstrapAuthority(load_or_mint_secret(tmp_path), state_path=state)
+
+    with pytest.raises(BootstrapError, match="could not be read"):
+        authority.issue(allocation_id="alloc_1", epoch=0)
+
+
+def test_a_failed_nonce_persistence_refuses_and_rolls_back(tmp_path, monkeypatch):
+    """No handshake may succeed unless its single-use burn is durable."""
+    import openai4s.orchestration.bootstrap as bootstrap
+
+    state = tmp_path / "fence.json"
+    secret = load_or_mint_secret(tmp_path)
+    authority = BootstrapAuthority(secret, state_path=state)
+    credential = authority.issue(allocation_id="alloc_1", epoch=0)
+    real_replace = bootstrap.os.replace
+    fail = True
+
+    def replace(source, target):
+        if fail:
+            raise OSError("disk full")
+        return real_replace(source, target)
+
+    monkeypatch.setattr(bootstrap.os, "replace", replace)
+    with pytest.raises(BootstrapError, match="could not persist"):
+        authority.consume(credential)
+
+    # The failed operation was refused, not half-published in memory. A retry
+    # after storage recovers remains legitimate and is then burned durably.
+    authority.verify(credential)
+    fail = False
+    authority.consume(credential)
+    restarted = BootstrapAuthority(secret, state_path=state)
+    with pytest.raises(BootstrapError, match="already been used"):
+        restarted.consume(credential)
+
+
+def test_a_failed_fence_directory_fsync_refuses_the_nonce(tmp_path, monkeypatch):
+    """Replacing the JSON is not durable until its directory entry is synced.
+
+    The shared helper intentionally swallows unsupported directory fsyncs, but
+    doing that for a replay fence acknowledges a nonce that a power loss can
+    un-burn. This boundary must propagate the failure.
+    """
+    import openai4s.orchestration.bootstrap as bootstrap
+
+    state = tmp_path / "fence.json"
+    secret = load_or_mint_secret(tmp_path)
+    authority = BootstrapAuthority(secret, state_path=state)
+    credential = authority.issue(allocation_id="alloc_1", epoch=0)
+    real_fsync = bootstrap._strict_fsync_dir
+
+    def fail_fsync(directory):
+        raise OSError("directory sync failed")
+
+    monkeypatch.setattr(bootstrap, "_strict_fsync_dir", fail_fsync)
+    with pytest.raises(BootstrapError, match="could not persist"):
+        authority.consume(credential)
+
+    # Rename already happened, so memory and disk may now disagree about
+    # which fence survives a power loss. The live authority must lock closed;
+    # a restart reloads the complete candidate and conservatively keeps the
+    # nonce burned even though the handshake was refused.
+    monkeypatch.setattr(bootstrap, "_strict_fsync_dir", real_fsync)
+    with pytest.raises(BootstrapError, match="durability is uncertain"):
+        authority.consume(credential)
+    restarted = BootstrapAuthority(secret, state_path=state)
+    with pytest.raises(BootstrapError, match="already been used"):
+        restarted.consume(credential)
+
+
+def test_an_uncertain_epoch_publish_cannot_reopen_the_old_epoch(tmp_path, monkeypatch):
+    import openai4s.orchestration.bootstrap as bootstrap
+
+    state = tmp_path / "fence.json"
+    secret = load_or_mint_secret(tmp_path)
+    authority = BootstrapAuthority(secret, state_path=state)
+    old = authority.issue(allocation_id="alloc_1", epoch=1)
+    real_fsync = bootstrap._strict_fsync_dir
+
+    def fail_fsync(_directory):
+        raise OSError("directory sync failed")
+
+    monkeypatch.setattr(bootstrap, "_strict_fsync_dir", fail_fsync)
+
+    with pytest.raises(BootstrapError, match="could not persist"):
+        authority.issue(allocation_id="alloc_1", epoch=2)
+
+    monkeypatch.setattr(bootstrap, "_strict_fsync_dir", real_fsync)
+    with pytest.raises(BootstrapError, match="durability is uncertain"):
+        authority.issue(allocation_id="alloc_1", epoch=1)
+
+    restarted = BootstrapAuthority(secret, state_path=state)
+    with pytest.raises(BootstrapError, match="STALE_EPOCH"):
+        restarted.consume(old)
+
+
+def test_a_failed_epoch_persistence_does_not_publish_the_new_fence(
+    tmp_path, monkeypatch
+):
+    import openai4s.orchestration.bootstrap as bootstrap
+
+    state = tmp_path / "fence.json"
+    secret = load_or_mint_secret(tmp_path)
+    authority = BootstrapAuthority(secret, state_path=state)
+    stale = authority.issue(allocation_id="alloc_1", epoch=0)
+    real_replace = bootstrap.os.replace
+    fail = True
+
+    def replace(source, target):
+        if fail:
+            raise OSError("read-only filesystem")
+        return real_replace(source, target)
+
+    monkeypatch.setattr(bootstrap.os, "replace", replace)
+    with pytest.raises(BootstrapError, match="could not persist"):
+        authority.issue(allocation_id="alloc_1", epoch=1)
+
+    # Epoch 1 was not issued, so the in-memory authority remains at epoch 0.
+    authority.verify(stale)
+    fail = False
+    authority.issue(allocation_id="alloc_1", epoch=1)
+    with pytest.raises(BootstrapError, match="STALE_EPOCH"):
+        authority.consume(stale)
+
+    restarted = BootstrapAuthority(secret, state_path=state)
+    with pytest.raises(BootstrapError, match="STALE_EPOCH"):
+        restarted.consume(stale)
 
 
 def test_a_missing_fence_is_still_an_empty_fence(tmp_path):

--- a/tests/test_ws_resume_cursor.py
+++ b/tests/test_ws_resume_cursor.py
@@ -32,6 +32,15 @@ class _Conn:
     def send_json(self, obj):
         self.sent.append(obj)
 
+    # Team mode re-checks visibility per delivery: the hub refreshes outside
+    # its lock and then asks. A daemon with no team mode has no check to run,
+    # which is what these two answer.
+    def refresh_visibility(self, root_frame_id):
+        return None
+
+    def may_receive(self, root_frame_id):
+        return True
+
 
 def _chunks(conn):
     return [e["d"] for e in conn.sent if e.get("type") == "text_chunk"]


### PR DESCRIPTION
## Summary

Fixes the defects found by two max-effort review passes over `next`, plus a
third answering an external review. No feature work, no renames: every change
either closes a hole or deletes a second copy of a rule.

The severe ones, in order:

- **`host.query` was not scoped in team mode.** The authorizer's fifth
  argument names "the view responsible for this read", and SQLite fills it in
  for a *CTE* exactly as it does for a view — so `WITH my_messages AS (SELECT
  * FROM main.messages) SELECT ...` returned every colleague's prompts,
  replies, cell code and stdout. Reproduced against the real Store. A CTE may
  no longer be named after a scoped view, and the authorizer only honours a
  view the statement actually published.
- **The worker-bootstrap signing secret was readable from a cell.** It is a
  sibling of `openai4s.db`, like `access-token`, and was missing from
  `_default_secret_read_denials`. `BootstrapAuthority.verify` is pure HMAC +
  expiry + epoch + nonce, so those 32 bytes mint a credential for any
  allocation — i.e. arbitrary Host RPC inside another tenant's session.
- **`POST /frames/{id}/decision` accepted `scope: "global"` from a member**,
  planting the standing rule `POST /permissions` returns 403 for.
- **Cluster cells wrote where artifact capture never looked.** The kernel ran
  in the workload's directory; capture, the Host dispatcher and the R kernel
  stayed on `agent-workspaces/<root>`. No Artifact, no version, no lineage,
  and no error either.
- **`SlurmBackend.submit` inverted INV-8**, reading an unreachable scheduler
  as "nothing carries this token" and submitting a second job.
- **The watchdog claimed a reset that had been refused** — for a worker this
  daemon did not spawn, the interpreter is untouched and the cell may still be
  running on its allocation.

Also: WebSocket fan-out never re-checked a standing subscription; `Alice` and
`alice` shared one directory on a case-insensitive filesystem; the guest gate
ran after the auth routes; `redeem-invite` was an unauthenticated username
oracle; `/search` filtered after `LIMIT`; `_may_create_session_in` read three
kinds of "I do not know" as permission; the py3.10 TOML fallback killed the
cluster backend on the `requires-python` floor; `default_backend` never left
"local"; `Workload.backend` was a `setattr`; `Reconciler.recover` was a
second, non-atomic recovery with no production caller (deleted — the INV-6/7
test now drives `tick()`); the fence file was published without an fsync while
an unparseable fence failed admission closed *permanently*.

Every behavioural fix carries a regression test **verified to fail without
it** — by reverting the fix and re-running, or by mutating the code under
test. Two harness goldens had frozen missing events as expected behaviour and
are updated. Two pre-existing tests were vacuous (comparing two empty sets;
a `raises(Exception)` that could not tell "refused" from "no such table") and
now carry positive controls.

## Area

- [x] Agent / loop / delegation
- [x] Kernel / host RPC / runtime
- [x] Server / gateway / API
- [x] Store / provenance / artifacts
- [x] Compute / remote execution
- [x] Tests / harness / CI
- [x] Docs

## Change Type

- [x] Bug fix
- [x] Test / harness
- [x] Security-related change

## Verification

Ran:

```text
uv run pytest                                           # full offline suite, green
uv run pre-commit run --all-files                       # black, isort, ruff, mypy — all pass
uv run python -m harness.cli run --tier pr --offline    # 15/15
uv run python scripts/check_directory_readmes.py        # 107 dirs, complete bilingual coverage
python scripts/source_secret_scan.py                    # 1137 files, passed
uv run python scripts/capture_response_contract.py --check   # 183/183 routes
uv run python scripts/capture_response_schemas.py --check    # 183/183 covered, no breaking change
uv run python scripts/reaudit_crosswalk.py --check      # 48 closed rows, evidence unchanged
```

Falsification (each fix reverted or mutated, test re-run, confirmed red, restored):

```text
tests/test_query_scoping_team_mode.py::test_a_cte_cannot_impersonate_a_scoped_view
tests/test_cluster_session_production_wiring.py::test_the_session_workspace_follows_the_placement
tests/test_cluster_session_production_wiring.py::test_r_is_refused_on_a_cluster_session
tests/test_cluster_session_production_wiring.py::test_a_backend_that_will_not_answer_is_unknown_not_absent
tests/test_team_session_ownership.py::test_an_undecidable_creator_is_refused_not_admitted
tests/test_team_isolation_hardening.py::test_search_does_not_lose_your_own_hits_behind_colleagues
tests/test_orchestration_reconciler.py::test_recovery_is_a_new_epoch_not_a_rewrite
```

Not run:

```text
node tests/browser_smoke.mjs
node tests/browser_team_mode.mjs
node tests/browser_matrix.mjs --browser=firefox
bash scripts/container_smoke.sh
uv build && scripts/verify_release_artifacts.py dist
```

Reason:

```text
The browser gates need Playwright plus a daemon already serving on
127.0.0.1:8760; the container gate needs Docker; neither is available in this
environment. The release-artifact check is a cross-build here (no Linux
container), which this repo's own notes say is never "verified". CI runs all
of them. The WebSocket revocation fix in particular is the one a reviewer
should want browser evidence for — see below.
```

## Risk and Reviewer Focus

**This PR is not small.** 46 files, +1567/−234. It is single-*purpose* (the
review's findings) but not single-concern, and the changes interleave inside
`gateway.py`, so splitting it would have produced intermediate commits I had
not verified. Reviewing it as one unit is the honest ask.

Look first at:

1. `openai4s/store.py` — the CTE guard and the `published_views` layer. This
   is the tenant boundary for `host.query`; a text pre-check plus a
   parse-time check, deliberately two layers.
2. `openai4s/server/gateway.py` — `_sync_placement_workspace` (a session's
   workspace now follows its cluster placement, and returns on release) and
   `WSConnection.may_receive` / `refresh_visibility`. The visibility re-check
   is cached for 5s and refreshed **outside** the hub lock on purpose: doing
   the read under it would take the store lock while holding the hub lock,
   inverting the order every producer that broadcasts from a store operation
   already uses.
3. `openai4s/execution/watchdog.py` + `server/cell_run.py` — a new
   `KernelNotResetTimeout` (a `TimeoutError` subclass, so every existing
   `except TimeoutError` still catches it) and the user-facing wording that
   follows it.
4. `openai4s/orchestration/slurm/profiles.py` — the py3.10 TOML fallback now
   agrees with `tomllib` on trailing comments and quoted dotted keys. Both
   readers are production paths.

Behaviour changes a reviewer may want to argue with, all deliberate:

- `default_backend` becomes `"cluster"` once a cluster backend registers.
  Previously every unqualified member submission was 403'd on a cluster
  daemon. The local backend stays reachable by name.
- R is now **refused** on a cluster session, matching what
  `host.exec_background` already does. Riding the remote worker would be a
  feature; this is the honest bounded option.
- Usernames are now case-insensitively unique. Existing installs that already
  have `Alice` and `alice` keep both — this stops new collisions, it does not
  retroactively fix one.
- `POST /team/quotas` now 400s on a missing `limit_amount` instead of quietly
  installing a quota of zero.

**Still open, and a product decision rather than a bug:**
`PRIVILEGED_BACKENDS = {"local"}` rests on the premise that a scheduler runs
the job under the submitting user's account. `SlurmBroker` runs
`subprocess.run(["sbatch", ...])` inside the daemon process — there is no
impersonation anywhere in `openai4s/orchestration/` — and
`docs/team-server.md` currently states the opposite. Either submit as the
member, or classify cluster backends as privileged too and correct the doc.
I did not choose for you.

## Checklist

### Diff Readiness

- [x] I reviewed and understand the full diff.
- [ ] This PR is small and single-purpose. — single-purpose, not small; see above.
- [x] No unrelated formatting, broad rewrite, or drive-by refactor is included.
- [x] Hotspot files were edited surgically if touched: `gateway.py`,
      `host_dispatch.py`, `store.py`, `app.js`, `worker.py`, `manager.py`.
- [x] `openai4s/server/webui/vendor/` and `tests/fixtures/` were not
      reformatted.

### Tests

- [x] Relevant tests or manual checks were run and listed above.
- [x] No new test requires live LLM, network, GPU, SSH, Docker, lab hardware,
      or secrets in the default offline suite.
- [x] No tests were deleted without tracked replacements.
- [x] Kernel / host-RPC / gateway changes include focused contract coverage or
      a documented smoke test.

### Core Dependency Policy

- [x] No hard third-party import was added to the core engine, LLM client, or
      stdlib web server.
- [x] Optional science imports are guarded by `try/except ImportError` at every
      in-tree use site.
- [x] New dependencies, if any, are documented and justified. — none added.

### Public Disclosure and Security

- [x] No secrets, API keys, tokens, real credentials, private data, model
      weights, or local absolute paths are included.
- [x] No unpublished research roadmap, internal assignment, benchmark detail,
      or unreleased experimental result is disclosed.
- [x] Security-sensitive changes include appropriate synthetic tests or manual
      verification notes.
- [x] Docs do not overstate isolation, sandboxing, privacy, or security
      guarantees. — `docs/team-server.md` corrected: it documented
      `OPENAI4S_ALLOWED_HOSTS`, which does not exist in the code.

### Docs

- [x] Docs match actual code behavior.
- [x] User-facing behavior changes are reflected in docs or release notes where
      appropriate.
- [x] `README.md` and `README_zh.md` stay in sync where translated sections are
      affected. — root READMEs untouched; `docs/team-server.md` and its `_zh`
      pair were corrected together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
