### PR TITLE
fix(release): install uv in the windows-package job before its receipt step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -480,6 +480,13 @@ jobs:
         with:
           name: linux-app-bundle
           path: dist/
+      # The receipt step below runs `uv run --locked`, and this job never
+      # installed uv — which nothing noticed for as long as the pipeline was
+      # unreachable, and the first complete dispatch (v0.2.0 pypi_only, run
+      # 32831018097) died here with `uv: command not found` after every build
+      # had succeeded.
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       - name: Build the .zip
         run: bash scripts/build_windows_zip.sh
       - name: Verify the package


### PR DESCRIPTION
## Summary

The v0.2.0 `pypi_only` dispatch ([run 32831018097](https://github.com/PKU-YuanGroup/OpenAI4S/actions/runs/32831018097)) failed in **Build the Windows package**: its receipt step runs `uv run --locked`, and `windows-package` was the only uv-calling job in `release.yml` with no `setup-uv` step — invisible for as long as the pipeline was unreachable, fatal on the first complete dispatch. Everything before it (guard in the new pypi_only mode, freeze, quality, build, linux-app, macos-app) succeeded, and `!failure()` correctly blocked `pypi`.

One step added: the same pinned `astral-sh/setup-uv` the `linux-app` job uses, placed before the build/receipt steps.

After merging: re-dispatch `release.yml` with `tag=v0.2.0`, `pypi_only=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)