### PR TITLE
chore(deps): update Python image, formatting hooks, and CodeQL action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,6 +52,13 @@ updates:
       # read on its own, not merged as one row of a version table (black
       # 23.3.0 -> 26.5.1 reformatted 234 files).
       #
+      # isort is out for the same reason, learned the same way: 8.0.1 -> 9.0.1
+      # arrived as one row of a two-row version table, reformatted five files --
+      # two of them the `store.py` and `kernel/worker.py` facades CLAUDE.md says
+      # to edit surgically -- and needed a hand-written directive to settle a
+      # disagreement it opened with black. It is the other formatter `setup.sh`
+      # installs on every contributor machine.
+      #
       # `exclude-patterns`, not `update-types`, because this ecosystem cannot
       # evaluate `update-types`. Dependabot resolves pre-commit hooks as git
       # refs and does not semver-classify them: every hook bump it has opened
@@ -63,7 +70,9 @@ updates:
       # it was meant to stop kept arriving and kept being consolidated by hand.
       hook-versions:
         patterns: ["*"]
-        exclude-patterns: ["https://github.com/psf/black"]
+        exclude-patterns:
+          - "https://github.com/psf/black"
+          - "https://github.com/pycqa/isort"
     open-pull-requests-limit: 3
 
   - package-ecosystem: "github-actions"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -53,7 +53,7 @@ jobs:
       # `tests/test_ci_gate_independence.py` pins for ci.yml, which is scoped
       # to that file and cannot see this one.
       - name: Upload to code scanning
-        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: results.sarif
       # `always()` so the run that failed is the one whose SARIF you can still

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       - id: check-merge-conflict
         args: ['--assume-in-merge']
   - repo: https://github.com/pycqa/isort
-    rev: a333737ed43df02b18e6c95477ea1b285b3de15a  # frozen: 8.0.1
+    rev: 131f4adcd5582bfc53928ab0d740eceb8b506b6c  # frozen: 9.0.1
     hooks:
       - id: isort
         args: ["--profile", "black"]
@@ -31,7 +31,7 @@ repos:
   # arrived and a bare `ruff` became ambiguous. The rule set is pinned in
   # pyproject.toml's [tool.ruff.lint]; see the comment there for why.
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: aab412d509121cb5f7533134b7e67f9fab59c682  # frozen: v0.16.4
+    rev: 321478e58f4938179c6b86e4ddfa923d1547a49b  # frozen: v0.16.6
     hooks:
       - id: ruff-check
         args: [--fix, "--ignore=E501,F401,E722,E402,E741"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@
 # `.github/workflows/ci.yml`'s offline matrix and in
 # `scripts/release_gates.py` CHECK_SUITE_GATES; `tests/test_platform_support.py`
 # reads this FROM line rather than restating the series.
-FROM python:3.14-slim-bookworm@sha256:416f0db2a2b561945630cef9877a7ea0581b27449eb9fd9df42f03e1b74b5b63 AS builder
+FROM python:3.14-slim-bookworm@sha256:9ab8d9c8514b44f90cf0029dd42fdd7e9e211e639c8b995304cc04568dee900f AS builder
 
 WORKDIR /src
 # The build backend first, in its own layer: it changes only when the pin in
@@ -49,7 +49,7 @@ RUN python -m pip wheel --no-cache-dir --no-deps --no-build-isolation \
         --wheel-dir /wheels /src
 
 # --- runtime stage -----------------------------------------------------------
-FROM python:3.14-slim-bookworm@sha256:416f0db2a2b561945630cef9877a7ea0581b27449eb9fd9df42f03e1b74b5b63 AS runtime
+FROM python:3.14-slim-bookworm@sha256:9ab8d9c8514b44f90cf0029dd42fdd7e9e211e639c8b995304cc04568dee900f AS runtime
 
 # `science` installs numpy/pandas/matplotlib/scikit-learn so agent cells can do
 # actual work. Pass `--build-arg OPENAI4S_EXTRAS=` for the stdlib-only control

--- a/openai4s/kernel/worker.py
+++ b/openai4s/kernel/worker.py
@@ -58,15 +58,12 @@ if (
 ):
     sys.path.insert(0, _TRUSTED_PACKAGE_PARENT)
 
-from openai4s.kernel.protocol import (  # noqa: E402 - trusted path fixed above
+# The trusted package path must be fixed before importing the protocol.
+from openai4s.kernel.protocol import (  # noqa: E402
     JSON_WORST_BYTES_PER_CHAR as _JSON_WORST_BYTES_PER_CHAR,
 )
-from openai4s.kernel.protocol import (  # noqa: E402 - trusted path fixed above
-    MAX_FRAME_BYTES as _MAX_FRAME_BYTES,
-)
-from openai4s.kernel.protocol import (  # noqa: E402 - trusted path fixed above
-    MAX_OUTPUT_CHARS as MAX_OUTPUT,
-)
+from openai4s.kernel.protocol import MAX_FRAME_BYTES as _MAX_FRAME_BYTES  # noqa: E402
+from openai4s.kernel.protocol import MAX_OUTPUT_CHARS as MAX_OUTPUT  # noqa: E402
 
 _DISCARD_BUDGET = 8  # bounded discard for desync
 _HOST_CALL_WIRE_CAP = 15_000_000  # 15MB host_call payload cap

--- a/openai4s/kernel/worker.py
+++ b/openai4s/kernel/worker.py
@@ -52,13 +52,17 @@ from functools import partial
 _TRUSTED_PACKAGE_PARENT = os.path.dirname(
     os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 )
+# This must run before the protocol import below: those imports are
+# deliberately not at the top of the file, which is what their per-line
+# suppression comments record. Keep those comments short -- isort sizes such a
+# statement without its trailing comment while Black sizes it with, so a long
+# one makes the two rewrap the line forever.
 if (
     os.path.isfile(os.path.join(_TRUSTED_PACKAGE_PARENT, "openai4s", "__init__.py"))
     and _TRUSTED_PACKAGE_PARENT not in sys.path
 ):
     sys.path.insert(0, _TRUSTED_PACKAGE_PARENT)
 
-# The trusted package path must be fixed before importing the protocol.
 from openai4s.kernel.protocol import (  # noqa: E402
     JSON_WORST_BYTES_PER_CHAR as _JSON_WORST_BYTES_PER_CHAR,
 )

--- a/openai4s/kernel/worker.py
+++ b/openai4s/kernel/worker.py
@@ -52,11 +52,20 @@ from functools import partial
 _TRUSTED_PACKAGE_PARENT = os.path.dirname(
     os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 )
-# This must run before the protocol import below: those imports are
-# deliberately not at the top of the file, which is what their per-line
-# suppression comments record. Keep those comments short -- isort sizes such a
-# statement without its trailing comment while Black sizes it with, so a long
-# one makes the two rewrap the line forever.
+# This must run before the protocol imports below, which is why they are not at
+# the top of the file and why each carries a suppression comment. Unlike the
+# retrosynthesis test's, these are load-bearing: the insert sits inside an `if`,
+# so ruff's allowance for imports after a sys.path mutation does not apply and
+# stripping them really does raise E402.
+#
+# Keep them short. `combine_as_imports` is off, so isort renders each aliased
+# name as its own one-line statement and then decides to collapse on the code
+# alone, while Black measures the same line with the comment -- put the two on
+# opposite sides of 88 and they rewrap it against each other forever. Only the
+# aliased imports here are exposed, and only while they stay collapsed:
+# `_MAX_FRAME_BYTES` is 72 characters of code, so its trailing comment may be 16
+# and is 14. The first import is already past 88 on code alone, so it stays
+# wrapped and is not exposed at all.
 if (
     os.path.isfile(os.path.join(_TRUSTED_PACKAGE_PARENT, "openai4s", "__init__.py"))
     and _TRUSTED_PACKAGE_PARENT not in sys.path

--- a/openai4s/orchestration/bootstrap.py
+++ b/openai4s/orchestration/bootstrap.py
@@ -49,10 +49,7 @@ from openai4s.security.permissions import (
     FILE_MODE,
 )
 from openai4s.security.permissions import fsync_dir as _fsync_dir
-from openai4s.security.permissions import (
-    harden_dir,
-    harden_file,
-)
+from openai4s.security.permissions import harden_dir, harden_file
 
 #: Filename of the per-daemon signing secret, under the data dir.
 SECRET_FILENAME = "worker-bootstrap-secret"

--- a/openai4s/store.py
+++ b/openai4s/store.py
@@ -128,9 +128,7 @@ from openai4s.storage.model_capability_receipts import (
 from openai4s.storage.permissions import (
     DEFAULT_PERMISSION_RULES as _DEFAULT_PERMISSION_RULES,
 )
-from openai4s.storage.permissions import (
-    PermissionRuleRepository,
-)
+from openai4s.storage.permissions import PermissionRuleRepository
 from openai4s.storage.permissions import perm_match as _perm_match
 from openai4s.storage.plans import PlanRepository
 from openai4s.storage.recovery import RecoveryJournalRepository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -227,11 +227,19 @@ line-length = 88
 # in the repository where the other two blocks already keep theirs.
 #
 # `profile` restates the hook's `--profile black` so that a bare `isort .` -- the
-# default an editor integration runs -- agrees with the gate instead of emitting
-# a diff the gate then reverts. `py_version` states the union-across-versions
-# default explicitly, which is the correct one for a `requires-python = ">=3.10"`
-# package that CI runs on 3.10 through 3.14; narrowing it to the floor would
-# misfile a module that only became stdlib later.
+# default an editor integration runs -- lays imports out the way the gate does,
+# instead of emitting a diff the gate then reverts. It does not make that run
+# safe, and nothing here can: the byte-exact trees are guarded only by
+# pre-commit's own `exclude:`, so a bare `isort .` still rewrites 318 of the 408
+# pinned files under `skills/bioskills/`. Mirroring those paths into a `skip`
+# here would not reach the gate either -- the hook's `args:` replaces the
+# upstream manifest's `--filter-files`, and without it isort ignores `skip` for
+# files named on the command line, which is the only way pre-commit invokes it.
+#
+# `py_version` states the union-across-versions default explicitly, which is the
+# correct one for a `requires-python = ">=3.10"` package that CI runs on 3.10
+# through 3.14; narrowing it to the floor would misfile `tomllib`, which this
+# repository imports and which only became stdlib in 3.11.
 #
 # Like the black block, this changes no output: the tree is byte-identical with
 # and without it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,6 +211,34 @@ markers = [
 target-version = ["py310"]
 line-length = 88
 
+[tool.isort]
+# Same reason as the block above and the one below: state the setting instead of
+# inheriting whatever the pinned formatter happens to compute. isort was the one
+# formatter of the three with no section here -- its entire configuration was
+# `--profile black` on the hook's command line -- so everything the profile does
+# not name was whatever the pinned version shipped, across an 8.0.1 -> 9.0.1
+# major that moved exactly those defaults.
+#
+# `src_paths` is the load-bearing entry. It defaults to `(cwd/"src", cwd)`, so
+# first-party detection was a property of the process rather than of the
+# repository: run isort from anywhere but the repo root and `openai4s` is
+# demoted to third-party, which moves the section breaks. A relative path in a
+# config file resolves against that file's directory, which puts the answer back
+# in the repository where the other two blocks already keep theirs.
+#
+# `profile` restates the hook's `--profile black` so that a bare `isort .` -- the
+# default an editor integration runs -- agrees with the gate instead of emitting
+# a diff the gate then reverts. `py_version` states the union-across-versions
+# default explicitly, which is the correct one for a `requires-python = ">=3.10"`
+# package that CI runs on 3.10 through 3.14; narrowing it to the floor would
+# misfile a module that only became stdlib later.
+#
+# Like the black block, this changes no output: the tree is byte-identical with
+# and without it.
+profile = "black"
+py_version = "3"
+src_paths = ["."]
+
 [tool.ruff.lint]
 # State the rule set instead of inheriting whatever the pinned ruff calls its
 # default. Until now there was no [tool.ruff] section at all, so the rule set

--- a/tests/test_orchestration_slurm.py
+++ b/tests/test_orchestration_slurm.py
@@ -47,9 +47,7 @@ from openai4s.orchestration.slurm import (
     SubmitSpec,
 )
 from openai4s.orchestration.slurm import broker as broker_mod
-from openai4s.orchestration.slurm import (
-    parse_cluster_config,
-)
+from openai4s.orchestration.slurm import parse_cluster_config
 from openai4s.orchestration.slurm.broker import StepSpec
 from openai4s.orchestration.slurm.profiles import (
     EXAMPLE_CLUSTER_TOML,

--- a/tests/test_retrosynthesis_scenario_protocols.py
+++ b/tests/test_retrosynthesis_scenario_protocols.py
@@ -74,7 +74,9 @@ from retrosynthesis_planning.reproducibility_bundle import (  # noqa: E402
     build_reproducibility_bundle,
 )
 from retrosynthesis_planning.route_review import route_similarity  # noqa: E402
-from retrosynthesis_planning.scenario_benchmark_cli import (  # noqa: E402
+
+# Keep the noqa here: isort 9 and Black otherwise move it back and forth.
+from retrosynthesis_planning.scenario_benchmark_cli import (  # noqa: E402; isort: skip
     main as scenario_cli_main,
 )
 from retrosynthesis_planning.yield_benchmark import (  # noqa: E402

--- a/tests/test_retrosynthesis_scenario_protocols.py
+++ b/tests/test_retrosynthesis_scenario_protocols.py
@@ -75,10 +75,12 @@ from retrosynthesis_planning.reproducibility_bundle import (  # noqa: E402
 )
 from retrosynthesis_planning.route_review import route_similarity  # noqa: E402
 
-# Keep the noqa here: isort 9 and Black otherwise move it back and forth.
-from retrosynthesis_planning.scenario_benchmark_cli import (  # noqa: E402; isort: skip
-    main as scenario_cli_main,
-)
+# This one import carries no trailing suppression comment, unlike its
+# neighbours. isort sizes the collapsed statement at 84 characters because it
+# does not count a trailing comment, while Black sizes the line it emits at 98
+# and wraps it again -- so the pair never reaches a fixed point. None is needed
+# here: ruff exempts imports that follow the sys.path mutation above.
+from retrosynthesis_planning.scenario_benchmark_cli import main as scenario_cli_main
 from retrosynthesis_planning.yield_benchmark import (  # noqa: E402
     SPLITS,
     evaluate_yield_predictions,

--- a/tests/test_retrosynthesis_scenario_protocols.py
+++ b/tests/test_retrosynthesis_scenario_protocols.py
@@ -75,11 +75,19 @@ from retrosynthesis_planning.reproducibility_bundle import (  # noqa: E402
 )
 from retrosynthesis_planning.route_review import route_similarity  # noqa: E402
 
-# This one import carries no trailing suppression comment, unlike its
-# neighbours. isort sizes the collapsed statement at 84 characters because it
-# does not count a trailing comment, while Black sizes the line it emits at 98
-# and wraps it again -- so the pair never reaches a fixed point. None is needed
-# here: ruff exempts imports that follow the sys.path mutation above.
+# No trailing suppression comment on this one, unlike its neighbours -- with one
+# the two formatters never agree about it. `combine_as_imports` is off, so isort
+# renders an aliased name as its own one-line statement whatever the trailing
+# comma says, then decides to collapse on the code alone: 84 characters, inside
+# the 88 limit. Black measures the line isort emitted, comment included: 98,
+# outside it, so Black wraps it back. Neither budges, and every hook run reports
+# the file as modified. It is the alias that opens this, not the length: a plain
+# name with the same 84 characters keeps its trailing comma and is left alone.
+#
+# Dropping the comment costs nothing. The suppression was already inert -- ruff
+# exempts imports that follow the sys.path mutation above, so this file is clean
+# with the rule explicitly selected. Its neighbours keep theirs only because
+# rewriting all fifteen is a separate change.
 from retrosynthesis_planning.scenario_benchmark_cli import main as scenario_cli_main
 from retrosynthesis_planning.yield_benchmark import (  # noqa: E402
     SPLITS,


### PR DESCRIPTION
## Summary

Update the container and development/CI dependencies together. This PR supersedes #148, #149, and #150.

| Dependency | Previous | Updated |
| --- | --- | --- |
| Python 3.14 slim-bookworm image, both stages | `416f0db…` | `9ab8d9c…` |
| isort | 8.0.1 | 9.0.1 |
| Ruff | 0.16.4 | 0.16.6 |
| CodeQL SARIF upload action | 4.37.8 | 4.37.9 |

The isort upgrade requires import formatting in five Python files. It also exposes an isort/Black loop on two commented alias imports: shorten the worker's inline comments while preserving the trusted-path explanation, and apply a documented, single-import `isort: skip` in the scenario test. All five Python files retain identical ASTs. Frozen dependency identities, the existing E/F lint rule selection, and the Python 3.10 formatting target remain intact.

## Area and Change Type

- [x] CLI / config / packaging
- [x] Tests / harness / CI
- [x] Dependency maintenance and formatter compatibility fix

## Verification

Passed locally:

```text
uv sync --locked
uv run --offline --no-sync pytest -n auto --maxprocesses=4 --dist loadfile
uv run pre-commit run --all-files
uv run mypy
uv run python -m harness.cli run --tier pr --offline
uv run python scripts/check_directory_readmes.py
uv run python scripts/capture_response_contract.py --check
uv run python scripts/source_secret_scan.py
git diff --check origin/main...HEAD
```

Full offline suite: **8,494 passed, 50 skipped, 2 warnings** on Python 3.13.13 (481.99 seconds).

The harness passed all 38 scenarios; the route contract matched all 212 routes. The complete pre-commit gate passed after the compatibility fixes, and the commit hooks passed again. A stdlib AST comparison confirmed no executable change in any of the five Python files.

`bash scripts/container_smoke.sh` was attempted but its preflight stopped because Docker is unavailable on this host. Container runtime, Linux sandbox, browser, and the other Python-version jobs are delegated to this PR's CI; their results are separate from the local checks. A real SARIF upload runs only on the Scorecard workflow's configured triggers.

## Risk and Reviewer Focus

Review `Dockerfile`, `.pre-commit-config.yaml`, `.github/workflows/scorecard.yml`, and the comment-placement changes in `openai4s/kernel/worker.py` and `tests/test_retrosynthesis_scenario_protocols.py`.

Two independent reviews verified the official image digest, unchanged Python series and architecture coverage, the exact upstream hook/action tag-to-SHA mappings, and isort/Ruff compatibility. The formatter loop found during review is fixed. No unresolved actionable findings remain in the reviewed diff. This review does not substitute for the repository's required code-owner approval before merge.

## Checklist

- [x] Full diff reviewed; scope is the requested consolidated dependency update and necessary formatting compatibility.
- [x] No unrelated formatting or broad rewrite. Worker and Store facade edits are limited to imports/comments.
- [x] No frontend source/dist change; vendored assets and captured fixtures were not reformatted.
- [x] Full offline suite and lint run; existing kernel, agent, and gateway tests are included in the suite.
- [x] No tests deleted and no live-resource tests or credentials added.
- [x] No hard third-party core imports or runtime dependencies added.
- [x] No secrets, private data, local paths, or unpublished research information added.
- [x] Documentation and translated behavior claims remain accurate; no user-facing API or security guarantee changed.

## Review follow-up (4 commits)

A max-effort review of the diff found one real defect in the compatibility fix and three structural gaps the bump exposed.

**`6df4911a` — the `isort: skip` workaround was wrong in three ways.**
`# noqa: E402; isort: skip` is not a directive ruff can parse: the `;` makes it reject the whole thing, so it suppressed nothing and printed `warning: Invalid # noqa directive` on every cold-cache run — the only invalid noqa in the tree. It is not merely inert: with the code selected and `--fix` on, ruff *deletes* the line, and `ruff-check` runs with `--fix` and tree-wide write access. Beyond the spelling, `isort: skip` created a section boundary (an appended `import zlib` was pinned under the third-party group at line 82 and `isort --check-only` still exited 0) and only held under isort 9 (isort 8 moved the statement below `yield_benchmark`, out of sorted order — reachable by reverting `657ea805` alone, or from a warm hook cache).

Fixed by dropping the trailing comment rather than re-spelling the directive: the statement then collapses to 84 characters and both formatters leave it alone. No suppression is lost — ruff exempts imports following a `sys.path` mutation, so the file is clean with `--select E402`. Verified byte-stable over four isort→black round-trips under isort 9.0.1 **and** 8.0.1.

**`ab7e94fa` — `[tool.isort]`.** `[tool.black]` and `[tool.ruff.lint]` each argue that a formatter's behaviour must be stated, not inherited; isort was the one of the three with no such block, and this is its *major* bump. `src_paths` defaults to `(cwd/"src", cwd)`, so first-party detection was a property of the process:

```
with the block, cwd=repo root ....   0 of 883 files reported unsorted
with the block, cwd=elsewhere ...    0
without,        cwd=repo root ....   0
without,        cwd=elsewhere ...  317   <- `openai4s` demoted to third-party
```

Zero output change, per the precedent that block records.

**`f857e7d8` — dependabot.** `hook-versions` excluded black because "a black bump is a style change that has to be read on its own, not merged as one row of a version table". isort has the same property; it was not excluded, which is how a major arrived batched with a ruff patch.

**`76a53cf9` — corrections to the above.** A sweep pass found the new comments' *explanations* wrong even where the code was right: the formatter trigger is not length alone (with `combine_as_imports` off, only *aliased* imports are collapsed — isolated with two imports of identical 81-character bodies), the two files are not symmetric (the kernel worker's suppressions **are** load-bearing, because its insert sits inside an `if`; the test's are inert), and `[tool.isort]` overclaimed that a bare `isort .` "agrees with the gate" — it still rewrites 318 of 408 pinned `skills/bioskills/` files. One disputed claim was re-measured and stands: the oscillation is unbounded, not a one-pass convergence (six rounds, `isort→b317cd8aabca`, `black→31dc7b2429e1`, never equal).

### Re-verified after the fixes

`pre-commit run --all-files` passes with no file modified · `uv run mypy` · full offline suite **8,494 passed, 50 skipped** · `harness.cli --tier pr --offline` 38/38 · `capture_response_contract.py --check` 212/212 · `check_directory_readmes.py` · `source_secret_scan.py` · 0 invalid-noqa warnings across all 883 checked files · all five reformatted files still AST-identical to `origin/main`.

### Reported, deliberately not applied

`base-image`'s `update-types` filter never matches a digest-only Docker update (proven by `7f45a740`'s trailers, which carry no `update-type:` and no `dependency-group:`) — but the fix is a product decision, since a single docker dependency cannot be batched down. Nothing verifies a `# frozen:` comment against its SHA, nor that the Dockerfile digest belongs to the tag beside it (Docker ignores the tag when a digest is present); `combine_as_imports` would remove 113 duplicated module paths across 63 files but rewrites 67. All are inline comments on the PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pin bumps and import formatting only; kernel and store edits are comment/import layout with identical AST per PR verification.
> 
> **Overview**
> Consolidates dependency maintenance: **Python 3.14 slim-bookworm** digest updates in both **Dockerfile** stages, **isort 9.0.1** and **Ruff 0.16.6** frozen SHAs in **`.pre-commit-config.yaml`**, and **CodeQL `upload-sarif` v4.37.9** in the Scorecard workflow.
> 
> **isort 9** only changes how imports are written in five Python files (collapsed multi-line `from … import` blocks). **`worker.py`** keeps the trusted-path comment with shorter `# noqa: E402` lines; **`test_retrosynthesis_scenario_protocols.py`** adds an **`isort: skip`** on one late import to stop an isort/Black reorder loop. No runtime or API behavior is intended to change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8fa1b6bfc6630a12544f884de6b169830950a4b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
